### PR TITLE
Index pool keys by token pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
+### 2026-07-30: Pool token-pair lookup index
+
+`pool_keys` now has an index on `(chain_id, token0, token1)` so API queries can
+find every configuration for a token pair without scanning all pool keys.
+Apply migrations before deploying the optimized pair-events API query. No
+backfill or manual intervention is required beyond running the migration.
+
 ### 2026-07-30: Ve33 fees included in hourly pool stats
 
 EVM V3 `PoolFeesAccounted` events now contribute to

--- a/migrations/00110_pool_keys_pair_index/index.sql
+++ b/migrations/00110_pool_keys_pair_index/index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX pool_keys_chain_id_token0_token1_idx
+    ON pool_keys (chain_id, token0, token1);

--- a/tests/migrations/pool-keys-pair-index.test.ts
+++ b/tests/migrations/pool-keys-pair-index.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+import { runMigrations } from "../helpers/db.js";
+
+const BASE_MIGRATIONS = ["00001_chain_tables", "00002_core_tables"] as const;
+
+test("pool keys are indexed by chain and token pair", async () => {
+  const client = new PGlite("memory://pool-keys-pair-index");
+  try {
+    await runMigrations(client, { files: [...BASE_MIGRATIONS] });
+    await runMigrations(client, { files: ["00110_pool_keys_pair_index"] });
+
+    const { rows } = await client.query<{ indexdef: string }>(
+      `SELECT indexdef
+       FROM pg_indexes
+       WHERE schemaname = 'public'
+         AND indexname = 'pool_keys_chain_id_token0_token1_idx'`,
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].indexdef).toContain(
+      "USING btree (chain_id, token0, token1)",
+    );
+  } finally {
+    await client.close();
+  }
+});


### PR DESCRIPTION
## Problem

Pair-scoped API queries resolve every pool configuration with an exact `(chain_id, token0, token1)` predicate, but `pool_keys` only has indexes for its primary key and `(chain_id, core_address, pool_id)`. PostgreSQL therefore scans the full pool-key table before it can use the event tables per pool.

## Solution

- add migration `00110_pool_keys_pair_index` with a B-tree index on `(chain_id, token0, token1)`
- add migration coverage that verifies the installed index definition
- document the schema change and deployment order in the breaking changelog

This is the supporting schema change for [api#74](https://github.com/EkuboProtocol/api/pull/74). Apply this migration before deploying that API change for the best plan; the API remains compatible if rollout order is reversed.

## Verification

- `bun test tests/migrations/pool-keys-pair-index.test.ts`
- `bun test` (184 tests pass)

## Database impact

The standard migration creates one index on the small `pool_keys` table. It requires no data backfill or manual intervention.