### PR TITLE
Include Ve33 fees in hourly pool stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
+### 2026-07-30: Ve33 fees included in hourly pool stats
+
+EVM V3 `PoolFeesAccounted` events now contribute to
+`hourly_volume_by_token.fees`, which feeds the API's fee totals and APRs. The
+migration backfills existing Ve33 fee events and keeps the hourly aggregates
+correct when events are inserted or removed during a reorg. Apply migrations
+before deploying the updated EVM indexer; no manual backfill is required.
+
 ### 2026-07-28: Token metadata automation moved to `default-tokens`
 
 The DigitalOcean `sync-tokens` scheduled job and `scripts/sync-tokens.ts` were

--- a/migrations/00108_ve33_hourly_pool_fees/index.sql
+++ b/migrations/00108_ve33_hourly_pool_fees/index.sql
@@ -1,0 +1,126 @@
+ALTER TABLE ve33_pool_fees_accounted
+    ADD COLUMN block_time timestamptz;
+
+ALTER TABLE ve33_pool_fees_accounted DISABLE TRIGGER no_updates_ve33_pool_fees_accounted;
+
+UPDATE ve33_pool_fees_accounted pfa
+SET block_time = b.block_time
+FROM blocks b
+WHERE pfa.block_time IS NULL
+  AND pfa.chain_id = b.chain_id
+  AND pfa.block_number = b.block_number;
+
+ALTER TABLE ve33_pool_fees_accounted
+    ALTER COLUMN block_time SET NOT NULL;
+
+ALTER TABLE ve33_pool_fees_accounted ENABLE TRIGGER no_updates_ve33_pool_fees_accounted;
+
+CREATE TRIGGER set_block_time_ve33_pool_fees_accounted
+    BEFORE INSERT ON ve33_pool_fees_accounted
+    FOR EACH ROW
+    EXECUTE FUNCTION set_block_time_from_blocks();
+
+CREATE FUNCTION upsert_hourly_fees_from_ve33_pool_fees_accounted()
+RETURNS trigger AS $$
+DECLARE
+    rec ve33_pool_fees_accounted%ROWTYPE;
+    sign int := 1;
+    v_hour timestamptz;
+    v_token0 NUMERIC;
+    v_token1 NUMERIC;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        rec := OLD;
+        sign := -1;
+    ELSE
+        rec := NEW;
+    END IF;
+
+    IF rec.pool_key_id IS NULL OR (rec.amount0 = 0 AND rec.amount1 = 0) THEN
+        RETURN NULL;
+    END IF;
+
+    SELECT pk.token0,
+           pk.token1
+    INTO STRICT v_token0,
+                v_token1
+    FROM pool_keys pk
+    WHERE pk.pool_key_id = rec.pool_key_id;
+
+    v_hour := date_trunc('hour', rec.block_time);
+
+    IF rec.amount0 <> 0 THEN
+        INSERT INTO hourly_volume_by_token (pool_key_id, hour, token, volume, fees)
+        VALUES (rec.pool_key_id, v_hour, v_token0, 0, sign * rec.amount0)
+        ON CONFLICT (pool_key_id, hour, token) DO UPDATE
+        SET fees = hourly_volume_by_token.fees + EXCLUDED.fees;
+
+        IF sign = -1 THEN
+            DELETE FROM hourly_volume_by_token
+            WHERE pool_key_id = rec.pool_key_id
+              AND hour = v_hour
+              AND token = v_token0
+              AND volume = 0
+              AND fees = 0;
+        END IF;
+    END IF;
+
+    IF rec.amount1 <> 0 THEN
+        INSERT INTO hourly_volume_by_token (pool_key_id, hour, token, volume, fees)
+        VALUES (rec.pool_key_id, v_hour, v_token1, 0, sign * rec.amount1)
+        ON CONFLICT (pool_key_id, hour, token) DO UPDATE
+        SET fees = hourly_volume_by_token.fees + EXCLUDED.fees;
+
+        IF sign = -1 THEN
+            DELETE FROM hourly_volume_by_token
+            WHERE pool_key_id = rec.pool_key_id
+              AND hour = v_hour
+              AND token = v_token1
+              AND volume = 0
+              AND fees = 0;
+        END IF;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER hourly_ve33_pool_fees_accounted
+    AFTER INSERT OR DELETE ON ve33_pool_fees_accounted
+    FOR EACH ROW
+    EXECUTE FUNCTION upsert_hourly_fees_from_ve33_pool_fees_accounted();
+
+WITH fee_token0 AS (
+    SELECT
+        pfa.pool_key_id,
+        date_trunc('hour', pfa.block_time) AS hour,
+        pk.token0 AS token,
+        SUM(pfa.amount0) AS fees
+    FROM ve33_pool_fees_accounted pfa
+    JOIN pool_keys pk ON pk.pool_key_id = pfa.pool_key_id
+    WHERE pfa.amount0 <> 0
+    GROUP BY pfa.pool_key_id, hour, pk.token0
+    HAVING SUM(pfa.amount0) <> 0
+),
+fee_token1 AS (
+    SELECT
+        pfa.pool_key_id,
+        date_trunc('hour', pfa.block_time) AS hour,
+        pk.token1 AS token,
+        SUM(pfa.amount1) AS fees
+    FROM ve33_pool_fees_accounted pfa
+    JOIN pool_keys pk ON pk.pool_key_id = pfa.pool_key_id
+    WHERE pfa.amount1 <> 0
+    GROUP BY pfa.pool_key_id, hour, pk.token1
+    HAVING SUM(pfa.amount1) <> 0
+),
+fee_totals AS (
+    SELECT pool_key_id, hour, token, fees FROM fee_token0
+    UNION ALL
+    SELECT pool_key_id, hour, token, fees FROM fee_token1
+)
+INSERT INTO hourly_volume_by_token (pool_key_id, hour, token, volume, fees)
+SELECT pool_key_id, hour, token, 0, fees
+FROM fee_totals
+ON CONFLICT (pool_key_id, hour, token) DO UPDATE
+SET fees = hourly_volume_by_token.fees + EXCLUDED.fees;

--- a/tests/migrations/ve33-hourly-pool-fees.test.ts
+++ b/tests/migrations/ve33-hourly-pool-fees.test.ts
@@ -1,0 +1,276 @@
+import { expect, test } from "bun:test";
+import type { PGlite } from "@electric-sql/pglite";
+import {
+  createClient,
+  ensureIndexerCursor,
+  runMigrations,
+} from "../helpers/db.js";
+
+const PRE_VE33_HOURLY_FEES_MIGRATIONS = [
+  "00001_chain_tables",
+  "00002_core_tables",
+  "00011_pool_tvl",
+  "00019_hourly_tables",
+  "00021_last_24h_pool_stats_view",
+  "00026_hourly_tables_block_time",
+  "00035_update_last_24h_pool_stats_view",
+  "00104_ve33_events",
+] as const;
+
+async function seedBlock(
+  client: PGlite,
+  chainId: number,
+  blockNumber: number,
+  blockTime: Date,
+) {
+  await ensureIndexerCursor(client, chainId);
+  await client.query(
+    `INSERT INTO blocks (chain_id, block_number, block_hash, block_time, num_events)
+     VALUES ($1, $2, $3, $4, 0)`,
+    [chainId, blockNumber, `${chainId}${blockNumber}`, blockTime],
+  );
+}
+
+async function seedPool(client: PGlite, chainId: number) {
+  const {
+    rows: [{ pool_key_id: poolKeyId }],
+  } = await client.query<{ pool_key_id: bigint }>(
+    `INSERT INTO pool_keys (
+        chain_id,
+        core_address,
+        pool_id,
+        token0,
+        token1,
+        fee,
+        fee_denominator,
+        tick_spacing,
+        pool_extension
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+     RETURNING pool_key_id`,
+    [chainId, "2000", "3000", "4000", "4001", "0", "1000000", 64, "5000"],
+  );
+
+  return poolKeyId.toString();
+}
+
+test("ve33 fees are backfilled and kept reorg-safe in hourly pool stats", async () => {
+  const client = await createClient({
+    files: [...PRE_VE33_HOURLY_FEES_MIGRATIONS],
+  });
+
+  try {
+    const chainId = 11155111;
+    const blockNumber = 1000;
+    const blockTime = new Date();
+    await seedBlock(client, chainId, blockNumber, blockTime);
+    const poolKeyId = await seedPool(client, chainId);
+
+    await client.query(
+      `INSERT INTO swaps (
+          chain_id,
+          block_number,
+          transaction_index,
+          event_index,
+          transaction_hash,
+          emitter,
+          pool_key_id,
+          locker,
+          delta0,
+          delta1,
+          sqrt_ratio_after,
+          tick_after,
+          liquidity_after
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+      [
+        chainId,
+        blockNumber,
+        0,
+        0,
+        "6000",
+        "2000",
+        poolKeyId,
+        "7000",
+        "100",
+        "-50",
+        "9101112",
+        15,
+        "100000",
+      ],
+    );
+
+    await client.query(
+      `INSERT INTO ve33_pool_fees_accounted (
+          chain_id,
+          block_number,
+          transaction_index,
+          event_index,
+          transaction_hash,
+          emitter,
+          pool_key_id,
+          pool_id,
+          amount0,
+          amount1
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+      [
+        chainId,
+        blockNumber,
+        0,
+        1,
+        "6001",
+        "5000",
+        poolKeyId,
+        "3000",
+        "5",
+        "0",
+      ],
+    );
+
+    await runMigrations(client, {
+      files: ["00108_ve33_hourly_pool_fees"],
+    });
+
+    const { rows: backfilledRows } = await client.query<{
+      token: string;
+      volume: string;
+      fees: string;
+    }>(
+      `SELECT token, volume, fees
+       FROM hourly_volume_by_token
+       WHERE pool_key_id = $1
+       ORDER BY token`,
+      [poolKeyId],
+    );
+    expect(backfilledRows).toEqual([
+      { token: "4000", volume: "100", fees: "5" },
+    ]);
+
+    const {
+      rows: [{ event_id: token1FeeEventId, block_time: insertedBlockTime }],
+    } = await client.query<{ event_id: bigint; block_time: Date }>(
+      `INSERT INTO ve33_pool_fees_accounted (
+          chain_id,
+          block_number,
+          transaction_index,
+          event_index,
+          transaction_hash,
+          emitter,
+          pool_key_id,
+          pool_id,
+          amount0,
+          amount1
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+       RETURNING event_id, block_time`,
+      [
+        chainId,
+        blockNumber,
+        0,
+        2,
+        "6002",
+        "5000",
+        poolKeyId,
+        "3000",
+        "0",
+        "7",
+      ],
+    );
+    expect(new Date(insertedBlockTime)).toEqual(blockTime);
+
+    const { rows: insertedRows } = await client.query<{
+      token: string;
+      volume: string;
+      fees: string;
+    }>(
+      `SELECT token, volume, fees
+       FROM hourly_volume_by_token
+       WHERE pool_key_id = $1
+       ORDER BY token`,
+      [poolKeyId],
+    );
+    expect(insertedRows).toEqual([
+      { token: "4000", volume: "100", fees: "5" },
+      { token: "4001", volume: "0", fees: "7" },
+    ]);
+
+    await client.exec(
+      "REFRESH MATERIALIZED VIEW last_24h_pool_stats_materialized",
+    );
+    const { rows: apiStatsRows } = await client.query<{
+      volume0_24h: string;
+      fees0_24h: string;
+      fees1_24h: string;
+    }>(
+      `SELECT volume0_24h, fees0_24h, fees1_24h
+       FROM last_24h_pool_stats_materialized
+       WHERE pool_key_id = $1`,
+      [poolKeyId],
+    );
+    expect(apiStatsRows).toEqual([
+      { volume0_24h: "100", fees0_24h: "5", fees1_24h: "7" },
+    ]);
+
+    await client.query(
+      `INSERT INTO ve33_pool_fees_accounted (
+          chain_id,
+          block_number,
+          transaction_index,
+          event_index,
+          transaction_hash,
+          emitter,
+          pool_key_id,
+          pool_id,
+          amount0,
+          amount1
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+      [
+        chainId,
+        blockNumber,
+        0,
+        3,
+        "6003",
+        "5000",
+        null,
+        "9999",
+        "11",
+        "0",
+      ],
+    );
+
+    await client.query(
+      `DELETE FROM ve33_pool_fees_accounted
+       WHERE chain_id = $1 AND event_id = $2`,
+      [chainId, token1FeeEventId],
+    );
+
+    const { rows: rowsAfterFeeDelete } = await client.query<{
+      token: string;
+      volume: string;
+      fees: string;
+    }>(
+      `SELECT token, volume, fees
+       FROM hourly_volume_by_token
+       WHERE pool_key_id = $1
+       ORDER BY token`,
+      [poolKeyId],
+    );
+    expect(rowsAfterFeeDelete).toEqual([
+      { token: "4000", volume: "100", fees: "5" },
+    ]);
+
+    await client.query(
+      `DELETE FROM blocks WHERE chain_id = $1 AND block_number = $2`,
+      [chainId, blockNumber],
+    );
+
+    const {
+      rows: [{ count }],
+    } = await client.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count
+       FROM hourly_volume_by_token
+       WHERE pool_key_id = $1`,
+      [poolKeyId],
+    );
+    expect(count).toBe("0");
+  } finally {
+    await client.close();
+  }
+});


### PR DESCRIPTION
## Summary

- add migration 00108 to feed Ve33 PoolFeesAccounted amounts into hourly_volume_by_token.fees
- backfill already-indexed Ve33 fee events and attach block timestamps for hourly bucketing
- reverse hourly fee deltas on event deletion so chain reorgs remain correct
- document the schema and rollout impact in the breaking changelog

The API and interface already consume hourly_volume_by_token.fees through pair-volume queries and last_24h_pool_stats_materialized, so no downstream code change is required. The existing five-minute materialized-view refresh makes the new fees available to pool fee totals and APRs after deployment.

## Verification

- bun test
- 180 tests passed, including a migration regression that covers historical backfill, both token sides, unresolved pool keys, materialized API stats, and reorg deletion