### PR TITLE
Make per-tick liquidity reorg-safe

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun ci
-      - run: bun test
+      - run: bun test --timeout 15000
 
       - uses: digitalocean/action-doctl@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun ci
-      - run: bun test
+      - run: bun test --timeout 15000

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
+### 2026-07-31: Reorg-safe per-tick liquidity aggregation
+
+The `per_pool_per_tick_liquidity` triggers now retain transient rows until both
+the net liquidity delta and total liquidity are zero. This prevents
+order-dependent corruption when position updates are cascade-deleted during a
+reorg. The migration atomically rebuilds every tick aggregate from canonical
+`position_updates`; no manual backfill is required beyond running the
+migration.
+
 ### 2026-07-30: Pool token-pair lookup index
 
 `pool_keys` now has an index on `(chain_id, token0, token1)` so API queries can

--- a/migrations/00111_fix_per_pool_per_tick_liquidity_reorg/index.sql
+++ b/migrations/00111_fix_per_pool_per_tick_liquidity_reorg/index.sql
@@ -1,0 +1,210 @@
+-- Keep the rebuild consistent with the trigger-maintained table. The migration
+-- runner wraps this file in a transaction, so writers resume after commit.
+LOCK TABLE position_updates IN SHARE MODE;
+
+CREATE OR REPLACE FUNCTION net_liquidity_deltas_after_insert()
+    RETURNS TRIGGER
+    AS $$
+BEGIN
+    -- Update or insert for lower_bound
+    UPDATE per_pool_per_tick_liquidity
+    SET net_liquidity_delta_diff = net_liquidity_delta_diff + NEW.liquidity_delta,
+        total_liquidity_on_tick = total_liquidity_on_tick + NEW.liquidity_delta
+    WHERE pool_key_id = NEW.pool_key_id
+      AND tick = NEW.lower_bound;
+
+    IF NOT FOUND THEN
+        INSERT INTO per_pool_per_tick_liquidity (
+            pool_key_id,
+            tick,
+            net_liquidity_delta_diff,
+            total_liquidity_on_tick
+        )
+        VALUES (
+            NEW.pool_key_id,
+            NEW.lower_bound,
+            NEW.liquidity_delta,
+            NEW.liquidity_delta
+        );
+    END IF;
+
+    -- Only remove fully canceled aggregates.
+    DELETE FROM per_pool_per_tick_liquidity
+    WHERE pool_key_id = NEW.pool_key_id
+      AND tick = NEW.lower_bound
+      AND net_liquidity_delta_diff = 0
+      AND total_liquidity_on_tick = 0;
+
+    -- Update or insert for upper_bound
+    UPDATE per_pool_per_tick_liquidity
+    SET net_liquidity_delta_diff = net_liquidity_delta_diff - NEW.liquidity_delta,
+        total_liquidity_on_tick = total_liquidity_on_tick + NEW.liquidity_delta
+    WHERE pool_key_id = NEW.pool_key_id
+      AND tick = NEW.upper_bound;
+
+    IF NOT FOUND THEN
+        INSERT INTO per_pool_per_tick_liquidity (
+            pool_key_id,
+            tick,
+            net_liquidity_delta_diff,
+            total_liquidity_on_tick
+        )
+        VALUES (
+            NEW.pool_key_id,
+            NEW.upper_bound,
+            -NEW.liquidity_delta,
+            NEW.liquidity_delta
+        );
+    END IF;
+
+    -- Only remove fully canceled aggregates.
+    DELETE FROM per_pool_per_tick_liquidity
+    WHERE pool_key_id = NEW.pool_key_id
+      AND tick = NEW.upper_bound
+      AND net_liquidity_delta_diff = 0
+      AND total_liquidity_on_tick = 0;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION net_liquidity_deltas_after_delete()
+    RETURNS TRIGGER
+    AS $$
+BEGIN
+    -- Reverse effect for lower_bound
+    UPDATE per_pool_per_tick_liquidity
+    SET net_liquidity_delta_diff = net_liquidity_delta_diff - OLD.liquidity_delta,
+        total_liquidity_on_tick = total_liquidity_on_tick - OLD.liquidity_delta
+    WHERE pool_key_id = OLD.pool_key_id
+      AND tick = OLD.lower_bound;
+
+    IF NOT FOUND THEN
+        INSERT INTO per_pool_per_tick_liquidity (
+            pool_key_id,
+            tick,
+            net_liquidity_delta_diff,
+            total_liquidity_on_tick
+        )
+        VALUES (
+            OLD.pool_key_id,
+            OLD.lower_bound,
+            -OLD.liquidity_delta,
+            -OLD.liquidity_delta
+        );
+    END IF;
+
+    -- Reorg cascades can temporarily zero only one aggregate.
+    DELETE FROM per_pool_per_tick_liquidity
+    WHERE pool_key_id = OLD.pool_key_id
+      AND tick = OLD.lower_bound
+      AND net_liquidity_delta_diff = 0
+      AND total_liquidity_on_tick = 0;
+
+    -- Reverse effect for upper_bound
+    UPDATE per_pool_per_tick_liquidity
+    SET net_liquidity_delta_diff = net_liquidity_delta_diff + OLD.liquidity_delta,
+        total_liquidity_on_tick = total_liquidity_on_tick - OLD.liquidity_delta
+    WHERE pool_key_id = OLD.pool_key_id
+      AND tick = OLD.upper_bound;
+
+    IF NOT FOUND THEN
+        INSERT INTO per_pool_per_tick_liquidity (
+            pool_key_id,
+            tick,
+            net_liquidity_delta_diff,
+            total_liquidity_on_tick
+        )
+        VALUES (
+            OLD.pool_key_id,
+            OLD.upper_bound,
+            OLD.liquidity_delta,
+            -OLD.liquidity_delta
+        );
+    END IF;
+
+    -- Reorg cascades can temporarily zero only one aggregate.
+    DELETE FROM per_pool_per_tick_liquidity
+    WHERE pool_key_id = OLD.pool_key_id
+      AND tick = OLD.upper_bound
+      AND net_liquidity_delta_diff = 0
+      AND total_liquidity_on_tick = 0;
+
+    RETURN NULL;
+END;
+$$
+LANGUAGE plpgsql;
+
+CREATE TEMPORARY TABLE rebuilt_per_pool_per_tick_liquidity (
+    pool_key_id int8 NOT NULL,
+    tick int4 NOT NULL,
+    net_liquidity_delta_diff numeric NOT NULL,
+    total_liquidity_on_tick numeric NOT NULL,
+    PRIMARY KEY (pool_key_id, tick)
+) ON COMMIT DROP;
+
+INSERT INTO rebuilt_per_pool_per_tick_liquidity (
+    pool_key_id,
+    tick,
+    net_liquidity_delta_diff,
+    total_liquidity_on_tick
+)
+SELECT
+    pool_key_id,
+    tick,
+    SUM(net_liquidity_delta_diff),
+    SUM(total_liquidity_on_tick)
+FROM position_updates
+CROSS JOIN LATERAL (
+    VALUES
+        (
+            lower_bound,
+            liquidity_delta,
+            liquidity_delta
+        ),
+        (
+            upper_bound,
+            -liquidity_delta,
+            liquidity_delta
+        )
+) tick_liquidity_changes (
+    tick,
+    net_liquidity_delta_diff,
+    total_liquidity_on_tick
+)
+GROUP BY pool_key_id, tick
+HAVING SUM(net_liquidity_delta_diff) <> 0
+    OR SUM(total_liquidity_on_tick) <> 0;
+
+INSERT INTO per_pool_per_tick_liquidity AS current (
+    pool_key_id,
+    tick,
+    net_liquidity_delta_diff,
+    total_liquidity_on_tick
+)
+SELECT
+    pool_key_id,
+    tick,
+    net_liquidity_delta_diff,
+    total_liquidity_on_tick
+FROM rebuilt_per_pool_per_tick_liquidity
+ON CONFLICT (pool_key_id, tick)
+DO UPDATE
+SET net_liquidity_delta_diff = EXCLUDED.net_liquidity_delta_diff,
+    total_liquidity_on_tick = EXCLUDED.total_liquidity_on_tick
+WHERE (
+    current.net_liquidity_delta_diff,
+    current.total_liquidity_on_tick
+) IS DISTINCT FROM (
+    EXCLUDED.net_liquidity_delta_diff,
+    EXCLUDED.total_liquidity_on_tick
+);
+
+DELETE FROM per_pool_per_tick_liquidity current
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM rebuilt_per_pool_per_tick_liquidity rebuilt
+    WHERE rebuilt.pool_key_id = current.pool_key_id
+      AND rebuilt.tick = current.tick
+);

--- a/tests/migrations/per-pool-per-tick-liquidity.test.ts
+++ b/tests/migrations/per-pool-per-tick-liquidity.test.ts
@@ -1,12 +1,21 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import type { PGlite } from "@electric-sql/pglite";
-import { createClient, ensureIndexerCursor } from "../helpers/db.js";
+import {
+  createClient,
+  ensureIndexerCursor,
+  runMigrations,
+} from "../helpers/db.js";
 
-const MIGRATION_FILES = [
+const LEGACY_MIGRATION_FILES = [
   "00001_chain_tables",
   "00002_core_tables",
   "00005_per_pool_per_tick_liquidity",
   "00060_pool_config_v2",
+] as const;
+
+const MIGRATION_FILES = [
+  ...LEGACY_MIGRATION_FILES,
+  "00111_fix_per_pool_per_tick_liquidity_reorg",
 ] as const;
 
 let client: PGlite;
@@ -19,22 +28,26 @@ afterAll(async () => {
   await client.close();
 });
 
-async function seedBlock(chainId: number, blockNumber: number) {
-  await ensureIndexerCursor(client, chainId);
+async function seedBlock(
+  chainId: number,
+  blockNumber: number,
+  database = client
+) {
+  await ensureIndexerCursor(database, chainId);
   const blockHash = `${chainId}${blockNumber}${Date.now()}`;
   const blockTime = new Date("2024-01-01T00:00:00Z");
 
-  await client.query(
+  await database.query(
     `INSERT INTO blocks (chain_id, block_number, block_hash, block_time, num_events)
      VALUES ($1, $2, $3, $4, 0)`,
     [chainId, blockNumber, blockHash, blockTime]
   );
 }
 
-async function insertPoolKey(chainId: number) {
+async function insertPoolKey(chainId: number, database = client) {
   const {
     rows: [{ pool_key_id: poolKeyId }],
-  } = await client.query<{ pool_key_id: bigint }>(
+  } = await database.query<{ pool_key_id: bigint }>(
     `INSERT INTO pool_keys (
         chain_id,
         core_address,
@@ -53,28 +66,31 @@ async function insertPoolKey(chainId: number) {
   return poolKeyId;
 }
 
-async function insertPositionUpdate({
-  chainId,
-  blockNumber,
-  transactionIndex,
-  eventIndex,
-  poolKeyId,
-  lowerBound,
-  upperBound,
-  liquidityDelta,
-}: {
-  chainId: number;
-  blockNumber: number;
-  transactionIndex: number;
-  eventIndex: number;
-  poolKeyId: bigint;
-  lowerBound: number;
-  upperBound: number;
-  liquidityDelta: string;
-}) {
+async function insertPositionUpdate(
+  {
+    chainId,
+    blockNumber,
+    transactionIndex,
+    eventIndex,
+    poolKeyId,
+    lowerBound,
+    upperBound,
+    liquidityDelta,
+  }: {
+    chainId: number;
+    blockNumber: number;
+    transactionIndex: number;
+    eventIndex: number;
+    poolKeyId: bigint;
+    lowerBound: number;
+    upperBound: number;
+    liquidityDelta: string;
+  },
+  database = client
+) {
   const {
     rows: [{ event_id: eventId }],
-  } = await client.query<{ event_id: bigint }>(
+  } = await database.query<{ event_id: bigint }>(
     `INSERT INTO position_updates (
         chain_id,
         block_number,
@@ -370,6 +386,171 @@ test("deleting blocks cascades position updates and rewinds tick liquidity state
     [chainId, secondBlock]
   );
   expect(remainingPositionUpdates.length).toBe(0);
+});
+
+test("migration repairs and prevents order-dependent reorg corruption", async () => {
+  const legacyClient = await createClient({
+    files: [...LEGACY_MIGRATION_FILES],
+  });
+
+  try {
+    const chainId = 205;
+    const persistentBlock = 6200;
+    const temporaryAddBlock = 6201;
+    const temporaryRemoveBlock = 6202;
+    const liquidity = "880000424966";
+
+    await seedBlock(chainId, persistentBlock, legacyClient);
+    await seedBlock(chainId, temporaryAddBlock, legacyClient);
+    await seedBlock(chainId, temporaryRemoveBlock, legacyClient);
+    const poolKeyId = await insertPoolKey(chainId, legacyClient);
+
+    await insertPositionUpdate(
+      {
+        chainId,
+        blockNumber: persistentBlock,
+        transactionIndex: 0,
+        eventIndex: 0,
+        poolKeyId,
+        lowerBound: 450,
+        upperBound: 600,
+        liquidityDelta: liquidity,
+      },
+      legacyClient
+    );
+    await insertPositionUpdate(
+      {
+        chainId,
+        blockNumber: temporaryAddBlock,
+        transactionIndex: 0,
+        eventIndex: 0,
+        poolKeyId,
+        lowerBound: 300,
+        upperBound: 450,
+        liquidityDelta: liquidity,
+      },
+      legacyClient
+    );
+    await insertPositionUpdate(
+      {
+        chainId,
+        blockNumber: temporaryRemoveBlock,
+        transactionIndex: 0,
+        eventIndex: 0,
+        poolKeyId,
+        lowerBound: 300,
+        upperBound: 450,
+        liquidityDelta: `-${liquidity}`,
+      },
+      legacyClient
+    );
+
+    await legacyClient.query(
+      `DELETE FROM blocks
+       WHERE chain_id = $1
+         AND block_number >= $2`,
+      [chainId, temporaryAddBlock]
+    );
+
+    const beforeMigration = await legacyClient.query<{
+      net_liquidity_delta_diff: string;
+      total_liquidity_on_tick: string;
+    }>(
+      `SELECT net_liquidity_delta_diff, total_liquidity_on_tick
+       FROM per_pool_per_tick_liquidity
+       WHERE pool_key_id = $1
+         AND tick = 450`,
+      [poolKeyId.toString()]
+    );
+
+    expect(beforeMigration.rows).toEqual([
+      {
+        net_liquidity_delta_diff: `-${liquidity}`,
+        total_liquidity_on_tick: liquidity,
+      },
+    ]);
+
+    await runMigrations(legacyClient, {
+      files: ["00111_fix_per_pool_per_tick_liquidity_reorg"],
+    });
+
+    const afterMigration = await legacyClient.query<{
+      tick: number;
+      net_liquidity_delta_diff: string;
+      total_liquidity_on_tick: string;
+    }>(
+      `SELECT tick, net_liquidity_delta_diff, total_liquidity_on_tick
+       FROM per_pool_per_tick_liquidity
+       WHERE pool_key_id = $1
+       ORDER BY tick`,
+      [poolKeyId.toString()]
+    );
+
+    expect(afterMigration.rows).toEqual([
+      {
+        tick: 450,
+        net_liquidity_delta_diff: liquidity,
+        total_liquidity_on_tick: liquidity,
+      },
+      {
+        tick: 600,
+        net_liquidity_delta_diff: `-${liquidity}`,
+        total_liquidity_on_tick: liquidity,
+      },
+    ]);
+
+    await seedBlock(chainId, temporaryAddBlock, legacyClient);
+    await seedBlock(chainId, temporaryRemoveBlock, legacyClient);
+    await insertPositionUpdate(
+      {
+        chainId,
+        blockNumber: temporaryAddBlock,
+        transactionIndex: 0,
+        eventIndex: 0,
+        poolKeyId,
+        lowerBound: 300,
+        upperBound: 450,
+        liquidityDelta: liquidity,
+      },
+      legacyClient
+    );
+    await insertPositionUpdate(
+      {
+        chainId,
+        blockNumber: temporaryRemoveBlock,
+        transactionIndex: 0,
+        eventIndex: 0,
+        poolKeyId,
+        lowerBound: 300,
+        upperBound: 450,
+        liquidityDelta: `-${liquidity}`,
+      },
+      legacyClient
+    );
+
+    await legacyClient.query(
+      `DELETE FROM blocks
+       WHERE chain_id = $1
+         AND block_number >= $2`,
+      [chainId, temporaryAddBlock]
+    );
+
+    const afterSecondRewind = await legacyClient.query<{
+      tick: number;
+      net_liquidity_delta_diff: string;
+      total_liquidity_on_tick: string;
+    }>(
+      `SELECT tick, net_liquidity_delta_diff, total_liquidity_on_tick
+       FROM per_pool_per_tick_liquidity
+       WHERE pool_key_id = $1
+       ORDER BY tick`,
+      [poolKeyId.toString()]
+    );
+
+    expect(afterSecondRewind.rows).toEqual(afterMigration.rows);
+  } finally {
+    await legacyClient.close();
+  }
 });
 
 test("position_updates rows cannot be updated", async () => {


### PR DESCRIPTION
## Summary
- retain tick rows until both net and total liquidity aggregates are zero
- atomically rebuild all per-pool tick liquidity from canonical position updates
- add a regression that reproduces the production sign flip, verifies the backfill, and repeats the rewind against the fixed trigger
- document the migration in the breaking changelog
- explicitly apply the existing 15-second PGlite test timeout in CI and deploy checks

## Cause
Cascade deletion can process position updates out of event order. The old trigger deleted a tick row whenever total liquidity temporarily reached zero, even when its net liquidity delta was still nonzero. A later delete then recreated the row with the wrong sign.

## Migration behavior
Migration 00111 locks position-event writes for its transaction, replaces both trigger functions, and reconciles every materialized tick row against canonical position updates. No separate manual backfill is required.

## Validation
- `bun test tests/migrations/per-pool-per-tick-liquidity.test.ts`
- `bun test --timeout 15000` (185 passed)
- `git diff --check`