### PR TITLE
Fix price insert crash from ON CONFLICT against a dropped primary key

### DIFF
--- a/src/price-sync/fetchers/chainlink.test.ts
+++ b/src/price-sync/fetchers/chainlink.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import type { Sql } from "postgres";
-import { chainlinkPriceFetcher } from "./chainlink";
+import { chainlinkPriceFetcher, shouldReportChainlinkRound } from "./chainlink";
 
 const tokenAddress = "0x0000000000000000000000000000000000000001";
 const feedAddress = "0x0000000000000000000000000000000000000002";
@@ -36,6 +36,30 @@ test("a catalog outage still reports explicitly configured feeds", async () => {
   }
 
   expect(reachedFeedRead).toBe(true);
+});
+
+test("an unchanged round is reported once, not once per poll", () => {
+  // A feed keeps returning its last round until it next publishes, so polling
+  // faster than the heartbeat must not write a row per poll.
+  const round = new Date("2026-08-09T00:00:00Z");
+  expect(shouldReportChainlinkRound(1n, tokenAddress, round)).toBe(true);
+  expect(shouldReportChainlinkRound(1n, tokenAddress, round)).toBe(false);
+  expect(shouldReportChainlinkRound(1n, tokenAddress, round)).toBe(false);
+
+  // A genuine publication is reported again.
+  expect(
+    shouldReportChainlinkRound(1n, tokenAddress, new Date(round.getTime() + 1)),
+  ).toBe(true);
+});
+
+test("rounds are tracked per chain and per token", () => {
+  const round = new Date("2026-08-09T01:00:00Z");
+  expect(shouldReportChainlinkRound(8453n, tokenAddress, round)).toBe(true);
+  // Same token address on a different chain is a different feed.
+  expect(shouldReportChainlinkRound(42161n, tokenAddress, round)).toBe(true);
+  // As is a different token on the same chain.
+  expect(shouldReportChainlinkRound(8453n, feedAddress, round)).toBe(true);
+  expect(shouldReportChainlinkRound(8453n, tokenAddress, round)).toBe(false);
 });
 
 test("a chain with no configured feeds and no catalog yields nothing", async () => {

--- a/src/price-sync/fetchers/chainlink.ts
+++ b/src/price-sync/fetchers/chainlink.ts
@@ -29,6 +29,26 @@ type ChainlinkTokenRow = {
 // An upper bound on how long any single observation may be considered fresh.
 const MAX_PRICE_VALIDITY_MS = 30 * 24 * 60 * 60 * 1_000;
 
+// A feed keeps returning its last round until it next publishes, so polling
+// faster than the heartbeat re-reads one observation many times over. Emitting
+// those repeats would write a row per poll that says nothing new, so track the
+// round already reported per feed and yield only genuine updates. Held in
+// memory: after a restart the first poll re-reports one round per feed, which
+// the latest-price cache absorbs.
+const lastReportedRoundAt = new Map<string, number>();
+
+export function shouldReportChainlinkRound(
+  chainId: bigint,
+  tokenAddress: string,
+  roundUpdatedAt: Date,
+): boolean {
+  const key = `${chainId}:${tokenAddress.toLowerCase()}`;
+  const updatedAtMs = roundUpdatedAt.getTime();
+  if (lastReportedRoundAt.get(key) === updatedAtMs) return false;
+  lastReportedRoundAt.set(key, updatedAtMs);
+  return true;
+}
+
 // Feed discovery and the on-chain reads both need full-width EVM addresses,
 // unlike the numeric form the database stores prices under.
 function toEvmAddress(address: string): `0x${string}` {
@@ -132,13 +152,15 @@ export function chainlinkPriceFetcher({
         feeds,
       });
 
-      // Each observation carries the round's own updatedAt, so an unchanged
-      // round produces a row that already exists and is discarded on insert.
-      // Validity is anchored at that updatedAt and extends through the feed's
-      // staleness window — mirroring the read-side contract — floored at the
-      // job's default so a fast-heartbeat feed cannot expire between syncs.
-      const updates: PriceUpdate[] = Object.entries(observations).map(
-        ([tokenAddress, { usdPrice, timestamp }]) => {
+      // Validity is anchored at the round's own updatedAt and extends through
+      // the feed's staleness window — mirroring the read-side contract —
+      // floored at the job's default so a fast-heartbeat feed cannot expire
+      // between syncs.
+      const updates: PriceUpdate[] = Object.entries(observations)
+        .filter(([tokenAddress, { timestamp }]) =>
+          shouldReportChainlinkRound(chainId, tokenAddress, timestamp),
+        )
+        .map(([tokenAddress, { usdPrice, timestamp }]) => {
           const feed = feedsByToken.get(tokenAddress.toLowerCase());
           // Clamped because maxAgeSeconds also arrives from operator config,
           // where an implausible value would otherwise overflow the Date range
@@ -157,8 +179,7 @@ export function chainlinkPriceFetcher({
             usdPrice,
             validUntil: new Date(timestamp.getTime() + validityMs),
           };
-        },
-      );
+        });
 
       if (updates.length > 0) yield updates;
     },

--- a/src/price-sync/persistPriceUpdates.ts
+++ b/src/price-sync/persistPriceUpdates.ts
@@ -85,8 +85,7 @@ export async function persistPriceUpdates(
         )
         JOIN erc20_tokens AS t
           ON t.chain_id = data.chain_id::int8
-         AND t.token_address = data.token_address::numeric
-        ON CONFLICT (chain_id, token_address, "timestamp", source) DO NOTHING;
+         AND t.token_address = data.token_address::numeric;
       `;
       insertedCount += count;
     }


### PR DESCRIPTION
Hotfix: the `token-price-sync` worker is failing every insert on main with

```
PostgresError: there is no unique or exclusion constraint matching the ON CONFLICT specification
```

Migration `00073` drops `erc20_tokens_usd_prices`' primary key so the hourly retention prune stays cheap. #140 added `ON CONFLICT (chain_id, token_address, "timestamp", source) DO NOTHING` targeting that constraint — I checked the `00059` `CREATE TABLE` and not the later migrations. The migration tests insert SQL directly rather than going through `persistPriceUpdates`, so the statement never ran against the real schema and CI stayed green.

**The dedupe belonged elsewhere anyway.** Only Chainlink can produce a repeat: `latestRoundData` keeps returning the same round until the feed next publishes, so a 60s poll against a 1-hour-heartbeat feed re-reads one observation ~60 times. Every other source stamps wall-clock time per run and can never collide. Guarding every insert for every source to absorb one source's quirk was the wrong altitude.

So the insert goes back to a plain insert, and the Chainlink fetcher no longer emits a round it has already reported — an unchanged round is the same observation re-read, not a new one.

The tracking is in-process, so a restart re-reports one round per feed. That is a dropped optimization rather than a correctness issue: the latest-price cache already ignores an observation whose timestamp it has seen.

Verified: `bun run test` — 223 pass, 0 fail, including new coverage that an unchanged round is reported once and that rounds are tracked per chain and per token.