### PR TITLE
Add circulating supply to ERC-20 tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
+### 2026-07-31: Token circulating supply
+
+`erc20_tokens` now has a nullable, non-negative integer `circulating_supply`
+column.
+Like `total_supply`, the value is stored in the token's indivisible units so
+consumers must divide by `10 ^ token_decimals` before multiplying by a per-token
+USD price. Apply this migration before deploying the `default-tokens` database
+sync that writes the new field. Existing rows remain `NULL` until that sync
+finds a supply source; no manual backfill is required.
+
 ### 2026-07-31: Ve33 fee component added to fee stats
 
 `hourly_volume_by_token` now tracks the Ve33 portion of its total `fees` in a

--- a/migrations/00114_erc20_tokens_circulating_supply/index.sql
+++ b/migrations/00114_erc20_tokens_circulating_supply/index.sql
@@ -1,0 +1,10 @@
+ALTER TABLE erc20_tokens
+    ADD COLUMN circulating_supply NUMERIC
+    CONSTRAINT erc20_tokens_circulating_supply_nonnegative_integer
+    CHECK (
+        circulating_supply >= 0
+        AND circulating_supply = TRUNC(circulating_supply)
+    );
+
+COMMENT ON COLUMN erc20_tokens.circulating_supply IS
+    'Latest known circulating supply in the token''s indivisible units; NULL when unknown';

--- a/tests/migrations/erc20-tokens-circulating-supply.test.ts
+++ b/tests/migrations/erc20-tokens-circulating-supply.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { createClient, runMigrations } from "../helpers/db.js";
+
+test("adds nullable non-negative integer supply without changing token rows", async () => {
+  const client = await createClient({ files: ["00018_tokens"] });
+  try {
+    await client.query(
+      `INSERT INTO erc20_tokens (
+         chain_id, token_address, token_symbol, token_name, token_decimals,
+         visibility_priority, sort_order, total_supply
+       ) VALUES (1, 123, 'TKN', 'Token', 6, 1, 0, 1000000)`,
+    );
+
+    await runMigrations(client, {
+      files: ["00114_erc20_tokens_circulating_supply"],
+    });
+
+    const {
+      rows: [column],
+    } = await client.query<{
+      data_type: string;
+      is_nullable: string;
+    }>(
+      `SELECT data_type, is_nullable
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = 'erc20_tokens'
+         AND column_name = 'circulating_supply'`,
+    );
+    expect(column).toEqual({ data_type: "numeric", is_nullable: "YES" });
+
+    const {
+      rows: [token],
+    } = await client.query<{
+      total_supply: string;
+      circulating_supply: string | null;
+    }>(
+      `SELECT total_supply::text, circulating_supply::text
+       FROM erc20_tokens
+       WHERE chain_id = 1 AND token_address = 123`,
+    );
+    expect(token).toEqual({
+      total_supply: "1000000",
+      circulating_supply: null,
+    });
+
+    await client.query(
+      `UPDATE erc20_tokens
+       SET circulating_supply = 750000
+       WHERE chain_id = 1 AND token_address = 123`,
+    );
+    await expect(
+      client.query(
+        `UPDATE erc20_tokens
+         SET circulating_supply = -1
+         WHERE chain_id = 1 AND token_address = 123`,
+      ),
+    ).rejects.toThrow();
+    await expect(
+      client.query(
+        `UPDATE erc20_tokens
+         SET circulating_supply = 1.5
+         WHERE chain_id = 1 AND token_address = 123`,
+      ),
+    ).rejects.toThrow();
+  } finally {
+    await client.close();
+  }
+});


### PR DESCRIPTION
## Summary

- add a nullable NUMERIC circulating_supply column to erc20_tokens
- constrain known values to non-negative integers in token indivisible units
- document the schema rollout and add migration regression coverage

## Deployment

Apply this migration before merging and deploying https://github.com/EkuboProtocol/default-tokens/pull/9. Existing rows remain NULL until that repository refreshes and synchronizes supply metadata.

## Test plan

- bun test (187 passing tests)