### PR TITLE
Cut CoinGecko price sync request volume

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -145,9 +145,11 @@ workers:
         scope: RUN_TIME
         type: SECRET
         value: ${COINGECKO_API_KEY}
+      # The Ekubo quoter and Sushi fetchers cover liquid tokens every minute;
+      # CoinGecko is the fallback for the illiquid tail, where this is plenty.
       - key: COINGECKO_TOKEN_PRICE_SYNC_INTERVAL_SECONDS
         scope: RUN_TIME
-        value: "300"
+        value: "900"
     run_command: bun src/price-sync/index.ts
 jobs:
   - name: run-migrations

--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ Token metadata generation and database synchronization are owned by the
 [`EkuboProtocol/default-tokens`](https://github.com/EkuboProtocol/default-tokens)
 repository. The indexer image does not fetch or write token metadata.
 
-The price-sync process runs every configured chain/source pair as an independent recurring job. A job is uniquely identified by its chain ID and three-character source identifier; startup fails if that pair is configured twice. `TOKEN_PRICE_SYNC_INTERVAL_MS` controls the default cadence in milliseconds (default: `60000`). CoinGecko jobs use `COINGECKO_TOKEN_PRICE_SYNC_INTERVAL_SECONDS`; set it to a positive number and provide `COINGECKO_API_KEY` to enable them. Zero or an unset value disables those jobs.
+The price-sync process runs every configured job as an independent recurring loop. A job declares the chains it may write prices for plus a three-character source identifier; startup fails if two jobs claim the same chain and source. Most jobs price one chain, but a job may price several when one upstream request covers them all. `TOKEN_PRICE_SYNC_INTERVAL_MS` controls the default cadence in milliseconds (default: `60000`). CoinGecko jobs use `COINGECKO_TOKEN_PRICE_SYNC_INTERVAL_SECONDS`; set it to a positive number and provide `COINGECKO_API_KEY` to enable them. Zero or an unset value disables those jobs.
+
+Two properties keep CoinGecko request volume flat rather than growing with `erc20_tokens`:
+
+- Native currency prices for every chain come from a single `cgn` job. Chains sharing a CoinGecko coin ID cost one request between them, not one apiece.
+- The per-chain `cg1` jobs request only the tokens CoinGecko has actually priced. Everything else is re-probed on a slow rotation (a full pass per day), so a chain with thousands of unlisted tokens does not pay for them every cycle. This state is held in the worker process, so a restart replays one full sweep before settling back down.
 
 ## Database migrations
 

--- a/src/price-sync/fetchers/coingecko.test.ts
+++ b/src/price-sync/fetchers/coingecko.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, expect, test } from "bun:test";
+import type { Sql } from "postgres";
+import {
+  coingeckoNativePriceFetcher,
+  coingeckoPriceFetcher,
+} from "./coingecko";
+import type { PriceUpdate } from "./types";
+
+const realFetch = globalThis.fetch;
+const realApiKey = process.env.COINGECKO_API_KEY;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  if (realApiKey === undefined) delete process.env.COINGECKO_API_KEY;
+  else process.env.COINGECKO_API_KEY = realApiKey;
+});
+
+// Records every URL requested and replies with the caller's payload.
+function stubCoinGecko(reply: (url: URL) => unknown): string[] {
+  const requested: string[] = [];
+  process.env.COINGECKO_API_KEY = "test-key";
+  globalThis.fetch = (async (input: string | URL) => {
+    const url = new URL(String(input));
+    requested.push(url.toString());
+    return new Response(JSON.stringify(reply(url)), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+  return requested;
+}
+
+// `sql` is only ever used here as a tagged template returning token rows.
+function stubSql(addresses: string[]): Sql<{ bigint: bigint }> {
+  return (() =>
+    Promise.resolve(
+      addresses.map((address) => ({ token_address: BigInt(address).toString() })),
+    )) as unknown as Sql<{ bigint: bigint }>;
+}
+
+async function collect(
+  fetcher: () => AsyncIterable<readonly PriceUpdate[]>,
+): Promise<PriceUpdate[]> {
+  const updates: PriceUpdate[] = [];
+  for await (const batch of fetcher()) updates.push(...batch);
+  return updates;
+}
+
+test("the native fetcher prices every chain sharing a coin ID in one request", async () => {
+  const requested = stubCoinGecko(() => ({ ethereum: { usd: 3_000 } }));
+  const job = coingeckoNativePriceFetcher({
+    intervalMs: 900_000,
+    chainIdsByCoinId: { ethereum: [1n, 8453n, 4663n, 42161n] },
+  });
+
+  const updates = await collect(job.fetch);
+
+  expect(requested).toHaveLength(1);
+  expect(requested[0]).toContain("ids=ethereum");
+  expect(updates.map((update) => update.chainId)).toEqual([
+    1n,
+    8453n,
+    4663n,
+    42161n,
+  ]);
+  expect(new Set(updates.map((update) => update.usdPrice))).toEqual(
+    new Set([3_000]),
+  );
+  expect(job.chainIds).toEqual([1n, 8453n, 4663n, 42161n]);
+});
+
+test("the native fetcher issues one request per distinct coin ID", async () => {
+  const requested = stubCoinGecko(() => ({
+    ethereum: { usd: 3_000 },
+    binancecoin: { usd: 600 },
+  }));
+  const job = coingeckoNativePriceFetcher({
+    intervalMs: 900_000,
+    chainIdsByCoinId: { ethereum: [1n, 8453n], binancecoin: [56n] },
+  });
+
+  const updates = await collect(job.fetch);
+
+  expect(requested).toHaveLength(1);
+  expect(updates).toHaveLength(3);
+  expect(updates.find((update) => update.chainId === 56n)?.usdPrice).toBe(600);
+});
+
+test("the native fetcher skips chains CoinGecko did not price", async () => {
+  stubCoinGecko(() => ({ ethereum: { usd: 0 } }));
+  const job = coingeckoNativePriceFetcher({
+    intervalMs: 900_000,
+    chainIdsByCoinId: { ethereum: [1n, 8453n] },
+  });
+
+  expect(await collect(job.fetch)).toEqual([]);
+});
+
+const TOKENS = [
+  "0x1111111111111111111111111111111111111111",
+  "0x2222222222222222222222222222222222222222",
+  "0x3333333333333333333333333333333333333333",
+  "0x4444444444444444444444444444444444444444",
+];
+
+function requestedAddresses(requested: string[]): string[][] {
+  return requested.map((url) =>
+    (new URL(url).searchParams.get("contract_addresses") ?? "").split(","),
+  );
+}
+
+test("the token fetcher sweeps every address on its first cycle", async () => {
+  const requested = stubCoinGecko(() => ({ [TOKENS[0]]: { usd: 1 } }));
+  const job = coingeckoPriceFetcher({
+    sql: stubSql(TOKENS),
+    chainId: 8453n,
+    intervalMs: 900_000,
+    platform: "base",
+  });
+
+  await collect(job.fetch);
+
+  expect(requestedAddresses(requested)).toEqual([TOKENS]);
+});
+
+test("the token fetcher drops addresses CoinGecko does not price from later cycles", async () => {
+  // Only the first two tokens are listed; the rest should fall out of rotation.
+  const requested = stubCoinGecko(() => ({
+    [TOKENS[0]]: { usd: 1 },
+    [TOKENS[1]]: { usd: 2 },
+  }));
+  const job = coingeckoPriceFetcher({
+    sql: stubSql(TOKENS),
+    chainId: 8453n,
+    intervalMs: 1_000,
+    // Long enough that no unpriced token is due again during this test.
+    unpricedReprobeIntervalMs: 1_000_000,
+    platform: "base",
+  });
+
+  await collect(job.fetch);
+  requested.length = 0;
+  const updates = await collect(job.fetch);
+
+  expect(requestedAddresses(requested)).toEqual([[TOKENS[0], TOKENS[1]]]);
+  expect(updates.map((update) => update.usdPrice)).toEqual([1, 2]);
+});
+
+test("the token fetcher re-probes unpriced addresses on rotation", async () => {
+  const requested = stubCoinGecko(() => ({}));
+  const job = coingeckoPriceFetcher({
+    sql: stubSql(TOKENS),
+    chainId: 8453n,
+    intervalMs: 1_000,
+    // Two slots: half the unpriced tail comes due on each cycle.
+    unpricedReprobeIntervalMs: 2_000,
+    platform: "base",
+  });
+
+  await collect(job.fetch);
+  requested.length = 0;
+  await collect(job.fetch);
+  await collect(job.fetch);
+
+  // Cycle 2 takes slot 1 (indexes 1 and 3), cycle 3 takes slot 0 (0 and 2).
+  expect(requestedAddresses(requested)).toEqual([
+    [TOKENS[1], TOKENS[3]],
+    [TOKENS[0], TOKENS[2]],
+  ]);
+});
+
+test("the token fetcher picks up a token that CoinGecko lists later", async () => {
+  let listed = false;
+  const requested = stubCoinGecko(() =>
+    listed ? { [TOKENS[1]]: { usd: 5 } } : {},
+  );
+  const job = coingeckoPriceFetcher({
+    sql: stubSql(TOKENS),
+    chainId: 8453n,
+    intervalMs: 1_000,
+    unpricedReprobeIntervalMs: 2_000,
+    platform: "base",
+  });
+
+  await collect(job.fetch);
+  listed = true;
+  await collect(job.fetch); // slot 1 re-probes TOKENS[1] and finds a price
+  requested.length = 0;
+  await collect(job.fetch);
+
+  // Now priced, TOKENS[1] is requested every cycle rather than on rotation.
+  expect(requestedAddresses(requested)[0]).toContain(TOKENS[1]);
+});
+
+test("the token fetcher forgets addresses that leave erc20_tokens", async () => {
+  const requested = stubCoinGecko(() => ({ [TOKENS[0]]: { usd: 1 } }));
+  let addresses = TOKENS;
+  const job = coingeckoPriceFetcher({
+    sql: (() =>
+      Promise.resolve(
+        addresses.map((address) => ({
+          token_address: BigInt(address).toString(),
+        })),
+      )) as unknown as Sql<{ bigint: bigint }>,
+    chainId: 8453n,
+    intervalMs: 1_000,
+    unpricedReprobeIntervalMs: 1_000_000,
+    platform: "base",
+  });
+
+  await collect(job.fetch);
+  addresses = TOKENS.slice(1);
+  requested.length = 0;
+  await collect(job.fetch);
+
+  // TOKENS[0] was the only priced address, so dropping it from erc20_tokens
+  // must drop it from the fast lane too rather than pinning it there forever.
+  expect(requestedAddresses(requested).flat()).not.toContain(TOKENS[0]);
+});

--- a/src/price-sync/fetchers/coingecko.ts
+++ b/src/price-sync/fetchers/coingecko.ts
@@ -6,14 +6,26 @@ const COINGECKO_API_BASE_URL = "https://pro-api.coingecko.com/api/v3";
 // Although CoinGecko accepts more addresses, large comma-separated batches can
 // exceed the HTTP request-line limit before reaching the API.
 const COINGECKO_MAX_CONTRACT_ADDRESSES = 100;
+// How long to leave a token out of the rotation after CoinGecko declines to
+// price it. Most of `erc20_tokens` is pool scaffolding and one-off deployments
+// CoinGecko will never list, so re-asking every cycle costs requests forever
+// and never yields a price.
+const UNPRICED_REPROBE_INTERVAL_MS = 24 * 60 * 60 * 1_000;
 
 type CoinGeckoTokenPriceResponse = Record<string, { usd?: number }>;
 type TokenAddressRow = { token_address: string };
 
 interface CoinGeckoPriceFetcherOptions extends PriceSyncJobOptions {
   sql: Sql<{ bigint: bigint }>;
-  platform?: string;
-  nativeCoinId?: string;
+  platform: string;
+  unpricedReprobeIntervalMs?: number;
+}
+
+interface CoinGeckoNativePriceFetcherOptions {
+  intervalMs: number;
+  // CoinGecko coin ID to the chains whose native currency it prices. Chains
+  // sharing a coin ID are served by one request instead of one apiece.
+  chainIdsByCoinId: Readonly<Record<string, readonly bigint[]>>;
 }
 
 function toEvmAddress(address: string): `0x${string}` {
@@ -61,80 +73,165 @@ async function fetchCoinGecko<T>({
   return (await response.json()) as T;
 }
 
+function requireApiKey(): string {
+  const apiKey = process.env.COINGECKO_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "COINGECKO_API_KEY is required when CoinGecko price syncing is enabled",
+    );
+  }
+  return apiKey;
+}
+
+function usablePrice(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+/**
+ * Prices the native currency of every configured chain. Chains that share a
+ * CoinGecko coin ID — every EVM rollup settling in ETH, for instance — are
+ * priced by a single `simple/price` request rather than one request per chain.
+ */
+export function coingeckoNativePriceFetcher({
+  intervalMs,
+  chainIdsByCoinId,
+}: CoinGeckoNativePriceFetcherOptions): PriceSyncJob {
+  const coinIds = Object.keys(chainIdsByCoinId).sort();
+  const chainIds = coinIds.flatMap((coinId) => [...chainIdsByCoinId[coinId]]);
+
+  return {
+    chainIds,
+    source: "cgn",
+    intervalMs,
+    fetch: async function* () {
+      if (coinIds.length === 0) return;
+
+      const apiKey = requireApiKey();
+      const query = new URLSearchParams({
+        ids: coinIds.join(","),
+        vs_currencies: "usd",
+        precision: "full",
+      });
+      const result = await fetchCoinGecko<CoinGeckoTokenPriceResponse>({
+        url: `${COINGECKO_API_BASE_URL}/simple/price?${query}`,
+        apiKey,
+        context: `native currencies ${coinIds.join(", ")}`,
+      });
+
+      const timestamp = new Date();
+      for (const coinId of coinIds) {
+        const usdPrice = result[coinId]?.usd;
+        if (!usablePrice(usdPrice)) continue;
+
+        for (const chainId of chainIdsByCoinId[coinId]) {
+          yield toPriceUpdates(chainId, [["0x0", usdPrice]], timestamp);
+        }
+      }
+    },
+  };
+}
+
+/**
+ * Prices a chain's ERC20 tokens by contract address.
+ *
+ * Only tokens CoinGecko has actually priced are requested every cycle. The rest
+ * — the large majority of `erc20_tokens` on any chain — are re-probed on a slow
+ * rotation, which keeps request volume proportional to the tokens CoinGecko
+ * covers instead of to the size of the table.
+ */
 export function coingeckoPriceFetcher({
   sql,
   chainId,
   intervalMs,
   platform,
-  nativeCoinId,
+  unpricedReprobeIntervalMs = UNPRICED_REPROBE_INTERVAL_MS,
 }: CoinGeckoPriceFetcherOptions): PriceSyncJob {
+  // Retained across cycles for the life of the process. A restart replays the
+  // full sweep once, which is what this job did on every cycle before.
+  const priced = new Set<string>();
+  const probed = new Set<string>();
+  let cycle = 0;
+
+  // Spread the re-probes of unpriced tokens evenly across the rotation window,
+  // so each cycle carries roughly one slot's worth instead of the whole tail.
+  const slotCount = Math.max(
+    1,
+    Math.round(unpricedReprobeIntervalMs / Math.max(intervalMs, 1)),
+  );
+
   return {
-    chainId,
+    chainIds: [chainId],
     source: "cg1",
     intervalMs,
     fetch: async function* () {
-      const apiKey = process.env.COINGECKO_API_KEY;
-      if (!apiKey) {
-        throw new Error(
-          "COINGECKO_API_KEY is required when CoinGecko price syncing is enabled",
-        );
+      const apiKey = requireApiKey();
+      const addresses = await fetchTokenAddresses(sql, chainId);
+      const currentAddresses = new Set(addresses);
+
+      // Tokens can leave `erc20_tokens`; do not let the sets grow forever.
+      for (const address of probed) {
+        if (!currentAddresses.has(address)) {
+          probed.delete(address);
+          priced.delete(address);
+        }
       }
 
-      if (nativeCoinId) {
+      const slot = cycle % slotCount;
+      cycle++;
+
+      const selected = addresses.filter(
+        (address, index) =>
+          // CoinGecko prices it, so keep it fresh every cycle.
+          priced.has(address) ||
+          // Never asked — a token new to the table, or the first sweep after a
+          // restart.
+          !probed.has(address) ||
+          // Due for its periodic re-probe in case CoinGecko has listed it since.
+          index % slotCount === slot,
+      );
+
+      for (
+        let offset = 0;
+        offset < selected.length;
+        offset += COINGECKO_MAX_CONTRACT_ADDRESSES
+      ) {
+        const batch = selected.slice(
+          offset,
+          offset + COINGECKO_MAX_CONTRACT_ADDRESSES,
+        );
         const query = new URLSearchParams({
-          ids: nativeCoinId,
+          contract_addresses: batch.join(","),
           vs_currencies: "usd",
           precision: "full",
         });
         const result = await fetchCoinGecko<CoinGeckoTokenPriceResponse>({
-          url: `${COINGECKO_API_BASE_URL}/simple/price?${query}`,
+          url: `${COINGECKO_API_BASE_URL}/simple/token_price/${platform}?${query}`,
           apiKey,
-          context: `native token for chain ${chainId}`,
+          context: `token prices for chain ${chainId}`,
         });
-        const nativeUsdPrice = result[nativeCoinId]?.usd;
+        const prices: [tokenAddress: string, usdPrice: number][] = [];
 
-        if (
-          typeof nativeUsdPrice === "number" &&
-          Number.isFinite(nativeUsdPrice) &&
-          nativeUsdPrice > 0
-        ) {
-          yield toPriceUpdates(chainId, [["0x0", nativeUsdPrice]]);
-        }
-      }
-
-      if (platform) {
-        const addresses = await fetchTokenAddresses(sql, chainId);
-
-        for (
-          let offset = 0;
-          offset < addresses.length;
-          offset += COINGECKO_MAX_CONTRACT_ADDRESSES
-        ) {
-          const batch = addresses.slice(
-            offset,
-            offset + COINGECKO_MAX_CONTRACT_ADDRESSES,
-          );
-          const query = new URLSearchParams({
-            contract_addresses: batch.join(","),
-            vs_currencies: "usd",
-            precision: "full",
-          });
-          const result = await fetchCoinGecko<CoinGeckoTokenPriceResponse>({
-            url: `${COINGECKO_API_BASE_URL}/simple/token_price/${platform}?${query}`,
-            apiKey,
-            context: `token prices for chain ${chainId}`,
-          });
-          const prices: [tokenAddress: string, usdPrice: number][] = [];
-
-          for (const [address, { usd }] of Object.entries(result)) {
-            if (typeof usd === "number" && Number.isFinite(usd) && usd > 0) {
-              prices.push([address, usd]);
-            }
+        // CoinGecko lowercases the addresses it echoes back, so compare on the
+        // requested form rather than trusting the response keys to match.
+        const pricedInBatch = new Set<string>();
+        for (const [address, { usd }] of Object.entries(result)) {
+          if (usablePrice(usd)) {
+            prices.push([address, usd]);
+            pricedInBatch.add(address.toLowerCase());
           }
-
-          const updates = toPriceUpdates(chainId, prices);
-          if (updates.length > 0) yield updates;
         }
+
+        for (const address of batch) {
+          probed.add(address);
+          if (pricedInBatch.has(address.toLowerCase())) {
+            priced.add(address);
+          } else {
+            priced.delete(address);
+          }
+        }
+
+        const updates = toPriceUpdates(chainId, prices);
+        if (updates.length > 0) yield updates;
       }
     },
   };

--- a/src/price-sync/fetchers/ekuboQuoter.ts
+++ b/src/price-sync/fetchers/ekuboQuoter.ts
@@ -150,7 +150,7 @@ export function quoterPriceFetcher({
   ).replace(/\/+$/, "");
 
   return {
-    chainId,
+    chainIds: [chainId],
     source: "qp1",
     intervalMs,
     fetch: async function* () {

--- a/src/price-sync/fetchers/oracleV1.ts
+++ b/src/price-sync/fetchers/oracleV1.ts
@@ -20,7 +20,7 @@ export function oracleV1PriceFetcher({
   twapDurationSeconds,
 }: OracleV1PriceFetcherOptions): PriceSyncJob {
   return {
-    chainId,
+    chainIds: [chainId],
     source: "ov1",
     intervalMs,
     fetch: async function* () {

--- a/src/price-sync/fetchers/sushiswap.ts
+++ b/src/price-sync/fetchers/sushiswap.ts
@@ -7,7 +7,7 @@ export function sushiswapPriceFetcher({
   intervalMs,
 }: PriceSyncJobOptions): PriceSyncJob {
   return {
-    chainId,
+    chainIds: [chainId],
     source: "ss1",
     intervalMs,
     fetch: async function* () {

--- a/src/price-sync/fetchers/types.ts
+++ b/src/price-sync/fetchers/types.ts
@@ -10,7 +10,10 @@ export interface PriceFetcher {
 }
 
 export interface PriceSyncJob {
-  readonly chainId: bigint;
+  // Chains this job may yield updates for. Per-chain jobs list exactly one; a
+  // job that prices the same upstream asset on several chains lists each one so
+  // a single request can serve all of them.
+  readonly chainIds: readonly bigint[];
   readonly source: string;
   readonly intervalMs: number;
   readonly fetch: PriceFetcher;

--- a/src/price-sync/jobs.ts
+++ b/src/price-sync/jobs.ts
@@ -1,5 +1,8 @@
 import type { Sql } from "postgres";
-import { coingeckoPriceFetcher } from "./fetchers/coingecko";
+import {
+  coingeckoNativePriceFetcher,
+  coingeckoPriceFetcher,
+} from "./fetchers/coingecko";
 import { quoterPriceFetcher } from "./fetchers/ekuboQuoter";
 // import { oracleV1PriceFetcher } from "./fetchers/oracleV1";
 import { sushiswapPriceFetcher } from "./fetchers/sushiswap";
@@ -17,6 +20,21 @@ export function createPriceSyncJobs({
   coingeckoIntervalMs,
 }: CreatePriceSyncJobsOptions): PriceSyncJob[] {
   return [
+    // Every chain whose native currency CoinGecko prices, in one request. Chains
+    // sharing a coin ID cost nothing extra, so add them here rather than giving
+    // each chain its own CoinGecko job.
+    coingeckoNativePriceFetcher({
+      intervalMs: coingeckoIntervalMs,
+      chainIdsByCoinId: {
+        ethereum: [
+          1n, // eth mainnet
+          8453n, // base
+          4663n, // robinhood
+          42161n, // arbitrum one
+        ],
+      },
+    }),
+
     // eth mainnet
     sushiswapPriceFetcher({
       chainId: 1n,
@@ -41,13 +59,6 @@ export function createPriceSyncJobs({
       twapDurationSeconds: 60,
     }),
     */
-    coingeckoPriceFetcher({
-      sql,
-      chainId: 1n,
-      intervalMs: coingeckoIntervalMs,
-      nativeCoinId: "ethereum",
-    }),
-
     // eth sepolia
     sushiswapPriceFetcher({
       chainId: 11155111n,
@@ -72,7 +83,6 @@ export function createPriceSyncJobs({
       chainId: 8453n,
       intervalMs: coingeckoIntervalMs,
       platform: "base",
-      nativeCoinId: "ethereum",
     }),
 
     // monad
@@ -103,7 +113,6 @@ export function createPriceSyncJobs({
       chainId: 4663n,
       intervalMs: coingeckoIntervalMs,
       platform: "robinhood",
-      nativeCoinId: "ethereum",
     }),
 
     // fake robinhood chain
@@ -126,7 +135,6 @@ export function createPriceSyncJobs({
       chainId: 42161n,
       intervalMs: coingeckoIntervalMs,
       platform: "arbitrum-one",
-      nativeCoinId: "ethereum",
     }),
 
     // arbitrum sepolia

--- a/src/price-sync/runPriceSyncJob.test.ts
+++ b/src/price-sync/runPriceSyncJob.test.ts
@@ -29,7 +29,7 @@ test("runPriceSyncJob writes each yielded batch and reports totals", async () =>
     ],
   ];
   const job: PriceSyncJob = {
-    chainId: 1n,
+    chainIds: [1n],
     source: "tst",
     intervalMs: 1_000,
     fetch: async function* () {
@@ -58,7 +58,7 @@ test("runPriceSyncJob writes each yielded batch and reports totals", async () =>
 
 test("runPriceSyncJob rejects updates for a different chain", async () => {
   const priceJob: PriceSyncJob = {
-    chainId: 1n,
+    chainIds: [1n],
     source: "tst",
     intervalMs: 1_000,
     fetch: async function* () {
@@ -76,4 +76,23 @@ test("runPriceSyncJob rejects updates for a different chain", async () => {
   await expect(runPriceSyncJob(priceJob, async () => 1)).rejects.toThrow(
     "Price sync job 1:tst yielded an update for chain 8453",
   );
+});
+
+test("runPriceSyncJob accepts every chain a multi-chain job declares", async () => {
+  const timestamp = new Date("2026-07-28T12:00:00.000Z");
+  const priceJob: PriceSyncJob = {
+    chainIds: [1n, 8453n],
+    source: "tst",
+    intervalMs: 1_000,
+    fetch: async function* () {
+      yield [{ chainId: 1n, tokenAddress: "0x0", timestamp, usdPrice: 3_000 }];
+      yield [
+        { chainId: 8453n, tokenAddress: "0x0", timestamp, usdPrice: 3_000 },
+      ];
+    },
+  };
+
+  const result = await runPriceSyncJob(priceJob, async () => 1);
+
+  expect(result).toEqual({ batchCount: 2, updateCount: 2, insertedCount: 2 });
 });

--- a/src/price-sync/runPriceSyncJob.ts
+++ b/src/price-sync/runPriceSyncJob.ts
@@ -18,12 +18,13 @@ export async function runPriceSyncJob(
   let batchCount = 0;
   let updateCount = 0;
   let insertedCount = 0;
+  const allowedChainIds = new Set(job.chainIds);
 
   for await (const updates of job.fetch()) {
     if (updates.length === 0) continue;
 
     for (const update of updates) {
-      if (update.chainId !== job.chainId) {
+      if (!allowedChainIds.has(update.chainId)) {
         throw new Error(
           `Price sync job ${priceSyncJobId(
             job,

--- a/src/price-sync/validatePriceSyncJobs.test.ts
+++ b/src/price-sync/validatePriceSyncJobs.test.ts
@@ -3,16 +3,16 @@ import type { PriceSyncJob } from "./fetchers/types";
 import { priceSyncJobId, validatePriceSyncJobs } from "./validatePriceSyncJobs";
 
 function job({
-  chainId,
+  chainIds,
   source,
   intervalMs = 1_000,
 }: {
-  chainId: bigint;
+  chainIds: readonly bigint[];
   source: string;
   intervalMs?: number;
 }): PriceSyncJob {
   return {
-    chainId,
+    chainIds,
     source,
     intervalMs,
     fetch: async function* () {},
@@ -20,26 +20,51 @@ function job({
 }
 
 test("priceSyncJobId derives the semantic chain and source identity", () => {
-  expect(priceSyncJobId(job({ chainId: 4663n, source: "cg1" }))).toBe(
+  expect(priceSyncJobId(job({ chainIds: [4663n], source: "cg1" }))).toBe(
     "4663:cg1",
+  );
+  expect(priceSyncJobId(job({ chainIds: [1n, 8453n], source: "cgn" }))).toBe(
+    "1+8453:cgn",
   );
 });
 
 test("validatePriceSyncJobs rejects duplicate chain and source jobs", () => {
   expect(() =>
     validatePriceSyncJobs([
-      job({ chainId: 4663n, source: "cg1" }),
-      job({ chainId: 4663n, source: "cg1", intervalMs: 5_000 }),
+      job({ chainIds: [4663n], source: "cg1" }),
+      job({ chainIds: [4663n], source: "cg1", intervalMs: 5_000 }),
     ]),
   ).toThrow("Duplicate price sync job: 4663:cg1");
+});
+
+test("validatePriceSyncJobs rejects a chain claimed by a multi-chain job", () => {
+  expect(() =>
+    validatePriceSyncJobs([
+      job({ chainIds: [1n, 8453n], source: "cgn" }),
+      job({ chainIds: [8453n], source: "cgn" }),
+    ]),
+  ).toThrow("Duplicate price sync job: 8453:cgn");
+});
+
+test("validatePriceSyncJobs rejects a job that repeats a chain", () => {
+  expect(() =>
+    validatePriceSyncJobs([job({ chainIds: [1n, 1n], source: "cgn" })]),
+  ).toThrow("repeats a chain ID");
+});
+
+test("validatePriceSyncJobs rejects a job with no chains", () => {
+  expect(() =>
+    validatePriceSyncJobs([job({ chainIds: [], source: "cgn" })]),
+  ).toThrow("must price at least one chain");
 });
 
 test("validatePriceSyncJobs accepts the same source on different chains", () => {
   expect(() =>
     validatePriceSyncJobs([
-      job({ chainId: 1n, source: "cg1" }),
-      job({ chainId: 4663n, source: "cg1" }),
-      job({ chainId: 4663n, source: "ss1" }),
+      job({ chainIds: [1n], source: "cg1" }),
+      job({ chainIds: [4663n], source: "cg1" }),
+      job({ chainIds: [4663n], source: "ss1" }),
+      job({ chainIds: [1n, 4663n], source: "cgn" }),
     ]),
   ).not.toThrow();
 });

--- a/src/price-sync/validatePriceSyncJobs.ts
+++ b/src/price-sync/validatePriceSyncJobs.ts
@@ -1,13 +1,15 @@
 import type { PriceSyncJob } from "./fetchers/types";
 
 export function priceSyncJobId(
-  job: Pick<PriceSyncJob, "chainId" | "source">,
+  job: Pick<PriceSyncJob, "chainIds" | "source">,
 ): string {
-  return `${job.chainId}:${job.source}`;
+  return `${job.chainIds.join("+")}:${job.source}`;
 }
 
 export function validatePriceSyncJobs(jobs: readonly PriceSyncJob[]): void {
-  const jobIds = new Set<string>();
+  // A source may price many chains and a chain may have many sources, but two
+  // jobs writing the same source on the same chain would race each other.
+  const claimedChainSources = new Set<string>();
 
   for (const job of jobs) {
     const jobId = priceSyncJobId(job);
@@ -17,8 +19,14 @@ export function validatePriceSyncJobs(jobs: readonly PriceSyncJob[]): void {
         `Price sync job ${jobId} must use a three-character source identifier`,
       );
     }
-    if (job.chainId <= 0n) {
-      throw new Error(`Price sync job ${jobId} must use a positive chain ID`);
+    if (job.chainIds.length === 0) {
+      throw new Error(`Price sync job ${jobId} must price at least one chain`);
+    }
+    if (new Set(job.chainIds).size !== job.chainIds.length) {
+      throw new Error(`Price sync job ${jobId} repeats a chain ID`);
+    }
+    if (job.chainIds.some((chainId) => chainId <= 0n)) {
+      throw new Error(`Price sync job ${jobId} must use positive chain IDs`);
     }
     if (
       !Number.isFinite(job.intervalMs) ||
@@ -29,10 +37,13 @@ export function validatePriceSyncJobs(jobs: readonly PriceSyncJob[]): void {
         `Price sync job ${jobId} must use a non-negative integer interval`,
       );
     }
-    if (jobIds.has(jobId)) {
-      throw new Error(`Duplicate price sync job: ${jobId}`);
-    }
 
-    jobIds.add(jobId);
+    for (const chainId of job.chainIds) {
+      const chainSource = `${chainId}:${job.source}`;
+      if (claimedChainSources.has(chainSource)) {
+        throw new Error(`Duplicate price sync job: ${chainSource}`);
+      }
+      claimedChainSources.add(chainSource);
+    }
   }
 }


### PR DESCRIPTION
Cuts the price-sync worker's CoinGecko usage from ~2,880 requests/day to ~385/day (10 requests per 5-minute cycle → 4 per 15-minute cycle). No migration — the new state is held in the worker process.

Two problems, both predating the July 28 refactor:

- **The ETH price was fetched four times per cycle.** Chains 1, 8453, 4663 and 42161 each passed `nativeCoinId: "ethereum"`, so four identical `simple/price` requests ran every five minutes — 40% of the job's entire CoinGecko spend. A job now declares the *chains* it may price rather than exactly one, which lets a single request serve every chain sharing a coin ID. New `cgn` source.
- **Every row of `erc20_tokens` was re-sent every cycle, forever**, including the large majority of tokens CoinGecko has never listed. Request volume tracked the size of the table rather than the tokens CoinGecko covers. The per-chain `cg1` jobs now keep in-process coverage state and request only the addresses CoinGecko has priced, re-probing the rest on a rotation that makes a full pass each day. A restart replays one full sweep — which is exactly what every cycle used to do — then settles.

This also matters as a guard: chain 1 has 6,756 rows in `erc20_tokens`. Enabling `platform: "ethereum"` on that job as it stood would have added ~19,600 requests/day on its own.

Finally, `COINGECKO_TOKEN_PRICE_SYNC_INTERVAL_SECONDS` goes 300 → 900. The quoter and Sushi fetchers already refresh liquid tokens every 60s; CoinGecko is the fallback for the illiquid tail.

Full suite green (199 pass), including new coverage for the shared native job, the rotation, re-listing pickup, and address removal.