### PR TITLE
Raise the quoter price-impact cap to 0.5 on Robinhood chain

### DIFF
--- a/src/price-sync/fetchers/ekuboQuoter.ts
+++ b/src/price-sync/fetchers/ekuboQuoter.ts
@@ -19,6 +19,9 @@ interface QuoterPriceFetcherOptions extends PriceSyncJobOptions {
   address: `0x${string}`;
   decimals: number;
   quoteAmount: bigint;
+  // The quoter folds pool fees into price_impact, so a chain whose pools carry
+  // an unusually high fee needs a looser cap than the default to report at all.
+  maxImpact?: number;
 }
 
 let ekuboQuoterFetchLimiter: Bottleneck | undefined;
@@ -144,6 +147,7 @@ export function quoterPriceFetcher({
   address,
   decimals,
   quoteAmount,
+  maxImpact,
 }: QuoterPriceFetcherOptions): PriceSyncJob {
   const quoterBaseUrl = (
     process.env.EKUBO_QUOTER_URL ?? "https://prod-api-quoter.ekubo.org"
@@ -171,6 +175,7 @@ export function quoterPriceFetcher({
               address,
               decimals,
               quoteAmount,
+              maxImpact,
               baseUrl: `${quoterBaseUrl}/${chainId}/`,
             });
 

--- a/src/price-sync/jobs.ts
+++ b/src/price-sync/jobs.ts
@@ -123,6 +123,10 @@ export function createPriceSyncJobs({
       address: "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168",
       decimals: 6,
       quoteAmount: 1000n,
+      // Pools here carry fees as high as 22%, and the quoter counts the fee
+      // toward price_impact, so the default 0.2 cap rejects otherwise good
+      // quotes -- STONX among them.
+      maxImpact: 0.5,
     }),
     sushiswapPriceFetcher({
       chainId: 4663n,


### PR DESCRIPTION
Pools on chain 4663 carry fees as high as 22%, and the Ekubo quoter folds the pool fee into `price_impact`. A perfectly good quote therefore reports impact around 0.33, which the default 0.2 cap in `fetchEkuboQuoterPrice` rejects.

Observed in production: STONX has had no valid price since 14:01 UTC on 2026-08-30, which is why earnings and implied APR render N/A. The indexer logs the rejection every minute:

```
Skipping result for STONX because price impact 0.32701163591664534 was g.t.e. max 0.2
```

`maxImpact` already existed as a parameter on `fetchEkuboQuoterPrice` but was not reachable from the job definitions. This plumbs it through `quoterPriceFetcher` and sets it to 0.5 for Robinhood mainnet only; every other chain keeps the 0.2 default.

Note the derived price is computed as `basePrice * (1 + priceImpact)`, so admitting a fee-dominated quote also adds that fee back into the reported price. Worth a look if the resulting STONX mark reads high.

Tests: 37 pass / 0 fail in `src/price-sync`; `eslint .` clean.

Not included here: the separate Chainlink weekend-staleness bug that nulls ~40 RHC stock tokens (diagnosed separately; needs a `maxAgeSeconds` floor plus a retention change).

https://claude.ai/code/session_01JydAsawJzNq2QaRD2Jf9w9