### PR TITLE
prioritize fresh token price sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker run --rm ekubo-indexer scripts/sync-tokens.ts
 docker run --rm ekubo-indexer scripts/sync-token-prices.ts
 ```
 
-The token-price entrypoint runs continuously; control its default cadence with `TOKEN_PRICE_SYNC_INTERVAL_MS` (milliseconds, defaults to 60000). CoinGecko contract-token prices for Base, Robinhood, and Arbitrum, plus their native ETH price and Ethereum mainnet's native ETH price, use a separate `COINGECKO_TOKEN_PRICE_SYNC_INTERVAL_SECONDS` cadence. Set it to a positive number and provide `COINGECKO_API_KEY` to enable CoinGecko syncing; zero or an unset value disables it.
+The token-price entrypoint runs continuously; control its default cadence with `TOKEN_PRICE_SYNC_INTERVAL_MS` (milliseconds, defaults to 60000). CoinGecko contract-token prices for Base, Robinhood, and Arbitrum, plus their native ETH price and Ethereum mainnet's native ETH price, use a separate `COINGECKO_TOKEN_PRICE_SYNC_INTERVAL_SECONDS` cadence. Set it to a positive number and provide `COINGECKO_API_KEY` to enable CoinGecko syncing; zero or an unset value disables it. Each source remains fresh for three sync intervals (with a one-minute minimum). The latest-price cache prefers quoter prices, then CoinGecko, then SushiSwap, then other configured sources; it averages sources tied at the highest confidence and reconciles expiration once per second.
 
 ## Database migrations
 
@@ -91,6 +91,10 @@ This log records indexer deployments that:
 
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
+
+### 2026-07-22: Freshness-aware prioritized token prices
+
+Token price source policy now lives in `erc20_token_price_sources`, with a bounded `confidence` and a `freshness_time`. The compact `erc20_tokens_latest_price_by_source` cache tracks source expirations, while the physical, primary-keyed `erc20_tokens_latest_price` table stores the fresh maximum-confidence aggregate for fast quoter reads. The price worker reconciles expirations once per second, promoting a lower-confidence source when needed. The high-volume `erc20_tokens_usd_prices` history schema and `all_pool_states_view` definition remain unchanged. Apply migrations before deploying the updated `sync-token-prices` worker. Consumers selecting every column from `erc20_tokens_latest_price` must account for its new `confidence` and `valid_until` columns and the synthetic `AVG` source on tied values; no manual backfill is required.
 
 ### 2026-07-16: Ve33 voted swap fee indexing
 

--- a/migrations/00108_prioritized_token_prices/index.sql
+++ b/migrations/00108_prioritized_token_prices/index.sql
@@ -1,0 +1,299 @@
+DROP TRIGGER IF EXISTS erc20_tokens_usd_prices_latest_on_insert ON erc20_tokens_usd_prices;
+DROP TRIGGER IF EXISTS erc20_tokens_usd_prices_latest_on_delete ON erc20_tokens_usd_prices;
+DROP FUNCTION IF EXISTS erc20_tokens_latest_price_on_insert();
+DROP FUNCTION IF EXISTS erc20_tokens_latest_price_on_delete();
+
+-- Price source policy is normalized because history is the high-volume table.
+-- Keeping these values here adds no per-observation storage overhead and lets
+-- operators adjust future source policy without rewriting price history.
+CREATE TABLE erc20_token_price_sources
+(
+    source         CHAR(3)  PRIMARY KEY,
+    freshness_time INTERVAL NOT NULL CHECK (freshness_time > INTERVAL '0 seconds'),
+    confidence     SMALLINT NOT NULL CHECK (confidence BETWEEN 0 AND 255)
+);
+
+INSERT INTO erc20_token_price_sources (source, freshness_time, confidence)
+VALUES ('qp1', INTERVAL '5 minutes', 3),
+       ('cg1', INTERVAL '5 minutes', 2),
+       ('ss1', INTERVAL '5 minutes', 1),
+       ('ov1', INTERVAL '5 minutes', 0),
+       ('LEG', INTERVAL '5 minutes', 0);
+
+-- Cache one observation per token/source. Confidence and expiry are copied
+-- here when an observation arrives so the high-volume history remains narrow.
+CREATE TABLE erc20_tokens_latest_price_by_source
+(
+    chain_id      BIGINT           NOT NULL,
+    token_address NUMERIC          NOT NULL,
+    source        CHAR(3)          NOT NULL,
+    "timestamp"   timestamptz      NOT NULL,
+    value         DOUBLE PRECISION NOT NULL,
+    confidence    SMALLINT         NOT NULL CHECK (confidence BETWEEN 0 AND 255),
+    valid_until   timestamptz      NOT NULL,
+    PRIMARY KEY (chain_id, token_address, source)
+);
+
+INSERT INTO erc20_tokens_latest_price_by_source
+    (chain_id, token_address, source, "timestamp", value, confidence, valid_until)
+SELECT DISTINCT ON (up.chain_id, up.token_address, up.source)
+       up.chain_id,
+       up.token_address,
+       up.source,
+       up."timestamp",
+       up.value,
+       s.confidence,
+       up."timestamp" + s.freshness_time
+FROM erc20_tokens_usd_prices up
+         JOIN erc20_token_price_sources s USING (source)
+ORDER BY up.chain_id, up.token_address, up.source, up."timestamp" DESC;
+
+-- Keep the existing physical table and primary key because the quoter reads it
+-- on every block. Source aggregation happens on writes, never on this hot path.
+ALTER TABLE erc20_tokens_latest_price
+    ADD COLUMN confidence SMALLINT,
+    ADD COLUMN valid_until timestamptz;
+
+CREATE OR REPLACE FUNCTION recompute_erc20_token_latest_price(
+    p_chain_id BIGINT,
+    p_token_address NUMERIC,
+    p_as_of timestamptz DEFAULT CURRENT_TIMESTAMP
+)
+    RETURNS VOID
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    v_source       CHAR(3);
+    v_timestamp    timestamptz;
+    v_value        DOUBLE PRECISION;
+    v_confidence   SMALLINT;
+    v_valid_until  timestamptz;
+BEGIN
+    WITH fresh_prices AS (
+        SELECT lp.source,
+               lp."timestamp",
+               lp.value,
+               lp.confidence,
+               lp.valid_until
+        FROM erc20_tokens_latest_price_by_source lp
+        WHERE lp.chain_id = p_chain_id
+          AND lp.token_address = p_token_address
+          AND lp.valid_until > p_as_of
+    ),
+    winning_prices AS (
+        SELECT *
+        FROM fresh_prices
+        WHERE confidence = (SELECT MAX(confidence) FROM fresh_prices)
+    )
+    SELECT CASE
+               WHEN COUNT(*) = 1 THEN MIN(source)
+               ELSE 'AVG'::CHAR(3)
+               END,
+           MAX("timestamp"),
+           AVG(value)::DOUBLE PRECISION,
+           MAX(confidence)::SMALLINT,
+           MIN(valid_until)
+    INTO v_source, v_timestamp, v_value, v_confidence, v_valid_until
+    FROM winning_prices
+    HAVING COUNT(*) > 0;
+
+    IF NOT FOUND THEN
+        DELETE FROM erc20_tokens_latest_price
+        WHERE chain_id = p_chain_id
+          AND token_address = p_token_address;
+        RETURN;
+    END IF;
+
+    INSERT INTO erc20_tokens_latest_price
+        (chain_id, token_address, source, "timestamp", value, confidence, valid_until)
+    VALUES (p_chain_id, p_token_address, v_source, v_timestamp, v_value,
+            v_confidence, v_valid_until)
+    ON CONFLICT (chain_id, token_address) DO UPDATE
+        SET source       = excluded.source,
+            "timestamp"  = excluded."timestamp",
+            value        = excluded.value,
+            confidence   = excluded.confidence,
+            valid_until  = excluded.valid_until
+    WHERE (erc20_tokens_latest_price.source,
+           erc20_tokens_latest_price."timestamp",
+           erc20_tokens_latest_price.value,
+           erc20_tokens_latest_price.confidence,
+           erc20_tokens_latest_price.valid_until)
+              IS DISTINCT FROM
+          (excluded.source,
+           excluded."timestamp",
+           excluded.value,
+           excluded.confidence,
+           excluded.valid_until);
+END;
+$$;
+
+TRUNCATE erc20_tokens_latest_price;
+
+SELECT recompute_erc20_token_latest_price(chain_id, token_address)
+FROM (
+    SELECT DISTINCT chain_id, token_address
+    FROM erc20_tokens_latest_price_by_source
+) tokens;
+
+ALTER TABLE erc20_tokens_latest_price
+    ALTER COLUMN confidence SET NOT NULL,
+    ALTER COLUMN valid_until SET NOT NULL,
+    ADD CHECK (confidence BETWEEN 0 AND 255);
+
+CREATE INDEX erc20_tokens_latest_price_valid_until_idx
+    ON erc20_tokens_latest_price (valid_until);
+
+CREATE OR REPLACE FUNCTION erc20_tokens_latest_price_on_insert()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    affected RECORD;
+BEGIN
+    INSERT INTO erc20_tokens_latest_price_by_source
+        (chain_id, token_address, source, "timestamp", value, confidence, valid_until)
+    SELECT latest.chain_id,
+           latest.token_address,
+           latest.source,
+           latest."timestamp",
+           latest.value,
+           latest.confidence,
+           latest.valid_until
+    FROM (
+        SELECT DISTINCT ON (new_prices.chain_id, new_prices.token_address, new_prices.source)
+               new_prices.chain_id,
+               new_prices.token_address,
+               new_prices.source,
+               new_prices."timestamp",
+               new_prices.value,
+               s.confidence,
+               new_prices."timestamp" + s.freshness_time AS valid_until
+        FROM inserted_prices new_prices
+                 JOIN erc20_token_price_sources s USING (source)
+        ORDER BY new_prices.chain_id,
+                 new_prices.token_address,
+                 new_prices.source,
+                 new_prices."timestamp" DESC
+    ) latest
+    ON CONFLICT (chain_id, token_address, source) DO UPDATE
+        SET "timestamp" = excluded."timestamp",
+            value       = excluded.value,
+            confidence  = excluded.confidence,
+            valid_until = excluded.valid_until
+    WHERE excluded."timestamp" >= erc20_tokens_latest_price_by_source."timestamp";
+
+    FOR affected IN
+        SELECT DISTINCT chain_id, token_address
+        FROM inserted_prices
+        ORDER BY chain_id, token_address
+    LOOP
+        PERFORM recompute_erc20_token_latest_price(
+            affected.chain_id,
+            affected.token_address
+        );
+    END LOOP;
+
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER erc20_tokens_usd_prices_latest_on_insert
+    AFTER INSERT
+    ON erc20_tokens_usd_prices
+    REFERENCING NEW TABLE AS inserted_prices
+    FOR EACH STATEMENT
+EXECUTE FUNCTION erc20_tokens_latest_price_on_insert();
+
+CREATE OR REPLACE FUNCTION erc20_tokens_latest_price_on_delete()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    affected RECORD;
+BEGIN
+    -- Hourly retention deletes old history in bulk. Only rebuild a source cache
+    -- when the deleted statement actually contained its cached observation.
+    FOR affected IN
+        SELECT DISTINCT lp.chain_id, lp.token_address, lp.source
+        FROM erc20_tokens_latest_price_by_source lp
+                 JOIN deleted_prices old_prices
+                      ON old_prices.chain_id = lp.chain_id
+                          AND old_prices.token_address = lp.token_address
+                          AND old_prices.source = lp.source
+                          AND old_prices."timestamp" >= lp."timestamp"
+        ORDER BY lp.chain_id, lp.token_address, lp.source
+    LOOP
+        DELETE FROM erc20_tokens_latest_price_by_source
+        WHERE chain_id = affected.chain_id
+          AND token_address = affected.token_address
+          AND source = affected.source;
+
+        INSERT INTO erc20_tokens_latest_price_by_source
+            (chain_id, token_address, source, "timestamp", value, confidence, valid_until)
+        SELECT up.chain_id,
+               up.token_address,
+               up.source,
+               up."timestamp",
+               up.value,
+               s.confidence,
+               up."timestamp" + s.freshness_time
+        FROM erc20_tokens_usd_prices up
+                 JOIN erc20_token_price_sources s USING (source)
+        WHERE up.chain_id = affected.chain_id
+          AND up.token_address = affected.token_address
+          AND up.source = affected.source
+        ORDER BY up."timestamp" DESC
+        LIMIT 1;
+
+        PERFORM recompute_erc20_token_latest_price(
+            affected.chain_id,
+            affected.token_address
+        );
+    END LOOP;
+
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER erc20_tokens_usd_prices_latest_on_delete
+    AFTER DELETE
+    ON erc20_tokens_usd_prices
+    REFERENCING OLD TABLE AS deleted_prices
+    FOR EACH STATEMENT
+EXECUTE FUNCTION erc20_tokens_latest_price_on_delete();
+
+-- Called by the price worker as expiry deadlines pass. The valid-until index
+-- makes the normal no-op poll cheap, and only expired tokens are recomputed.
+CREATE OR REPLACE FUNCTION refresh_expired_erc20_token_latest_prices(
+    p_as_of timestamptz DEFAULT CURRENT_TIMESTAMP
+)
+    RETURNS BIGINT
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    expired RECORD;
+    refreshed BIGINT := 0;
+BEGIN
+    FOR expired IN
+        SELECT chain_id, token_address
+        FROM erc20_tokens_latest_price
+        WHERE valid_until <= p_as_of
+        FOR UPDATE
+        SKIP LOCKED
+    LOOP
+        PERFORM recompute_erc20_token_latest_price(
+            expired.chain_id,
+            expired.token_address,
+            p_as_of
+        );
+        refreshed := refreshed + 1;
+    END LOOP;
+
+    RETURN refreshed;
+END;
+$$;

--- a/scripts/sync-token-prices.ts
+++ b/scripts/sync-token-prices.ts
@@ -27,6 +27,7 @@ const QUOTE_USD_AMOUNT = 1000n;
 const EKUBO_QUOTER_BASE_URL =
   process.env.EKUBO_QUOTER_URL ?? "https://prod-api-quoter.ekubo.org";
 const COINGECKO_API_BASE_URL = "https://pro-api.coingecko.com/api/v3";
+const PRICE_EXPIRATION_POLL_INTERVAL_MS = 1_000;
 // Although CoinGecko accepts more addresses, large comma-separated batches can
 // exceed the HTTP request-line limit before reaching the API.
 const COINGECKO_MAX_CONTRACT_ADDRESSES = 100;
@@ -86,6 +87,7 @@ interface PriceFetcher {
 
 interface PriceFetcherConfig {
   source: string;
+  confidence: number;
   fetch: PriceFetcher;
 }
 
@@ -435,24 +437,28 @@ const ekuboQuoterPriceFetcher: PriceFetcher = async (sql, chainId) => {
 
 const quoterPriceFetcher: PriceFetcherConfig = {
   source: "qp1",
+  confidence: 3,
   fetch: ekuboQuoterPriceFetcher,
 };
 const oracleV1PriceFetcher: PriceFetcherConfig = {
   source: "ov1",
+  confidence: 0,
   fetch: ekuboUsdOraclePriceFetcher,
 };
 const sushiswapPriceFetcher: PriceFetcherConfig = {
   source: "ss1",
+  confidence: 1,
   fetch: sushiswapApiPriceFetcher,
 };
 const coingeckoV1PriceFetcher: PriceFetcherConfig = {
   source: "cg1",
+  confidence: 2,
   fetch: coingeckoPriceFetcher,
 };
 
 const FETCHER_BY_CHAIN_ID: { [chainId: string]: PriceFetcherConfig[] } = {
   // eth mainnet
-  ["1"]: [sushiswapPriceFetcher, quoterPriceFetcher /*oracleV1PriceFetcher,*/],
+  ["1"]: [quoterPriceFetcher, sushiswapPriceFetcher /*oracleV1PriceFetcher,*/],
   // eth sepolia
   ["11155111"]: [sushiswapPriceFetcher],
   // base
@@ -503,37 +509,65 @@ async function syncTokenPricesForChain(
   sql: Sql<{ bigint: bigint }>,
   chainId: string,
   fetchers: PriceFetcherConfig[],
+  freshnessTimeMs: number,
 ) {
-  await sql.begin(async (sql) => {
-    const priceRows: [
-      chain_id: string,
-      token_address: `0x${string}`,
-      source: string,
-      usd_price: number,
-    ][] = [];
+  const priceRows: [
+    chain_id: string,
+    token_address: `0x${string}`,
+    source: string,
+    usd_price: number,
+  ][] = [];
+  let fetchFailed = false;
 
-    try {
-      const priceSnapshots = await Promise.all(
-        fetchers.map(async (fetcher) => ({
-          source: fetcher.source,
-          prices: await fetcher.fetch(sql, BigInt(chainId)),
-        })),
+  try {
+    // Fetch outside a transaction. Some sources make many rate-limited HTTP
+    // requests, and holding a database connection here can starve expiry work.
+    const priceSnapshots = await Promise.all(
+      fetchers.map(async (fetcher) => ({
+        source: fetcher.source,
+        prices: await fetcher.fetch(sql, BigInt(chainId)),
+      })),
+    );
+
+    for (const snapshot of priceSnapshots) {
+      for (const [tokenAddress, usdPrice] of Object.entries(snapshot.prices)) {
+        priceRows.push([
+          chainId,
+          `0x${BigInt(tokenAddress).toString(16)}`,
+          snapshot.source,
+          usdPrice,
+        ]);
+      }
+    }
+  } catch (e) {
+    fetchFailed = true;
+    console.warn(`Failed to fetch prices for chain ID ${chainId}`, e);
+  }
+
+  await sql.begin(async (sql) => {
+    if (fetchers.length > 0) {
+      const sourceRows = fetchers.map(
+        ({ source, confidence }): [string, number, number] => [
+          source,
+          confidence,
+          freshnessTimeMs,
+        ],
       );
 
-      for (const snapshot of priceSnapshots) {
-        for (const [tokenAddress, usdPrice] of Object.entries(
-          snapshot.prices,
-        )) {
-          priceRows.push([
-            chainId,
-            `0x${BigInt(tokenAddress).toString(16)}`,
-            snapshot.source,
-            usdPrice,
-          ]);
-        }
-      }
-    } catch (e) {
-      console.warn(`Failed to fetch prices for chain ID ${chainId}`, e);
+      await sql`
+        INSERT INTO erc20_token_price_sources (source, confidence, freshness_time)
+        SELECT data.source::char(3),
+               data.confidence::smallint,
+               data.freshness_time_ms::double precision * INTERVAL '1 millisecond'
+        FROM (values ${sql(sourceRows)})
+                 AS data (source, confidence, freshness_time_ms)
+        ON CONFLICT (source) DO UPDATE
+          SET confidence = excluded.confidence,
+              freshness_time = excluded.freshness_time;
+      `;
+    }
+
+    if (fetchFailed) {
       return;
     }
 
@@ -568,11 +602,17 @@ async function main() {
   const runSyncForChain = async (
     chainId: string,
     fetchers: PriceFetcherConfig[],
+    freshnessTimeMs: number,
   ) => {
     const startedAt = Date.now();
 
     try {
-      await syncTokenPricesForChain(sql, chainId, fetchers);
+      await syncTokenPricesForChain(
+        sql,
+        chainId,
+        fetchers,
+        freshnessTimeMs,
+      );
       console.log(
         `Token price sync completed for chain ID ${chainId} in ${Math.round(
           Date.now() - startedAt,
@@ -590,10 +630,13 @@ async function main() {
     scheduler: Bottleneck,
     chainId: string,
     fetchers: PriceFetcherConfig[],
+    freshnessTimeMs: number,
   ) => {
     while (!isShuttingDown) {
       try {
-        await scheduler.schedule(() => runSyncForChain(chainId, fetchers));
+        await scheduler.schedule(() =>
+          runSyncForChain(chainId, fetchers, freshnessTimeMs),
+        );
       } catch (error) {
         if (error instanceof Bottleneck.BottleneckError) {
           break;
@@ -607,6 +650,22 @@ async function main() {
   };
 
   const chainSchedulers: Bottleneck[] = [];
+
+  const runPriceExpirationLoop = async () => {
+    while (!isShuttingDown) {
+      try {
+        await sql`SELECT refresh_expired_erc20_token_latest_prices()`;
+      } catch (error) {
+        if (!isShuttingDown) {
+          console.error("Failed to expire stale token prices", error);
+        }
+      }
+
+      await new Promise((resolve) =>
+        setTimeout(resolve, PRICE_EXPIRATION_POLL_INTERVAL_MS),
+      );
+    }
+  };
 
   const shutdown = async () => {
     if (isShuttingDown) return;
@@ -659,16 +718,25 @@ async function main() {
     );
   }
 
-  await Promise.all(
-    syncJobs.map(({ chainId, fetchers, intervalMs }) => {
+  await Promise.all([
+    ...syncJobs.map(({ chainId, fetchers, intervalMs }) => {
       const scheduler = new Bottleneck({
         maxConcurrent: 1,
         minTime: intervalMs,
       });
       chainSchedulers.push(scheduler);
-      return runSyncLoopForChain(scheduler, chainId, fetchers);
+      // Keep a snapshot valid across two missed runs, with a one-minute floor
+      // for deliberately aggressive development cadences.
+      const freshnessTimeMs = Math.max(intervalMs * 3, 60_000);
+      return runSyncLoopForChain(
+        scheduler,
+        chainId,
+        fetchers,
+        freshnessTimeMs,
+      );
     }),
-  );
+    runPriceExpirationLoop(),
+  ]);
 }
 
 main().catch(async (error) => {

--- a/tests/migrations/all-migrations.test.ts
+++ b/tests/migrations/all-migrations.test.ts
@@ -19,5 +19,5 @@ test("all migrations apply successfully", async () => {
     `SELECT count(1) as result FROM information_schema.tables WHERE table_schema = 'public'`
   );
 
-  expect(result).toBe(82);
+  expect(result).toBe(84);
 });

--- a/tests/migrations/all-pool-states-view-pool-tvl-usd.test.ts
+++ b/tests/migrations/all-pool-states-view-pool-tvl-usd.test.ts
@@ -6,6 +6,10 @@ let client: PGlite;
 
 beforeAll(async () => {
   client = await createClient();
+  await client.query(
+    `INSERT INTO erc20_token_price_sources (source, freshness_time, confidence)
+     VALUES ('SRC', INTERVAL '1 hour', 1)`
+  );
 });
 
 afterAll(async () => {
@@ -73,8 +77,8 @@ test("all_pool_states_view computes pool_tvl_usd from latest token prices", asyn
   await client.query(
     `INSERT INTO erc20_tokens_usd_prices (chain_id, token_address, source, "timestamp", value)
      VALUES
-       ($1, $2, 'SRC', '2024-01-01T00:00:00Z', 1.5),
-       ($1, $3, 'SRC', '2024-01-01T00:00:00Z', 2.0)`,
+       ($1, $2, 'SRC', CURRENT_TIMESTAMP, 1.5),
+       ($1, $3, 'SRC', CURRENT_TIMESTAMP, 2.0)`,
     [chainId, token0, token1]
   );
 
@@ -136,7 +140,7 @@ test("all_pool_states_view leaves pool_tvl_usd null when either latest price is 
 
   await client.query(
     `INSERT INTO erc20_tokens_usd_prices (chain_id, token_address, source, "timestamp", value)
-     VALUES ($1, $2, 'SRC', '2024-01-01T00:00:00Z', 4.0)`,
+     VALUES ($1, $2, 'SRC', CURRENT_TIMESTAMP, 4.0)`,
     [chainId, token0]
   );
 

--- a/tests/migrations/erc20-tokens-latest-price.test.ts
+++ b/tests/migrations/erc20-tokens-latest-price.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "bun:test";
 import { createClient } from "../helpers/db.js";
 
+type Client = Awaited<ReturnType<typeof createClient>>;
+
 async function insertToken(
-  client: Awaited<ReturnType<typeof createClient>>,
+  client: Client,
   chainId: bigint,
   tokenAddress: bigint
 ) {
@@ -15,186 +17,396 @@ async function insertToken(
   );
 }
 
-test("insert trigger tracks latest price by chain/token", async () => {
+async function insertSource(
+  client: Client,
+  source: string,
+  confidence: number,
+  freshnessTime: string = "1 hour"
+) {
+  await client.query(
+    `INSERT INTO erc20_token_price_sources (source, confidence, freshness_time)
+     VALUES ($1, $2, $3::interval)
+     ON CONFLICT (source) DO UPDATE
+       SET confidence = excluded.confidence,
+           freshness_time = excluded.freshness_time`,
+    [source, confidence, freshnessTime]
+  );
+}
+
+test("latest price uses the highest-confidence fresh source", async () => {
   const client = await createClient();
   try {
     const chainId = 1n;
     const token = 123n;
-
     await insertToken(client, chainId, token);
+    await insertSource(client, "LOW", 1);
+    await insertSource(client, "TOP", 2);
 
     await client.query(
-      `INSERT INTO erc20_tokens_usd_prices (chain_id, token_address, source, "timestamp", value)
-       VALUES ($1, $2, 'SRC', '2024-01-01T00:00:00Z', 1.0)`,
-      [chainId, token]
-    );
-
-    await client.query(
-      `INSERT INTO erc20_tokens_usd_prices (chain_id, token_address, source, "timestamp", value)
-       VALUES ($1, $2, 'SRC', '2024-01-02T00:00:00Z', 2.5)`,
+      `INSERT INTO erc20_tokens_usd_prices
+          (chain_id, token_address, source, "timestamp", value)
+       VALUES ($1, $2, 'LOW', CURRENT_TIMESTAMP - INTERVAL '1 minute', 10),
+              ($1, $2, 'TOP', CURRENT_TIMESTAMP - INTERVAL '2 minutes', 20)`,
       [chainId, token]
     );
 
     const {
       rows: [latest],
-    } = await client.query<{
-      chain_id: string;
-      token_address: string;
-      source: string;
-      timestamp: string;
-      value: string;
-    }>(
-      `SELECT chain_id::text,
-              token_address::text,
-              source,
-              "timestamp"::text AS timestamp,
-              value::text
+    } = await client.query<{ source: string; value: number; confidence: number }>(
+      `SELECT source, value, confidence
        FROM erc20_tokens_latest_price
        WHERE chain_id = $1 AND token_address = $2`,
       [chainId, token]
     );
 
-    expect(latest).toEqual({
-      chain_id: chainId.toString(),
-      token_address: token.toString(),
-      source: "SRC",
-      timestamp: "2024-01-02 00:00:00+00",
-      value: "2.5",
-    });
+    expect(latest).toEqual({ source: "TOP", value: 20, confidence: 2 });
   } finally {
     await client.close();
   }
 });
 
-test("equal-timestamp insert replaces latest value and source", async () => {
+test("lower-confidence observations do not rewrite the effective price", async () => {
+  const client = await createClient();
+  try {
+    const chainId = 1n;
+    const token = 234n;
+    await insertToken(client, chainId, token);
+    await insertSource(client, "LOW", 1);
+    await insertSource(client, "TOP", 2);
+
+    await client.query(
+      `INSERT INTO erc20_tokens_usd_prices
+          (chain_id, token_address, source, "timestamp", value)
+       VALUES ($1, $2, 'TOP', CURRENT_TIMESTAMP, 20)`,
+      [chainId, token]
+    );
+    const {
+      rows: [{ ctid: beforeCtid }],
+    } = await client.query<{ ctid: string }>(
+      `SELECT ctid::text
+       FROM erc20_tokens_latest_price
+       WHERE chain_id = $1 AND token_address = $2`,
+      [chainId, token]
+    );
+
+    await client.query(
+      `INSERT INTO erc20_tokens_usd_prices
+          (chain_id, token_address, source, "timestamp", value)
+       VALUES ($1, $2, 'LOW', CURRENT_TIMESTAMP, 10)`,
+      [chainId, token]
+    );
+    const {
+      rows: [{ ctid: afterCtid }],
+    } = await client.query<{ ctid: string }>(
+      `SELECT ctid::text
+       FROM erc20_tokens_latest_price
+       WHERE chain_id = $1 AND token_address = $2`,
+      [chainId, token]
+    );
+
+    expect(afterCtid).toBe(beforeCtid);
+  } finally {
+    await client.close();
+  }
+});
+
+test("latest price averages all fresh values tied at maximum confidence", async () => {
   const client = await createClient();
   try {
     const chainId = 1n;
     const token = 456n;
-    const ts = "2024-01-01T00:00:00Z";
-
     await insertToken(client, chainId, token);
+    await insertSource(client, "ONE", 5);
+    await insertSource(client, "TWO", 5);
+    await insertSource(client, "LOW", 4);
 
     await client.query(
-      `INSERT INTO erc20_tokens_usd_prices (chain_id, token_address, source, "timestamp", value)
-       VALUES ($1, $2, 'SRC', $3, 1.0)`,
-      [chainId, token, ts]
-    );
-    await client.query(
-      `INSERT INTO erc20_tokens_usd_prices (chain_id, token_address, source, "timestamp", value)
-       VALUES ($1, $2, 'ALT', $3, 3.0)`,
-      [chainId, token, ts]
+      `INSERT INTO erc20_tokens_usd_prices
+          (chain_id, token_address, source, "timestamp", value)
+       VALUES ($1, $2, 'ONE', CURRENT_TIMESTAMP - INTERVAL '3 minutes', 10),
+              ($1, $2, 'TWO', CURRENT_TIMESTAMP - INTERVAL '2 minutes', 14),
+              ($1, $2, 'LOW', CURRENT_TIMESTAMP - INTERVAL '1 minute', 100)`,
+      [chainId, token]
     );
 
     const {
       rows: [latest],
-    } = await client.query<{
-      source: string;
-      value: string;
-    }>(
-      `SELECT source, value::text
+    } = await client.query<{ source: string; value: number; confidence: number }>(
+      `SELECT source, value, confidence
        FROM erc20_tokens_latest_price
        WHERE chain_id = $1 AND token_address = $2`,
       [chainId, token]
     );
 
-    expect(latest).toEqual({ source: "ALT", value: "3" });
+    expect(latest).toEqual({ source: "AVG", value: 12, confidence: 5 });
   } finally {
     await client.close();
   }
 });
 
-test("delete trigger backfills the next-latest price", async () => {
+test("stale sources are excluded before selecting maximum confidence", async () => {
   const client = await createClient();
   try {
     const chainId = 1n;
     const token = 789n;
-
     await insertToken(client, chainId, token);
+    await insertSource(client, "OLD", 10, "5 minutes");
+    await insertSource(client, "NEW", 1, "5 minutes");
 
     await client.query(
-      `INSERT INTO erc20_tokens_usd_prices (chain_id, token_address, source, "timestamp", value)
-       VALUES ($1, $2, 'SRC', '2024-01-01T00:00:00Z', 1.0),
-              ($1, $2, 'SRC', '2024-01-02T00:00:00Z', 2.0)`,
+      `INSERT INTO erc20_tokens_usd_prices
+          (chain_id, token_address, source, "timestamp", value)
+       VALUES ($1, $2, 'OLD', CURRENT_TIMESTAMP - INTERVAL '6 minutes', 100),
+              ($1, $2, 'NEW', CURRENT_TIMESTAMP - INTERVAL '1 minute', 7)`,
+      [chainId, token]
+    );
+
+    const {
+      rows: [latest],
+    } = await client.query<{ source: string; value: number; confidence: number }>(
+      `SELECT source, value, confidence
+       FROM erc20_tokens_latest_price
+       WHERE chain_id = $1 AND token_address = $2`,
+      [chainId, token]
+    );
+
+    expect(latest).toEqual({ source: "NEW", value: 7, confidence: 1 });
+  } finally {
+    await client.close();
+  }
+});
+
+test("tokens with no fresh source have no latest price", async () => {
+  const client = await createClient();
+  try {
+    const chainId = 1n;
+    const token = 101112n;
+    await insertToken(client, chainId, token);
+    await insertSource(client, "OLD", 1, "5 minutes");
+
+    await client.query(
+      `INSERT INTO erc20_tokens_usd_prices
+          (chain_id, token_address, source, "timestamp", value)
+       VALUES ($1, $2, 'OLD', CURRENT_TIMESTAMP - INTERVAL '6 minutes', 100)`,
+      [chainId, token]
+    );
+
+    const { rows } = await client.query(
+      `SELECT 1
+       FROM erc20_tokens_latest_price
+       WHERE chain_id = $1 AND token_address = $2`,
+      [chainId, token]
+    );
+    expect(rows).toHaveLength(0);
+  } finally {
+    await client.close();
+  }
+});
+
+test("expiration refresh promotes the next fresh confidence tier", async () => {
+  const client = await createClient();
+  try {
+    const chainId = 1n;
+    const token = 111213n;
+    await insertToken(client, chainId, token);
+    await insertSource(client, "TOP", 2, "5 minutes");
+    await insertSource(client, "LOW", 1, "1 hour");
+
+    await client.query(
+      `INSERT INTO erc20_tokens_usd_prices
+          (chain_id, token_address, source, "timestamp", value)
+       VALUES ($1, $2, 'TOP', CURRENT_TIMESTAMP - INTERVAL '4 minutes', 20),
+              ($1, $2, 'LOW', CURRENT_TIMESTAMP, 10)`,
+      [chainId, token]
+    );
+
+    const {
+      rows: [beforeExpiration],
+    } = await client.query<{ source: string; value: number }>(
+      `SELECT source, value
+       FROM erc20_tokens_latest_price
+       WHERE chain_id = $1 AND token_address = $2`,
+      [chainId, token]
+    );
+    expect(beforeExpiration).toEqual({ source: "TOP", value: 20 });
+
+    await client.query(
+      `SELECT refresh_expired_erc20_token_latest_prices(
+          CURRENT_TIMESTAMP + INTERVAL '2 minutes'
+       )`
+    );
+
+    const {
+      rows: [afterExpiration],
+    } = await client.query<{ source: string; value: number }>(
+      `SELECT source, value
+       FROM erc20_tokens_latest_price
+       WHERE chain_id = $1 AND token_address = $2`,
+      [chainId, token]
+    );
+    expect(afterExpiration).toEqual({ source: "LOW", value: 10 });
+  } finally {
+    await client.close();
+  }
+});
+
+test("cache tracks only the latest observation from each source", async () => {
+  const client = await createClient();
+  try {
+    const chainId = 1n;
+    const token = 131415n;
+    await insertToken(client, chainId, token);
+    await insertSource(client, "SRC", 1);
+
+    await client.query(
+      `INSERT INTO erc20_tokens_usd_prices
+          (chain_id, token_address, source, "timestamp", value)
+       VALUES ($1, $2, 'SRC', CURRENT_TIMESTAMP - INTERVAL '2 minutes', 1),
+              ($1, $2, 'SRC', CURRENT_TIMESTAMP - INTERVAL '1 minute', 2.5)`,
+      [chainId, token]
+    );
+
+    const {
+      rows: [latest],
+    } = await client.query<{ value: number }>(
+      `SELECT value
+       FROM erc20_tokens_latest_price
+       WHERE chain_id = $1 AND token_address = $2`,
+      [chainId, token]
+    );
+    const {
+      rows: [cacheCount],
+    } = await client.query<{ count: number }>(
+      `SELECT COUNT(*)::integer AS count
+       FROM erc20_tokens_latest_price_by_source
+       WHERE chain_id = $1 AND token_address = $2`,
+      [chainId, token]
+    );
+
+    expect(latest.value).toBe(2.5);
+    expect(cacheCount.count).toBe(1);
+  } finally {
+    await client.close();
+  }
+});
+
+test("deleting a source's latest observation backfills that source", async () => {
+  const client = await createClient();
+  try {
+    const chainId = 1n;
+    const token = 161718n;
+    await insertToken(client, chainId, token);
+    await insertSource(client, "SRC", 1);
+
+    await client.query(
+      `INSERT INTO erc20_tokens_usd_prices
+          (chain_id, token_address, source, "timestamp", value)
+       VALUES ($1, $2, 'SRC', CURRENT_TIMESTAMP - INTERVAL '2 minutes', 1),
+              ($1, $2, 'SRC', CURRENT_TIMESTAMP - INTERVAL '1 minute', 2)`,
       [chainId, token]
     );
 
     await client.query(
       `DELETE FROM erc20_tokens_usd_prices
-       WHERE chain_id = $1 AND token_address = $2 AND "timestamp" = '2024-01-02T00:00:00Z'`,
+       WHERE chain_id = $1
+         AND token_address = $2
+         AND source = 'SRC'
+         AND value = 2`,
       [chainId, token]
     );
 
     const {
       rows: [latestAfterDelete],
-    } = await client.query<{
-      timestamp: string;
-      value: string;
-    }>(
-      `SELECT "timestamp"::text AS timestamp, value::text
+    } = await client.query<{ value: number }>(
+      `SELECT value
        FROM erc20_tokens_latest_price
        WHERE chain_id = $1 AND token_address = $2`,
       [chainId, token]
     );
-
-    expect(latestAfterDelete).toEqual({
-      timestamp: "2024-01-01 00:00:00+00",
-      value: "1",
-    });
+    expect(latestAfterDelete.value).toBe(1);
 
     await client.query(
       `DELETE FROM erc20_tokens_usd_prices
-       WHERE chain_id = $1 AND token_address = $2 AND "timestamp" = '2024-01-01T00:00:00Z'`,
+       WHERE chain_id = $1 AND token_address = $2 AND source = 'SRC'`,
       [chainId, token]
     );
 
-    const { rows: remainingRows } = await client.query(
-      `SELECT 1 FROM erc20_tokens_latest_price WHERE chain_id = $1 AND token_address = $2`,
+    const { rows } = await client.query(
+      `SELECT 1
+       FROM erc20_tokens_latest_price
+       WHERE chain_id = $1 AND token_address = $2`,
       [chainId, token]
     );
-    expect(remainingRows.length).toBe(0);
+    expect(rows).toHaveLength(0);
   } finally {
     await client.close();
   }
 });
 
-test("deleting non-latest price leaves latest untouched", async () => {
+test("source policy uses compact bounded types without widening history", async () => {
   const client = await createClient();
   try {
-    const chainId = 1n;
-    const token = 101112n;
-
-    await insertToken(client, chainId, token);
-
-    await client.query(
-      `INSERT INTO erc20_tokens_usd_prices (chain_id, token_address, source, "timestamp", value)
-       VALUES ($1, $2, 'SRC', '2024-01-01T00:00:00Z', 1.0),
-              ($1, $2, 'SRC', '2024-01-03T00:00:00Z', 3.0)`,
-      [chainId, token]
+    const { rows: sourceColumns } = await client.query<{ column_name: string }>(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_name = 'erc20_token_price_sources'
+       ORDER BY ordinal_position`
+    );
+    const { rows: historyColumns } = await client.query<{ column_name: string }>(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_name = 'erc20_tokens_usd_prices'
+       ORDER BY ordinal_position`
     );
 
-    await client.query(
-      `DELETE FROM erc20_tokens_usd_prices
-       WHERE chain_id = $1 AND token_address = $2 AND "timestamp" = '2024-01-01T00:00:00Z'`,
-      [chainId, token]
+    expect(sourceColumns.map(({ column_name }) => column_name)).toEqual([
+      "source",
+      "freshness_time",
+      "confidence",
+    ]);
+    expect(historyColumns.map(({ column_name }) => column_name)).not.toContain(
+      "freshness_time"
+    );
+    expect(historyColumns.map(({ column_name }) => column_name)).not.toContain(
+      "confidence"
     );
 
+    await expect(
+      client.query(
+        `INSERT INTO erc20_token_price_sources
+            (source, freshness_time, confidence)
+         VALUES ('BAD', INTERVAL '1 minute', 256)`
+      )
+    ).rejects.toThrow();
+  } finally {
+    await client.close();
+  }
+});
+
+test("quoter price reads retain the physical primary-key lookup plan", async () => {
+  const client = await createClient();
+  try {
     const {
-      rows: [latest],
-    } = await client.query<{
-      timestamp: string;
-      value: string;
-    }>(
-      `SELECT "timestamp"::text AS timestamp, value::text
-       FROM erc20_tokens_latest_price
-       WHERE chain_id = $1 AND token_address = $2`,
-      [chainId, token]
+      rows: [{ table_type }],
+    } = await client.query<{ table_type: string }>(
+      `SELECT table_type
+       FROM information_schema.tables
+       WHERE table_schema = 'public'
+         AND table_name = 'erc20_tokens_latest_price'`
     );
+    const { rows } = await client.query<Record<string, string>>(
+      `EXPLAIN
+       SELECT t.token_address, t.token_decimals, p.value
+       FROM erc20_tokens t
+                JOIN erc20_tokens_latest_price p USING (chain_id, token_address)
+       WHERE t.chain_id = 1`
+    );
+    const plan = rows.map((row) => Object.values(row)[0]).join("\n");
 
-    expect(latest).toEqual({
-      timestamp: "2024-01-03 00:00:00+00",
-      value: "3",
-    });
+    expect(table_type).toBe("BASE TABLE");
+    expect(plan).toContain("erc20_tokens_latest_price_pkey");
+    expect(plan).not.toContain("WindowAgg");
+    expect(plan).not.toContain("GroupAggregate");
   } finally {
     await client.close();
   }


### PR DESCRIPTION
## Summary

- add normalized token price source policy with bounded confidence and freshness time
- maintain a compact latest observation cache per token/source
- materialize the maximum-confidence aggregate into the existing physical `erc20_tokens_latest_price` table on writes
- prioritize quoter (3), CoinGecko (2), SushiSwap (1), then other sources (0)
- average sources tied at maximum confidence and promote fresh fallbacks as sources expire
- keep `erc20_tokens_usd_prices` narrow and leave `all_pool_states_view` unchanged

## Performance

The quoter hot path remains a primary-key lookup against the physical `erc20_tokens_latest_price` table. Before/after EXPLAIN plans for `pool_tvl_usd` are effectively identical and use `erc20_tokens_latest_price_pkey` for both pool tokens, with no window or aggregate nodes. Source aggregation is performed by statement-level history triggers, is scoped to distinct tokens touched, and skips unchanged effective-row updates to avoid unnecessary WAL/dead tuples. The worker polls the indexed `valid_until` deadline once per second to reconcile expirations. HTTP price fetching happens outside database transactions so expiry reconciliation is not connection-starved.

## Deployment

Run migration 00108 before deploying the updated `sync-token-prices` worker. `erc20_tokens_latest_price` remains a physical table and adds `confidence` and `valid_until`; equal-confidence aggregates expose source `AVG`. No manual backfill is required.

## Validation

- `bun test` (177 passing)
- `bun build scripts/sync-token-prices.ts --target=bun --outfile /tmp/ekubo-sync-token-prices.js`
- `git diff --check`
- verified `pg_get_viewdef(all_pool_states_view)` is identical before and after migration 00108
- compared migration 107/108 EXPLAIN plans for quoter token metadata and pool TVL reads
- benchmarked recomputation at 3,721 and 100,161 per-source cache rows; a 1,000-token batch remained about 38-42ms