### PR TITLE
Require pool keys for Ve33 fee events

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ This log records indexer deployments that:
 EVM V3 `PoolFeesAccounted` events now contribute to
 `hourly_volume_by_token.fees`, which feeds the API's fee totals and APRs. The
 migration backfills existing Ve33 fee events and keeps the hourly aggregates
-correct when events are inserted or removed during a reorg. Apply migrations
-before deploying the updated EVM indexer; no manual backfill is required.
+correct when events are inserted or removed during a reorg. These events now
+require a `pool_key_id`, so an unresolved pool fails indexing instead of being
+silently omitted from fee stats. Apply migrations before deploying the updated
+EVM indexer; no manual backfill is expected.
 
 ### 2026-07-28: Token metadata automation moved to `default-tokens`
 

--- a/migrations/00109_require_ve33_pool_fees_pool_key/index.sql
+++ b/migrations/00109_require_ve33_pool_fees_pool_key/index.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ve33_pool_fees_accounted
+    ALTER COLUMN pool_key_id SET NOT NULL;

--- a/tests/migrations/ve33-events.test.ts
+++ b/tests/migrations/ve33-events.test.ts
@@ -11,6 +11,7 @@ const MIGRATION_FILES = [
   "00002_core_tables",
   "00104_ve33_events",
   "00107_ve33_vote_weight_applied_voted_swap_fee",
+  "00109_require_ve33_pool_fees_pool_key",
 ] as const;
 
 let client: PGlite;
@@ -59,7 +60,7 @@ async function seedPoolKey(chainId: number) {
   return poolKeyId.toString();
 }
 
-test("ve33 event tables can reference known pools or keep raw pool ids", async () => {
+test("ve33 pool fee events require a known pool key", async () => {
   const chainId = 11155111;
   const blockNumber = 1;
   await seedBlock(chainId, blockNumber);
@@ -115,11 +116,22 @@ test("ve33 event tables can reference known pools or keep raw pool ids", async (
         amount0,
         amount1
      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
-    [chainId, blockNumber, 0, 1, "9001", "6000", null, "9999", "5", "6"],
+    [
+      chainId,
+      blockNumber,
+      0,
+      1,
+      "9001",
+      "6000",
+      poolKeyId,
+      "2000",
+      "5",
+      "0",
+    ],
   );
 
   const { rows } = await client.query<{
-    pool_key_id: string | null;
+    pool_key_id: string;
     pool_id: string;
   }>(
     `SELECT pool_key_id, pool_id
@@ -128,7 +140,27 @@ test("ve33 event tables can reference known pools or keep raw pool ids", async (
     [chainId],
   );
 
-  expect(rows).toEqual([{ pool_key_id: null, pool_id: "9999" }]);
+  expect(
+    rows.map((row) => ({ ...row, pool_key_id: String(row.pool_key_id) })),
+  ).toEqual([{ pool_key_id: poolKeyId, pool_id: "2000" }]);
+
+  await expect(
+    client.query(
+      `INSERT INTO ve33_pool_fees_accounted (
+          chain_id,
+          block_number,
+          transaction_index,
+          event_index,
+          transaction_hash,
+          emitter,
+          pool_key_id,
+          pool_id,
+          amount0,
+          amount1
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+      [chainId, blockNumber, 0, 2, "9002", "6000", null, "9999", "6", "0"],
+    ),
+  ).rejects.toThrow();
 
   const { rows: voteRows } = await client.query<{
     pool_key_id: string;

--- a/tests/migrations/ve33-hourly-pool-fees.test.ts
+++ b/tests/migrations/ve33-hourly-pool-fees.test.ts
@@ -126,7 +126,10 @@ test("ve33 fees are backfilled and kept reorg-safe in hourly pool stats", async 
     );
 
     await runMigrations(client, {
-      files: ["00108_ve33_hourly_pool_fees"],
+      files: [
+        "00108_ve33_hourly_pool_fees",
+        "00109_require_ve33_pool_fees_pool_key",
+      ],
     });
 
     const { rows: backfilledRows } = await client.query<{
@@ -208,32 +211,34 @@ test("ve33 fees are backfilled and kept reorg-safe in hourly pool stats", async 
       { volume0_24h: "100", fees0_24h: "5", fees1_24h: "7" },
     ]);
 
-    await client.query(
-      `INSERT INTO ve33_pool_fees_accounted (
-          chain_id,
-          block_number,
-          transaction_index,
-          event_index,
-          transaction_hash,
-          emitter,
-          pool_key_id,
-          pool_id,
-          amount0,
-          amount1
-       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
-      [
-        chainId,
-        blockNumber,
-        0,
-        3,
-        "6003",
-        "5000",
-        null,
-        "9999",
-        "11",
-        "0",
-      ],
-    );
+    await expect(
+      client.query(
+        `INSERT INTO ve33_pool_fees_accounted (
+            chain_id,
+            block_number,
+            transaction_index,
+            event_index,
+            transaction_hash,
+            emitter,
+            pool_key_id,
+            pool_id,
+            amount0,
+            amount1
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+        [
+          chainId,
+          blockNumber,
+          0,
+          3,
+          "6003",
+          "5000",
+          null,
+          "9999",
+          "11",
+          "0",
+        ],
+      ),
+    ).rejects.toThrow();
 
     await client.query(
       `DELETE FROM ve33_pool_fees_accounted


### PR DESCRIPTION
## Summary

- require ve33_pool_fees_accounted.pool_key_id with migration 00109
- fail indexing instead of silently omitting a PoolFeesAccounted event from hourly stats when its pool cannot be resolved
- replace the synthetic nullable-pool test coverage added around #126 with the actual pool-initialization invariant
- update the breaking changelog

PoolFeesAccounted can only be emitted for an initialized pool. Core emits PoolInitialized first, and the EVM indexer processes logs sequentially, so the pool key must already exist. SET NOT NULL also validates historical rows and intentionally stops deployment if that invariant was previously violated.

## Verification

- bun test
- 180 tests passed, 0 failed