### PR TITLE
Raise the test timeout to 30s and put it where Bun actually reads it

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun ci
-      - run: bun test --timeout 15000
+      - run: bun test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,4 +10,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun ci
-      - run: bun test
+      # Runs the "test" script so CI and local runs share one timeout.
+      - run: bun run test

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,6 @@
 [test]
-# PGlite 0.4 runs initdb during startup, which can exceed Bun's 5-second
-# default on slower CI runners for migration-heavy tests.
-timeout = 15000
+# PGlite runs initdb during startup, which can far exceed Bun's 5-second
+# default on slower CI runners for migration-heavy tests. This is the single
+# source of truth for the test timeout, so CI does not pass --timeout and
+# local runs get the same headroom.
+timeout = 30000

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,6 +1,0 @@
-[test]
-# PGlite runs initdb during startup, which can far exceed Bun's 5-second
-# default on slower CI runners for migration-heavy tests. This is the single
-# source of truth for the test timeout, so CI does not pass --timeout and
-# local runs get the same headroom.
-timeout = 30000

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "starknet:mainnet": "NETWORK=mainnet bun src/starknet.ts",
     "starknet:sepolia": "NETWORK=sepolia bun src/starknet.ts",
     "sync-token-prices": "bun src/price-sync/index.ts",
-    "migrate": "bun scripts/migrate.ts"
+    "migrate": "bun scripts/migrate.ts",
+    "test": "bun test --timeout 30000"
   },
   "author": "Moody Salem",
   "type": "module",


### PR DESCRIPTION
PGlite's `initdb` on startup can far exceed Bun's 5-second default on slower CI runners, which is what has been failing the open dependabot PRs (#129, #130) — their branches predate any timeout config.

While fixing this I found that **`bunfig.toml`'s `[test] timeout` key is silently ignored by Bun 1.3.14.** Setting it to 30000 and dropping CI's `--timeout` flag still failed at exactly 5000ms. Reproduced standalone: a test that sleeps 6s times out at the 5s default with `timeout = 30000` in `bunfig.toml`.

So the only thing ever enforcing a timeout was CI's `--timeout 15000` flag, and local runs have silently been on the 5s default.

This PR:
- adds a `test` package script (`bun test --timeout 30000`) as the single real source of truth, so local and CI runs agree;
- has CI call `bun run test`;
- deletes `bunfig.toml`, whose only content was the key that never took effect.

Verified: both dependabot bumps (viem 2.55.10, pglite 0.5.4) pass in full against current main — 199 pass, 0 fail. Neither had a real failure; both were purely timing out.