### PR TITLE
Add pool_keys discovery indexes for the /poolKeys API route

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
+### 2026-08-05: Pool-key discovery indexes
+
+Adds two indexes on `pool_keys` — `(chain_id, token1)` and
+`(chain_id, pool_extension)` — so the API's new `/poolKeys` discovery route
+can filter by a single token (either side) or by extension without scanning a
+chain's whole pool set. Schema-only change: run the migration; no manual
+backfill is required and no existing structure changes.
+
 ### 2026-07-31: Token circulating supply
 
 `erc20_tokens` now has a nullable, non-negative integer `circulating_supply`

--- a/migrations/00115_pool_keys_discovery_indexes/index.sql
+++ b/migrations/00115_pool_keys_discovery_indexes/index.sql
@@ -1,0 +1,8 @@
+-- Discovery-route filters over pool_keys. The token0 side of single-token
+-- lookups is already served by pool_keys_chain_id_token0_token1_idx (00110);
+-- token1-side lookups and extension filters would otherwise scan the whole
+-- chain partition.
+CREATE INDEX pool_keys_chain_id_token1_idx ON pool_keys (chain_id, token1);
+
+CREATE INDEX pool_keys_chain_id_pool_extension_idx
+    ON pool_keys (chain_id, pool_extension);


### PR DESCRIPTION
Migration 00115 adds two indexes on `pool_keys`:

- `(chain_id, token1)` — serves single-token either-side lookups on the new `/poolKeys` discovery route (the token0 side is already covered by `pool_keys_chain_id_token0_token1_idx` from 00110)
- `(chain_id, pool_extension)` — serves extension-filtered discovery

Schema-only, no backfill; README breaking changelog updated. `bun test`: 187 pass (all-migrations suite applies the new SQL under PGlite).

Land before EkuboProtocol/api#85, which adds the routes that need these indexes.

Note: the branch is based on origin/main (00114 is the latest merged migration), so this claims 00115 — the unmerged local VeTokenBribes migration currently numbered 00115 will need to move to 00116 when it lands, since postgres-shift requires sequential ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)