### PR TITLE
Add cyclomatic complexity gate and fix seven of eight violations

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,5 +10,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun ci
+      - run: bun run lint
       # Runs the "test" script so CI and local runs share one timeout.
       - run: bun run test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,15 @@ Commits follow short, action-oriented summaries (see `git log`, e.g. `increase n
 ## Breaking Change Documentation
 
 Any deployment that requires manual intervention or alters the database schema must be recorded in the README’s breaking changelog section. Include the date, affected networks, necessary operator actions, and downstream compatibility notes so future contributors know how to prepare for rollouts.
+
+## Complexity Policy
+- Run `bun run lint` before considering a change done. CI runs it on every push,
+  before the tests.
+- The only rule is ESLint's `complexity`, capped at 10 per function.
+- One exemption exists: the stream loop in `src/runtime.ts`. Three of its switch arms
+  reassign `currentCursor` and the retry loop reads it again after a failure, so
+  splitting the arms out means threading that reassignment back through every return
+  path — and there is no test coverage over that loop to catch a mistake. Getting the
+  cursor wrong means reprocessing blocks or silently skipping them. Extract the arms
+  when the loop is being reworked for other reasons, behind tests.
+- Any new disable needs a reason on the same line. Otherwise, split the function.

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,8 @@
       "devDependencies": {
         "@electric-sql/pglite": "^0.5.4",
         "@types/bun": "^1.3.14",
+        "@typescript-eslint/parser": "8.68.0",
+        "eslint": "10.9.1",
       },
     },
   },
@@ -39,9 +41,33 @@
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.5.4", "", {}, "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g=="],
 
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.10.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.23.5", "", { "dependencies": { "@eslint/object-schema": "^3.0.5", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.7.0", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw=="],
+
+    "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
+
     "@grpc/grpc-js": ["@grpc/grpc-js@1.13.3", "", { "dependencies": { "@grpc/proto-loader": "^0.7.13", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-FTXHdOoPbZrBjlVLHuKbDZnsTxXv2BlHF57xw6LuThXacXvtkahEPED0CKMk6obZDf65Hv4k3z62eyPNpvinIg=="],
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.7.15", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.2.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
@@ -85,15 +111,41 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
     "@types/node": ["@types/node@22.10.7", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg=="],
 
     "@types/triple-beam": ["@types/triple-beam@1.3.5", "", {}, ""],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.68.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.68.0", "@typescript-eslint/types": "8.68.0", "@typescript-eslint/typescript-estree": "8.68.0", "@typescript-eslint/visitor-keys": "8.68.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.68.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.68.0", "@typescript-eslint/types": "^8.68.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.68.0", "", { "dependencies": { "@typescript-eslint/types": "8.68.0", "@typescript-eslint/visitor-keys": "8.68.0" } }, "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.68.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.68.0", "", {}, "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.68.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.68.0", "@typescript-eslint/tsconfig-utils": "8.68.0", "@typescript-eslint/types": "8.68.0", "@typescript-eslint/visitor-keys": "8.68.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.68.0", "", { "dependencies": { "@typescript-eslint/types": "8.68.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A=="],
 
     "abi-wan-kanabi": ["abi-wan-kanabi@2.2.4", "", { "dependencies": { "ansicolors": "^0.3.2", "cardinal": "^2.1.1", "fs-extra": "^10.0.0", "yargs": "^17.7.2" }, "bin": { "generate": "dist/generate.js" } }, "sha512-0aA81FScmJCPX+8UvkXLki3X1+yPQuWxEkqXBVKltgPAK79J+NB+Lp5DouMXa7L6f+zcRlIA/6XO7BN/q9fnvg=="],
 
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "abort-controller-x": ["abort-controller-x@0.4.3", "", {}, "sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA=="],
+
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -103,7 +155,11 @@
 
     "async": ["async@3.2.5", "", {}, ""],
 
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
+
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -121,6 +177,12 @@
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -129,11 +191,45 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@10.9.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.7.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A=="],
+
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
+
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "bin/esparse.js", "esvalidate": "bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, ""],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
     "fecha": ["fecha@4.2.3", "", {}, ""],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.4", "", {}, "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q=="],
 
     "fn.name": ["fn.name@1.1.0", "", {}, ""],
 
@@ -141,19 +237,43 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, ""],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-stream": ["is-stream@2.0.1", "", {}, ""],
 
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
     "kuler": ["kuler@2.0.0", "", {}, ""],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 
@@ -161,7 +281,11 @@
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
+    "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "nice-grpc": ["nice-grpc@2.1.12", "", { "dependencies": { "@grpc/grpc-js": "^1.13.1", "abort-controller-x": "^0.4.0", "nice-grpc-common": "^2.0.2" } }, "sha512-J1n4Wg+D3IhRhGQb+iqh2OpiM0GzTve/kf2lnlW4S+xczmIEd0aHUDV1OsJ5a3q8GSTqJf+s4Rgg1M8uJltarw=="],
 
@@ -169,13 +293,29 @@
 
     "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, ""],
 
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
     "ox": ["ox@0.14.33", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picomatch": ["picomatch@4.0.7", "", {}, "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
     "postgres-shift": ["postgres-shift@0.1.0", "", {}, "sha512-/375iG0Kveh1Spk3kFtaTdGT9FUxtXYDDabGw/9/Jkk3f93dYM2R8ZgQzbknCG+ZpfoR114gZ71oR+lRr6XY3A=="],
 
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
     "protobufjs": ["protobufjs@7.5.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, ""],
 
@@ -187,6 +327,12 @@
 
     "safe-stable-stringify": ["safe-stable-stringify@2.4.3", "", {}, ""],
 
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "stack-trace": ["stack-trace@0.0.10", "", {}, ""],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -197,21 +343,35 @@
 
     "text-hex": ["text-hex@1.0.0", "", {}, ""],
 
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "triple-beam": ["triple-beam@1.4.1", "", {}, ""],
 
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
     "ts-error": ["ts-error@1.0.6", "", {}, "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, ""],
 
     "viem": ["viem@2.55.10", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.33", "ws": "8.21.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Q9Ba+/ma81U2M5o5P2AQ7Ux8rTIwmCZvUcr8rKdQ22bV0IBFHllM2m5gWDP8hFaUN2nH2oW3QG44amRazflYNQ=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "winston": ["winston@3.19.0", "", { "dependencies": { "@colors/colors": "^1.6.0", "@dabh/diagnostics": "^2.0.8", "async": "^3.2.3", "is-stream": "^2.0.0", "logform": "^2.7.0", "one-time": "^1.0.0", "readable-stream": "^3.4.0", "safe-stable-stringify": "^2.3.1", "stack-trace": "0.0.x", "triple-beam": "^1.3.0", "winston-transport": "^4.9.0" } }, "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA=="],
 
     "winston-transport": ["winston-transport@4.9.0", "", { "dependencies": { "logform": "^2.7.0", "readable-stream": "^3.6.2", "triple-beam": "^1.3.0" } }, ""],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -223,11 +383,15 @@
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
     "@apibara/evm/viem": ["viem@2.48.11", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.20", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw=="],
 
     "@apibara/evm-rpc/viem": ["viem@2.48.11", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.20", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw=="],
 
     "@apibara/protocol/viem": ["viem@2.48.11", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.20", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@scure/bip32/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,31 @@
+import tsParser from "@typescript-eslint/parser";
+
+// Complexity gate only. This is deliberately not a general-purpose lint setup:
+// the single rule here is a guardrail against functions growing unreviewably
+// branchy, and keeping the config to one rule means a failure is always
+// actionable and never a style argument.
+const rules = { complexity: ["error", 10] };
+
+export default [
+  {
+    ignores: ["node_modules/**", "dist/**", "build/**", ".astro/**", "generated/**"],
+  },
+  {
+    files: ["**/*.{ts,tsx,mts,cts}"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: { ecmaFeatures: { jsx: true }, sourceType: "module" },
+    },
+    rules,
+  },
+  {
+    files: ["**/*.{js,jsx,mjs}"],
+    languageOptions: { ecmaVersion: "latest", sourceType: "module" },
+    rules,
+  },
+  {
+    files: ["**/*.cjs"],
+    languageOptions: { ecmaVersion: "latest", sourceType: "commonjs" },
+    rules,
+  },
+];

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "starknet:sepolia": "NETWORK=sepolia bun src/starknet.ts",
     "sync-token-prices": "bun src/price-sync/index.ts",
     "migrate": "bun scripts/migrate.ts",
-    "test": "bun test --timeout 30000"
+    "test": "bun test --timeout 30000",
+    "lint": "eslint ."
   },
   "author": "Moody Salem",
   "type": "module",
@@ -28,7 +29,9 @@
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.5.4",
-    "@types/bun": "^1.3.14"
+    "@types/bun": "^1.3.14",
+    "@typescript-eslint/parser": "8.68.0",
+    "eslint": "10.9.1"
   },
   "dependencies": {
     "@apibara/evm": "^2.1.4",

--- a/src/_shared/parseBlockHeader.ts
+++ b/src/_shared/parseBlockHeader.ts
@@ -1,0 +1,41 @@
+/**
+ * The EVM and Starknet streams deliver different block shapes, but the three
+ * fields the runtime actually keys on — height, hash, timestamp — are validated
+ * identically on both. That validation lives here so the two entrypoints cannot
+ * drift apart on what counts as a usable header.
+ */
+export interface CommonBlockHeader {
+  number: number;
+  hash: bigint;
+  timestamp: number;
+}
+
+export function parseCommonBlockHeader(header: {
+  blockNumber?: unknown;
+  timestamp?: unknown;
+  blockHash?: unknown;
+}): CommonBlockHeader | null {
+  if (
+    typeof header.blockNumber !== "bigint" ||
+    !(header.timestamp instanceof Date)
+  ) {
+    return null;
+  }
+
+  const number = Number(header.blockNumber);
+  const timestamp = header.timestamp.getTime();
+  if (!Number.isSafeInteger(number) || !Number.isFinite(timestamp)) {
+    return null;
+  }
+
+  // A stream can hand back a header whose hash is absent or malformed; treating
+  // that as an unusable block is safer than indexing under a zero hash.
+  let hash: bigint;
+  try {
+    hash = BigInt((header.blockHash as string | undefined) ?? "0x0");
+  } catch {
+    return null;
+  }
+
+  return { number, hash, timestamp };
+}

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -4,6 +4,7 @@ import { createRpcClient } from "@apibara/protocol/rpc";
 import { createPublicClient, fallback } from "viem";
 import type { EventKey } from "./_shared/eventKey";
 import { logger } from "./_shared/logger";
+import { parseCommonBlockHeader } from "./_shared/parseBlockHeader";
 import {
   loadHexAddresses,
   loadOptionalHexAddress,
@@ -42,35 +43,51 @@ export function parseEvmBlockHeader(
   if (!evmBlock.header || !Array.isArray(evmBlock.logs)) return null;
 
   const { header } = evmBlock;
-  if (
-    typeof header.blockNumber !== "bigint" ||
-    !(header.timestamp instanceof Date)
-  ) {
-    return null;
-  }
-
-  const blockNumber = Number(header.blockNumber);
-  const timestamp = header.timestamp.getTime();
-  if (!Number.isSafeInteger(blockNumber) || !Number.isFinite(timestamp)) {
-    return null;
-  }
-
-  let hash: bigint;
-  try {
-    hash = BigInt(header.blockHash ?? "0x0");
-  } catch {
-    return null;
-  }
+  const common = parseCommonBlockHeader(header);
+  if (!common) return null;
 
   return {
     block: evmBlock as EvmBlock,
     header: {
-      number: blockNumber,
-      hash,
-      timestamp,
+      ...common,
       baseFeePerGas: header.baseFeePerGas ?? null,
     },
   };
+}
+
+// Announces which of the optional contract sets this process ended up indexing.
+// Purely diagnostic, and lifted out of createEvmEntrypoint because it is four
+// independent "did we get this one?" checks that have nothing to do with the
+// wiring around them.
+function logIndexedContracts({
+  evmV2AddressConfig,
+  evmV3AddressConfig,
+  positionsV3ProtocolFeeConfigs,
+  evmV3Ve33AddressConfig,
+}: {
+  evmV2AddressConfig: unknown;
+  evmV3AddressConfig: unknown;
+  positionsV3ProtocolFeeConfigs: { length: number } | null | undefined;
+  evmV3Ve33AddressConfig: {
+    ve33Address: unknown;
+    veTokenAddress: unknown;
+    ve33PositionsAddress: unknown;
+  };
+}): void {
+  if (evmV2AddressConfig)
+    logger.info(`Indexing V2 EVM contracts`, { evmV2AddressConfig });
+  if (evmV3AddressConfig)
+    logger.info(`Indexing V3 EVM contracts`, { evmV3AddressConfig });
+  if (positionsV3ProtocolFeeConfigs?.length)
+    logger.info(`Loaded V3 positions protocol fee configs`, {
+      positionsV3ProtocolFeeConfigs,
+    });
+  if (
+    evmV3Ve33AddressConfig.ve33Address ||
+    evmV3Ve33AddressConfig.veTokenAddress ||
+    evmV3Ve33AddressConfig.ve33PositionsAddress
+  )
+    logger.info(`Indexing V3 Ve33 contracts`, { evmV3Ve33AddressConfig });
 }
 
 export async function createEvmEntrypoint(
@@ -112,20 +129,12 @@ export async function createEvmEntrypoint(
     throw new Error("No config for either V2 or V3 contracts");
   }
 
-  if (evmV2AddressConfig)
-    logger.info(`Indexing V2 EVM contracts`, { evmV2AddressConfig });
-  if (evmV3AddressConfig)
-    logger.info(`Indexing V3 EVM contracts`, { evmV3AddressConfig });
-  if (positionsV3ProtocolFeeConfigs?.length)
-    logger.info(`Loaded V3 positions protocol fee configs`, {
-      positionsV3ProtocolFeeConfigs,
-    });
-  if (
-    evmV3Ve33AddressConfig.ve33Address ||
-    evmV3Ve33AddressConfig.veTokenAddress ||
-    evmV3Ve33AddressConfig.ve33PositionsAddress
-  )
-    logger.info(`Indexing V3 Ve33 contracts`, { evmV3Ve33AddressConfig });
+  logIndexedContracts({
+    evmV2AddressConfig,
+    evmV3AddressConfig,
+    positionsV3ProtocolFeeConfigs,
+    evmV3Ve33AddressConfig,
+  });
 
   const processors = [
     ...(evmV2AddressConfig ? createLogProcessorsV2(evmV2AddressConfig) : []),

--- a/src/price-sync/fetchers/chainlinkFeeds.ts
+++ b/src/price-sync/fetchers/chainlinkFeeds.ts
@@ -252,6 +252,65 @@ function normalizeSymbol(symbol: string): string {
   return symbol.trim().toUpperCase();
 }
 
+function groupTokensBySymbol(
+  tokens: ChainlinkToken[],
+): Map<string, ChainlinkToken[]> {
+  const bySymbol = new Map<string, ChainlinkToken[]>();
+  for (const token of tokens) {
+    const symbol = normalizeSymbol(token.symbol);
+    const matches = bySymbol.get(symbol) ?? [];
+    matches.push(token);
+    bySymbol.set(symbol, matches);
+  }
+  return bySymbol;
+}
+
+// The catalog carries every Chainlink data product, most of which are not USD
+// spot price feeds we can read. These are the admissibility rules, as a table
+// rather than one long conjunction: each rule is named, so a feed that fails to
+// appear can be traced to the exact rule that rejected it.
+const CATALOG_ENTRY_RULES: [string, (value: ChainlinkCatalogEntry) => boolean][] =
+  [
+    ["is a data feed", (v) => v.docs?.deliveryChannelCode === "DF"],
+    ["is a price product", (v) => v.docs?.productType === "Price"],
+    [
+      "is a reference or tokenized price",
+      (v) =>
+        ["RefPrice", "primaryTokenizedPrice"].includes(
+          String(v.docs?.productTypeCode),
+        ),
+    ],
+    ["is quoted in USD", (v) => v.docs?.quoteAsset === "USD"],
+    ["names a base asset", (v) => typeof v.docs?.baseAsset === "string"],
+    ["is not hidden", (v) => v.docs?.hidden !== true],
+    ["is not shut down", (v) => !v.docs?.shutdownDate],
+    ["is not deprecating", (v) => v.feedCategory !== "deprecating"],
+    ["has a path", (v) => typeof v.path === "string"],
+    [
+      "has a proxy address",
+      (v) => typeof v.proxyAddress === "string" && isAddress(v.proxyAddress),
+    ],
+    [
+      "has a usable heartbeat",
+      (v) =>
+        typeof v.heartbeat === "number" &&
+        Number.isSafeInteger(v.heartbeat) &&
+        v.heartbeat > 0 &&
+        v.heartbeat <= MAX_CHAINLINK_HEARTBEAT_SECONDS,
+    ],
+  ];
+
+function isUsableCatalogEntry(value: ChainlinkCatalogEntry): boolean {
+  return CATALOG_ENTRY_RULES.every(([, holds]) => holds(value));
+}
+
+// Lower is better. A feed with no secondary proxy is the plain one and wins
+// outright; among the rest, the shared SVR path is preferred.
+function feedRank(value: ChainlinkCatalogEntry): number {
+  if (!value.secondaryProxyAddress) return 0;
+  return String(value.path).includes("shared-svr") ? 1 : 2;
+}
+
 export function discoverChainlinkFeeds(
   catalog: unknown,
   tokens: ChainlinkToken[],
@@ -260,13 +319,7 @@ export function discoverChainlinkFeeds(
     throw new Error("Chainlink feed catalog must be an array");
   }
 
-  const tokensBySymbol = new Map<string, ChainlinkToken[]>();
-  for (const token of tokens) {
-    const symbol = normalizeSymbol(token.symbol);
-    const matches = tokensBySymbol.get(symbol) ?? [];
-    matches.push(token);
-    tokensBySymbol.set(symbol, matches);
-  }
+  const tokensBySymbol = groupTokensBySymbol(tokens);
 
   const catalogFeedsBySymbol = new Map<
     string,
@@ -275,31 +328,9 @@ export function discoverChainlinkFeeds(
   for (const rawValue of catalog) {
     if (!rawValue || typeof rawValue !== "object") continue;
     const value = rawValue as ChainlinkCatalogEntry;
-    const docs = value.docs;
-    if (
-      !docs ||
-      docs.deliveryChannelCode !== "DF" ||
-      docs.productType !== "Price" ||
-      !["RefPrice", "primaryTokenizedPrice"].includes(
-        String(docs.productTypeCode),
-      ) ||
-      docs.quoteAsset !== "USD" ||
-      typeof docs.baseAsset !== "string" ||
-      docs.hidden === true ||
-      docs.shutdownDate ||
-      value.feedCategory === "deprecating" ||
-      typeof value.path !== "string" ||
-      typeof value.proxyAddress !== "string" ||
-      !isAddress(value.proxyAddress) ||
-      typeof value.heartbeat !== "number" ||
-      !Number.isSafeInteger(value.heartbeat) ||
-      value.heartbeat <= 0 ||
-      value.heartbeat > MAX_CHAINLINK_HEARTBEAT_SECONDS
-    ) {
-      continue;
-    }
+    if (!isUsableCatalogEntry(value)) continue;
 
-    const symbol = normalizeSymbol(docs.baseAsset);
+    const symbol = normalizeSymbol(value.docs!.baseAsset as string);
     const matchingTokens = tokensBySymbol.get(symbol);
     if (matchingTokens?.length !== 1) continue;
 
@@ -308,13 +339,8 @@ export function discoverChainlinkFeeds(
       feedAddress: getAddress(value.proxyAddress),
       maxAgeSeconds: value.heartbeat * 2,
     };
-    const rank = value.secondaryProxyAddress
-      ? value.path.includes("shared-svr")
-        ? 1
-        : 2
-      : 0;
     const feeds = catalogFeedsBySymbol.get(symbol) ?? [];
-    feeds.push({ feed, rank });
+    feeds.push({ feed, rank: feedRank(value) });
     catalogFeedsBySymbol.set(symbol, feeds);
   }
 

--- a/src/price-sync/validatePriceSyncJobs.ts
+++ b/src/price-sync/validatePriceSyncJobs.ts
@@ -6,6 +6,35 @@ export function priceSyncJobId(
   return `${job.chainIds.join("+")}:${job.source}`;
 }
 
+// Checks a single job in isolation. Split from validatePriceSyncJobs so that
+// function is only about the cross-job invariant -- no two jobs writing the
+// same source on the same chain -- and this one is only about field shape.
+function assertJobIsWellFormed(job: PriceSyncJob, jobId: string): void {
+  if (job.source.length !== 3) {
+    throw new Error(
+      `Price sync job ${jobId} must use a three-character source identifier`,
+    );
+  }
+  if (job.chainIds.length === 0) {
+    throw new Error(`Price sync job ${jobId} must price at least one chain`);
+  }
+  if (new Set(job.chainIds).size !== job.chainIds.length) {
+    throw new Error(`Price sync job ${jobId} repeats a chain ID`);
+  }
+  if (job.chainIds.some((chainId) => chainId <= 0n)) {
+    throw new Error(`Price sync job ${jobId} must use positive chain IDs`);
+  }
+  if (
+    !Number.isFinite(job.intervalMs) ||
+    !Number.isInteger(job.intervalMs) ||
+    job.intervalMs < 0
+  ) {
+    throw new Error(
+      `Price sync job ${jobId} must use a non-negative integer interval`,
+    );
+  }
+}
+
 export function validatePriceSyncJobs(jobs: readonly PriceSyncJob[]): void {
   // A source may price many chains and a chain may have many sources, but two
   // jobs writing the same source on the same chain would race each other.
@@ -13,30 +42,7 @@ export function validatePriceSyncJobs(jobs: readonly PriceSyncJob[]): void {
 
   for (const job of jobs) {
     const jobId = priceSyncJobId(job);
-
-    if (job.source.length !== 3) {
-      throw new Error(
-        `Price sync job ${jobId} must use a three-character source identifier`,
-      );
-    }
-    if (job.chainIds.length === 0) {
-      throw new Error(`Price sync job ${jobId} must price at least one chain`);
-    }
-    if (new Set(job.chainIds).size !== job.chainIds.length) {
-      throw new Error(`Price sync job ${jobId} repeats a chain ID`);
-    }
-    if (job.chainIds.some((chainId) => chainId <= 0n)) {
-      throw new Error(`Price sync job ${jobId} must use positive chain IDs`);
-    }
-    if (
-      !Number.isFinite(job.intervalMs) ||
-      !Number.isInteger(job.intervalMs) ||
-      job.intervalMs < 0
-    ) {
-      throw new Error(
-        `Price sync job ${jobId} must use a non-negative integer interval`,
-      );
-    }
+    assertJobIsWellFormed(job, jobId);
 
     for (const chainId of job.chainIds) {
       const chainSource = `${chainId}:${job.source}`;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -70,6 +70,19 @@ export async function runIndexer<TBlock>({
     }
   }
 
+  // This is the indexer's stream loop: acquire the lock, initialise the cursor,
+  // then dispatch heartbeat / systemMessage / finalize / invalidate / data
+  // messages until the stream ends, retrying on a non-canonical cursor.
+  //
+  // Left over the complexity limit deliberately. Three of the switch arms
+  // reassign `currentCursor`, and the retry loop reads it again after a
+  // failure, so splitting the arms into functions means threading that
+  // reassignment back out through every return path. There is no test coverage
+  // over this loop, so that restructuring would be unverifiable -- and getting
+  // the cursor wrong here means either reprocessing blocks or silently skipping
+  // them. If this function is being reworked for other reasons, extracting the
+  // arms is worth doing then, behind tests.
+  // eslint-disable-next-line complexity -- indexer stream loop; see the note above before restructuring
   return (async function () {
     logger.info({ message: `Acquiring lock for chain ID ${chainId}` });
     const lockTimer = logger.startTimer();

--- a/src/starknet.ts
+++ b/src/starknet.ts
@@ -2,6 +2,7 @@ import { Metadata, createClient } from "@apibara/protocol";
 import { Block as StarknetBlock, StarknetStream } from "@apibara/starknet";
 import type { EventKey } from "./_shared/eventKey";
 import { logger } from "./_shared/logger";
+import { parseCommonBlockHeader } from "./_shared/parseBlockHeader";
 import { loadHexAddresses } from "./_shared/loadHexAddresses";
 import { requireStarknetApibaraUrl } from "./_shared/streamEndpoints";
 import { runIndexer, type ParsedRuntimeBlock } from "./runtime";
@@ -19,23 +20,13 @@ export function parseStarknetBlockHeader(
   }
 
   const { header } = starknetBlock;
-  if (
-    typeof header.blockNumber !== "bigint" ||
-    !(header.timestamp instanceof Date)
-  ) {
-    return null;
-  }
+  const common = parseCommonBlockHeader(header);
+  if (!common) return null;
 
-  const blockNumber = Number(header.blockNumber);
-  const timestamp = header.timestamp.getTime();
-  if (!Number.isSafeInteger(blockNumber) || !Number.isFinite(timestamp)) {
-    return null;
-  }
-
-  let hash: bigint;
+  // A malformed L2 gas price is treated the same as a malformed hash: the block
+  // is unusable rather than indexed with a missing fee.
   let baseFeePerGas: bigint | null = null;
   try {
-    hash = BigInt(header.blockHash ?? "0x0");
     if (header.l2GasPrice?.priceInFri) {
       baseFeePerGas = BigInt(header.l2GasPrice.priceInFri);
     }
@@ -45,12 +36,7 @@ export function parseStarknetBlockHeader(
 
   return {
     block: starknetBlock as StarknetBlock,
-    header: {
-      number: blockNumber,
-      hash,
-      timestamp,
-      baseFeePerGas,
-    },
+    header: { ...common, baseFeePerGas },
   };
 }
 

--- a/src/starknet/eventProcessors.ts
+++ b/src/starknet/eventProcessors.ts
@@ -125,13 +125,32 @@ export function createEventProcessors({
   limitOrdersAddress,
   splineLiquidityProviderAddress,
 }: StarknetEventProcessorConfig): readonly StarknetEventProcessor<any>[] {
-  let pendingPositionFeesCollected:
-    | {
-        blockNumber: number;
-        transactionIndex: number;
-        event: PositionFeesCollectedEvent;
-      }
-    | undefined;
+  type PendingPositionFeesCollected = {
+    blockNumber: number;
+    transactionIndex: number;
+    event: PositionFeesCollectedEvent;
+  };
+
+  let pendingPositionFeesCollected: PendingPositionFeesCollected | undefined;
+
+  // A SavedBalance only records withheld protocol fees when it is the one the
+  // Positions contract emitted in the same transaction as the preceding
+  // PositionFeesCollected, under the protocol-fee salt. Anything else is an
+  // unrelated saved balance that happens to be passing through.
+  function isProtocolFeeWithholding(
+    pending: PendingPositionFeesCollected | undefined,
+    parsed: SavedBalanceEvent,
+    key: { blockNumber: number; transactionIndex: number },
+  ): pending is PendingPositionFeesCollected {
+    return (
+      !!pending &&
+      pending.blockNumber === key.blockNumber &&
+      pending.transactionIndex === key.transactionIndex &&
+      parsed.key.owner === BigInt(positionsAddress) &&
+      parsed.key.owner === pending.event.position_key.owner &&
+      parsed.key.salt === PROTOCOL_FEES_SALT
+    );
+  }
 
   return [
     <StarknetEventProcessor<TransferEvent>>{
@@ -334,16 +353,7 @@ export function createEventProcessors({
       parser: parseSavedBalanceEvent,
       async handle(dao, { parsed, key }): Promise<void> {
         const pending = pendingPositionFeesCollected;
-        if (
-          !pending ||
-          pending.blockNumber !== key.blockNumber ||
-          pending.transactionIndex !== key.transactionIndex ||
-          parsed.key.owner !== BigInt(positionsAddress) ||
-          parsed.key.owner !== pending.event.position_key.owner ||
-          parsed.key.salt !== PROTOCOL_FEES_SALT
-        ) {
-          return;
-        }
+        if (!isProtocolFeeWithholding(pending, parsed, key)) return;
 
         const isToken0 = parsed.key.token === pending.event.pool_key.token0;
         const isToken1 = parsed.key.token === pending.event.pool_key.token1;

--- a/tests/migrations/incentives-compute-reward-period.test.ts
+++ b/tests/migrations/incentives-compute-reward-period.test.ts
@@ -437,6 +437,19 @@ type PositionSeed = {
   blockNumber?: number;
 };
 
+// The seed defaults live here rather than inline at the call site so
+// seedPositions is about the insert and this is about the fixture shape.
+function withPositionDefaults(position: PositionSeed) {
+  return {
+    blockNumber: position.blockNumber ?? 99,
+    lowerBound: position.lowerBound ?? -120,
+    upperBound: position.upperBound ?? 120,
+    liquidityDelta: position.liquidityDelta ?? 100000,
+    delta0: position.delta0 ?? 0,
+    delta1: position.delta1 ?? 0,
+  };
+}
+
 async function seedPositions(
   client: PGlite,
   poolKeyId: number,
@@ -451,7 +464,14 @@ async function seedPositions(
   } = options;
 
   for (const [index, position] of positions.entries()) {
-    const blockNumber = position.blockNumber ?? 99;
+    const {
+      blockNumber,
+      lowerBound,
+      upperBound,
+      liquidityDelta,
+      delta0,
+      delta1,
+    } = withPositionDefaults(position);
     const eventIndex = eventIndexStart + index;
     const transactionHash = 7001 + eventIndex;
     await client.query(
@@ -493,11 +513,11 @@ async function seedPositions(
         poolKeyId,
         position.locker,
         position.salt,
-        position.lowerBound ?? -120,
-        position.upperBound ?? 120,
-        position.liquidityDelta ?? 100000,
-        position.delta0 ?? 0,
-        position.delta1 ?? 0,
+        lowerBound,
+        upperBound,
+        liquidityDelta,
+        delta0,
+        delta1,
       ]
     );
   }


### PR DESCRIPTION
ESLint's complexity rule at 10, run in CI before the tests.

Fixed:
- parseEvmBlockHeader (12) and parseStarknetBlockHeader (13) validated height,
  hash and timestamp identically in two places. That validation is now
  parseCommonBlockHeader in _shared, so the two entrypoints cannot drift on
  what counts as a usable header.
- discoverChainlinkFeeds (28) had a sixteen-clause admissibility conjunction
  inline. It is now a table of named rules, so a feed that fails to appear can
  be traced to the rule that rejected it, plus feedRank and
  groupTokensBySymbol.
- createEvmEntrypoint (16): the four independent "did we get this contract
  set?" log lines moved to logIndexedContracts.
- validatePriceSyncJobs (11): per-job field checks moved to
  assertJobIsWellFormed, leaving the function about the cross-job invariant.
- The SavedBalance handler (11): its six-clause guard is now the named
  predicate isProtocolFeeWithholding, which also narrows the pending type.
- seedPositions (11) in the migration test: fixture defaults moved to
  withPositionDefaults.

Not fixed: the stream loop in runtime.ts (24) is exempted with a reason. Three
of its switch arms reassign currentCursor and the retry loop reads it again
after a failure, so extracting the arms means threading that reassignment
through every return path -- with no test coverage over the loop to catch a
mistake, and reprocessed or skipped blocks as the failure mode.

All 223 tests pass.
