### PR TITLE
Index token price history queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
+### 2026-07-31: Ve33 fee component added to fee stats
+
+`hourly_volume_by_token` now tracks the Ve33 portion of its total `fees` in a
+dedicated `ve33_fees` column. The 24-hour pool stats views expose
+`ve33_fees0_24h` and `ve33_fees1_24h` as components of the existing inclusive
+`fees0_24h` and `fees1_24h` totals. The migration backfills the breakdown from
+indexed `PoolFeesAccounted` events and keeps both totals reorg-safe. Apply the
+indexer migration before deploying API code that selects the new columns; no
+manual backfill is required.
+
 ### 2026-07-31: Token price history covering index
 
 `erc20_tokens_usd_prices` now has a covering index on

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
+### 2026-07-31: Token price history covering index
+
+`erc20_tokens_usd_prices` now has a covering index on
+`(chain_id, token_address, timestamp DESC)` that includes the price value and
+source. Apply migrations before deploying the token price-history API to keep
+its bounded chart queries index-only. No backfill or manual intervention is
+required beyond running the migration.
+
 ### 2026-07-31: Reorg-safe per-tick liquidity aggregation
 
 The `per_pool_per_tick_liquidity` triggers now retain transient rows until both

--- a/migrations/00112_token_price_history_covering_index/index.sql
+++ b/migrations/00112_token_price_history_covering_index/index.sql
@@ -1,0 +1,5 @@
+CREATE INDEX erc20_tokens_usd_prices_history_covering_idx
+    ON erc20_tokens_usd_prices (chain_id, token_address, "timestamp" DESC)
+    INCLUDE (value, source);
+
+DROP INDEX IF EXISTS erc20_tokens_usd_prices_latest_idx;

--- a/migrations/00113_split_ve33_hourly_fees/index.sql
+++ b/migrations/00113_split_ve33_hourly_fees/index.sql
@@ -1,0 +1,174 @@
+ALTER TABLE hourly_volume_by_token
+    ADD COLUMN ve33_fees NUMERIC NOT NULL DEFAULT 0;
+
+CREATE OR REPLACE FUNCTION upsert_hourly_fees_from_ve33_pool_fees_accounted()
+RETURNS trigger AS $$
+DECLARE
+    rec ve33_pool_fees_accounted%ROWTYPE;
+    sign int := 1;
+    v_hour timestamptz;
+    v_token0 NUMERIC;
+    v_token1 NUMERIC;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        rec := OLD;
+        sign := -1;
+    ELSE
+        rec := NEW;
+    END IF;
+
+    IF rec.amount0 = 0 AND rec.amount1 = 0 THEN
+        RETURN NULL;
+    END IF;
+
+    SELECT pk.token0,
+           pk.token1
+    INTO STRICT v_token0,
+                v_token1
+    FROM pool_keys pk
+    WHERE pk.pool_key_id = rec.pool_key_id;
+
+    v_hour := date_trunc('hour', rec.block_time);
+
+    IF rec.amount0 <> 0 THEN
+        INSERT INTO hourly_volume_by_token (pool_key_id, hour, token, volume, fees, ve33_fees)
+        VALUES (rec.pool_key_id, v_hour, v_token0, 0, sign * rec.amount0, sign * rec.amount0)
+        ON CONFLICT (pool_key_id, hour, token) DO UPDATE
+        SET fees = hourly_volume_by_token.fees + EXCLUDED.fees,
+            ve33_fees = hourly_volume_by_token.ve33_fees + EXCLUDED.ve33_fees;
+
+        IF sign = -1 THEN
+            DELETE FROM hourly_volume_by_token
+            WHERE pool_key_id = rec.pool_key_id
+              AND hour = v_hour
+              AND token = v_token0
+              AND volume = 0
+              AND fees = 0
+              AND ve33_fees = 0;
+        END IF;
+    END IF;
+
+    IF rec.amount1 <> 0 THEN
+        INSERT INTO hourly_volume_by_token (pool_key_id, hour, token, volume, fees, ve33_fees)
+        VALUES (rec.pool_key_id, v_hour, v_token1, 0, sign * rec.amount1, sign * rec.amount1)
+        ON CONFLICT (pool_key_id, hour, token) DO UPDATE
+        SET fees = hourly_volume_by_token.fees + EXCLUDED.fees,
+            ve33_fees = hourly_volume_by_token.ve33_fees + EXCLUDED.ve33_fees;
+
+        IF sign = -1 THEN
+            DELETE FROM hourly_volume_by_token
+            WHERE pool_key_id = rec.pool_key_id
+              AND hour = v_hour
+              AND token = v_token1
+              AND volume = 0
+              AND fees = 0
+              AND ve33_fees = 0;
+        END IF;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+WITH fee_token0 AS (
+    SELECT pfa.pool_key_id,
+           date_trunc('hour', pfa.block_time) AS hour,
+           pk.token0 AS token,
+           SUM(pfa.amount0) AS ve33_fees
+    FROM ve33_pool_fees_accounted pfa
+             JOIN pool_keys pk USING (pool_key_id)
+    WHERE pfa.amount0 <> 0
+    GROUP BY pfa.pool_key_id, hour, pk.token0
+    HAVING SUM(pfa.amount0) <> 0
+),
+fee_token1 AS (
+    SELECT pfa.pool_key_id,
+           date_trunc('hour', pfa.block_time) AS hour,
+           pk.token1 AS token,
+           SUM(pfa.amount1) AS ve33_fees
+    FROM ve33_pool_fees_accounted pfa
+             JOIN pool_keys pk USING (pool_key_id)
+    WHERE pfa.amount1 <> 0
+    GROUP BY pfa.pool_key_id, hour, pk.token1
+    HAVING SUM(pfa.amount1) <> 0
+),
+fee_totals AS (
+    SELECT pool_key_id, hour, token, ve33_fees FROM fee_token0
+    UNION ALL
+    SELECT pool_key_id, hour, token, ve33_fees FROM fee_token1
+)
+INSERT INTO hourly_volume_by_token (pool_key_id, hour, token, volume, fees, ve33_fees)
+SELECT pool_key_id, hour, token, 0, ve33_fees, ve33_fees
+FROM fee_totals
+ON CONFLICT (pool_key_id, hour, token) DO UPDATE
+SET ve33_fees = EXCLUDED.ve33_fees;
+
+DROP MATERIALIZED VIEW IF EXISTS last_24h_pool_stats_materialized;
+DROP VIEW IF EXISTS last_24h_pool_stats_view;
+
+CREATE VIEW last_24h_pool_stats_view AS
+WITH volume AS (SELECT vbt.pool_key_id,
+                       SUM(vbt.volume)
+                           FILTER (WHERE vbt.token = pk.token0) AS volume0,
+                       SUM(vbt.volume)
+                           FILTER (WHERE vbt.token = pk.token1) AS volume1,
+                       SUM(vbt.fees)
+                           FILTER (WHERE vbt.token = pk.token0) AS fees0,
+                       SUM(vbt.fees)
+                           FILTER (WHERE vbt.token = pk.token1) AS fees1,
+                       SUM(vbt.ve33_fees)
+                           FILTER (WHERE vbt.token = pk.token0) AS ve33_fees0,
+                       SUM(vbt.ve33_fees)
+                           FILTER (WHERE vbt.token = pk.token1) AS ve33_fees1
+                FROM hourly_volume_by_token vbt
+                         JOIN pool_keys pk USING (pool_key_id)
+                WHERE hour >= NOW() - INTERVAL '24 hours'
+                GROUP BY vbt.pool_key_id),
+     tvl_delta_24h AS (SELECT tbt.pool_key_id,
+                              SUM(
+                                      CASE
+                                          WHEN token = token0 THEN delta
+                                          ELSE 0
+                                          END
+                              ) AS tvl0,
+                              SUM(
+                                      CASE
+                                          WHEN token = token1 THEN delta
+                                          ELSE 0
+                                          END
+                              ) AS tvl1
+                       FROM hourly_tvl_delta_by_token tbt
+                                JOIN pool_keys pk ON tbt.pool_key_id = pk.pool_key_id
+                       WHERE hour >= NOW() - INTERVAL '24 hours'
+                       GROUP BY tbt.pool_key_id)
+SELECT ptvl.pool_key_id,
+       ptvl.balance0                        AS tvl0_total,
+       ptvl.balance1                        AS tvl1_total,
+       COALESCE(volume.volume0, 0)          AS volume0_24h,
+       COALESCE(volume.volume1, 0)          AS volume1_24h,
+       COALESCE(volume.fees0, 0)            AS fees0_24h,
+       COALESCE(volume.fees1, 0)            AS fees1_24h,
+       COALESCE(volume.ve33_fees0, 0)       AS ve33_fees0_24h,
+       COALESCE(volume.ve33_fees1, 0)       AS ve33_fees1_24h,
+       COALESCE(tvl_delta_24h.tvl0, 0)      AS tvl0_delta_24h,
+       COALESCE(tvl_delta_24h.tvl1, 0)      AS tvl1_delta_24h
+FROM pool_tvl ptvl
+         LEFT JOIN volume USING (pool_key_id)
+         LEFT JOIN tvl_delta_24h USING (pool_key_id)
+ORDER BY ptvl.pool_key_id;
+
+CREATE MATERIALIZED VIEW last_24h_pool_stats_materialized AS
+SELECT pool_key_id,
+       tvl0_total,
+       tvl1_total,
+       volume0_24h,
+       volume1_24h,
+       fees0_24h,
+       fees1_24h,
+       ve33_fees0_24h,
+       ve33_fees1_24h,
+       tvl0_delta_24h,
+       tvl1_delta_24h
+FROM last_24h_pool_stats_view;
+
+CREATE UNIQUE INDEX ON last_24h_pool_stats_materialized (pool_key_id);

--- a/tests/migrations/token-price-history-index.test.ts
+++ b/tests/migrations/token-price-history-index.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { createClient } from "../helpers/db.js";
+
+test("token USD price history uses a covering range index", async () => {
+  const client = await createClient();
+  try {
+    const { rows } = await client.query<{ indexdef: string }>(
+      `SELECT indexdef
+       FROM pg_indexes
+       WHERE schemaname = 'public'
+         AND indexname = 'erc20_tokens_usd_prices_history_covering_idx'`,
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].indexdef).toContain(
+      'USING btree (chain_id, token_address, "timestamp" DESC) INCLUDE (value, source)',
+    );
+
+    const { rows: supersededIndexes } = await client.query(
+      `SELECT 1
+       FROM pg_indexes
+       WHERE schemaname = 'public'
+         AND indexname = 'erc20_tokens_usd_prices_latest_idx'`,
+    );
+
+    expect(supersededIndexes).toHaveLength(0);
+  } finally {
+    await client.close();
+  }
+});

--- a/tests/migrations/ve33-hourly-pool-fees.test.ts
+++ b/tests/migrations/ve33-hourly-pool-fees.test.ts
@@ -47,13 +47,13 @@ async function seedPool(client: PGlite, chainId: number) {
         pool_extension
      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
      RETURNING pool_key_id`,
-    [chainId, "2000", "3000", "4000", "4001", "0", "1000000", 64, "5000"],
+    [chainId, "2000", "3000", "4000", "4001", "10000", "1000000", 64, "5000"],
   );
 
   return poolKeyId.toString();
 }
 
-test("ve33 fees are backfilled and kept reorg-safe in hourly pool stats", async () => {
+test("ve33 fees are tracked within total fees and kept reorg-safe", async () => {
   const client = await createClient({
     files: [...PRE_VE33_HOURLY_FEES_MIGRATIONS],
   });
@@ -111,24 +111,14 @@ test("ve33 fees are backfilled and kept reorg-safe in hourly pool stats", async 
           amount0,
           amount1
        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
-      [
-        chainId,
-        blockNumber,
-        0,
-        1,
-        "6001",
-        "5000",
-        poolKeyId,
-        "3000",
-        "5",
-        "0",
-      ],
+      [chainId, blockNumber, 0, 1, "6001", "5000", poolKeyId, "3000", "5", "0"],
     );
 
     await runMigrations(client, {
       files: [
         "00108_ve33_hourly_pool_fees",
         "00109_require_ve33_pool_fees_pool_key",
+        "00113_split_ve33_hourly_fees",
       ],
     });
 
@@ -136,15 +126,16 @@ test("ve33 fees are backfilled and kept reorg-safe in hourly pool stats", async 
       token: string;
       volume: string;
       fees: string;
+      ve33_fees: string;
     }>(
-      `SELECT token, volume, fees
+      `SELECT token, volume, fees, ve33_fees
        FROM hourly_volume_by_token
        WHERE pool_key_id = $1
        ORDER BY token`,
       [poolKeyId],
     );
     expect(backfilledRows).toEqual([
-      { token: "4000", volume: "100", fees: "5" },
+      { token: "4000", volume: "100", fees: "6", ve33_fees: "5" },
     ]);
 
     const {
@@ -163,18 +154,7 @@ test("ve33 fees are backfilled and kept reorg-safe in hourly pool stats", async 
           amount1
        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
        RETURNING event_id, block_time`,
-      [
-        chainId,
-        blockNumber,
-        0,
-        2,
-        "6002",
-        "5000",
-        poolKeyId,
-        "3000",
-        "0",
-        "7",
-      ],
+      [chainId, blockNumber, 0, 2, "6002", "5000", poolKeyId, "3000", "0", "7"],
     );
     expect(new Date(insertedBlockTime)).toEqual(blockTime);
 
@@ -182,16 +162,17 @@ test("ve33 fees are backfilled and kept reorg-safe in hourly pool stats", async 
       token: string;
       volume: string;
       fees: string;
+      ve33_fees: string;
     }>(
-      `SELECT token, volume, fees
+      `SELECT token, volume, fees, ve33_fees
        FROM hourly_volume_by_token
        WHERE pool_key_id = $1
        ORDER BY token`,
       [poolKeyId],
     );
     expect(insertedRows).toEqual([
-      { token: "4000", volume: "100", fees: "5" },
-      { token: "4001", volume: "0", fees: "7" },
+      { token: "4000", volume: "100", fees: "6", ve33_fees: "5" },
+      { token: "4001", volume: "0", fees: "7", ve33_fees: "7" },
     ]);
 
     await client.exec(
@@ -201,15 +182,37 @@ test("ve33 fees are backfilled and kept reorg-safe in hourly pool stats", async 
       volume0_24h: string;
       fees0_24h: string;
       fees1_24h: string;
+      ve33_fees0_24h: string;
+      ve33_fees1_24h: string;
     }>(
-      `SELECT volume0_24h, fees0_24h, fees1_24h
+      `SELECT volume0_24h,
+              fees0_24h,
+              fees1_24h,
+              ve33_fees0_24h,
+              ve33_fees1_24h
        FROM last_24h_pool_stats_materialized
        WHERE pool_key_id = $1`,
       [poolKeyId],
     );
     expect(apiStatsRows).toEqual([
-      { volume0_24h: "100", fees0_24h: "5", fees1_24h: "7" },
+      {
+        volume0_24h: "100",
+        fees0_24h: "6",
+        fees1_24h: "7",
+        ve33_fees0_24h: "5",
+        ve33_fees1_24h: "7",
+      },
     ]);
+
+    const {
+      rows: [{ count: materializedViewIndexes }],
+    } = await client.query<{ count: number }>(
+      `SELECT COUNT(*)::int AS count
+       FROM pg_indexes
+       WHERE tablename = 'last_24h_pool_stats_materialized'
+         AND indexdef LIKE 'CREATE UNIQUE INDEX% (pool_key_id)'`,
+    );
+    expect(materializedViewIndexes).toBe(1);
 
     await expect(
       client.query(
@@ -225,18 +228,7 @@ test("ve33 fees are backfilled and kept reorg-safe in hourly pool stats", async 
             amount0,
             amount1
          ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
-        [
-          chainId,
-          blockNumber,
-          0,
-          3,
-          "6003",
-          "5000",
-          null,
-          "9999",
-          "11",
-          "0",
-        ],
+        [chainId, blockNumber, 0, 3, "6003", "5000", null, "9999", "11", "0"],
       ),
     ).rejects.toThrow();
 
@@ -250,15 +242,16 @@ test("ve33 fees are backfilled and kept reorg-safe in hourly pool stats", async 
       token: string;
       volume: string;
       fees: string;
+      ve33_fees: string;
     }>(
-      `SELECT token, volume, fees
+      `SELECT token, volume, fees, ve33_fees
        FROM hourly_volume_by_token
        WHERE pool_key_id = $1
        ORDER BY token`,
       [poolKeyId],
     );
     expect(rowsAfterFeeDelete).toEqual([
-      { token: "4000", volume: "100", fees: "5" },
+      { token: "4000", volume: "100", fees: "6", ve33_fees: "5" },
     ]);
 
     await client.query(


### PR DESCRIPTION
## Summary

- add a covering range index for token USD price history
- replace the superseded latest-price index after the covering index is created
- add a migration integration test and deployment changelog entry

## Deployment

Apply this migration before deploying the token price-history API. No backfill or manual intervention is required beyond the normal migration workflow.

## Validation

- `bun test` — 186 passed, 0 failed
- focused token price-history migration test passed