### PR TITLE
Keep Chainlink equity prices alive while markets are closed

### DIFF
--- a/migrations/00117_retain_valid_token_prices/index.sql
+++ b/migrations/00117_retain_valid_token_prices/index.sql
@@ -1,0 +1,43 @@
+-- Retention deleted any observation whose round timestamp was over a day old.
+-- That timestamp is the observation's own age, not the age of the write, so a
+-- Chainlink equity feed -- which republishes nothing while its market is shut
+-- -- had Friday's closing round pruned on Saturday evening. The in-memory
+-- round dedupe then refused to re-emit an unchanged round, so the token stayed
+-- unpriced until the market reopened. Retention is history cleanup and has no
+-- business dropping the observation a token is currently priced from, so keep
+-- anything still inside its validity window and let it age out once superseded.
+
+DO
+$$
+    DECLARE
+        has_pg_cron BOOLEAN;
+        job_id      INT;
+    BEGIN
+        SELECT EXISTS (
+            SELECT 1
+            FROM pg_extension
+            WHERE extname = 'pg_cron'
+        )
+        INTO has_pg_cron;
+
+        IF NOT has_pg_cron THEN
+            RAISE NOTICE 'pg_cron not installed; skipping erc20 token prices cleanup job.';
+            RETURN;
+        END IF;
+
+        SELECT jobid
+        INTO job_id
+        FROM cron.job
+        WHERE jobname = 'prune_erc20_tokens_usd_prices';
+
+        IF job_id IS NOT NULL THEN
+            PERFORM cron.unschedule(job_id);
+        END IF;
+
+        PERFORM cron.schedule(
+            'prune_erc20_tokens_usd_prices',
+            '0 * * * *',
+            'DELETE FROM erc20_tokens_usd_prices WHERE "timestamp" < NOW() - INTERVAL ''1 day'' AND (valid_until IS NULL OR valid_until < NOW());'
+        );
+    END;
+$$;

--- a/src/price-sync/fetchers/chainlinkFeeds.test.ts
+++ b/src/price-sync/fetchers/chainlinkFeeds.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  chainlinkFeedMaxAgeSeconds,
   discoverChainlinkFeeds,
   fetchChainlinkFeedCatalog,
   fetchChainlinkTokenPricesWithMulticall,
@@ -65,6 +66,30 @@ describe("parseChainlinkPriceConfig", () => {
           "https://reference-data-directory.vercel.app/feeds-ethereum-mainnet-base-1.json",
       },
     });
+  });
+});
+
+describe("chainlinkFeedMaxAgeSeconds", () => {
+  test("doubles a sub-daily heartbeat", () => {
+    expect(chainlinkFeedMaxAgeSeconds(1200)).toBe(2400);
+    expect(chainlinkFeedMaxAgeSeconds(3600)).toBe(7200);
+  });
+
+  test("carries a daily-heartbeat feed across a holiday weekend", () => {
+    // An equity feed publishes only while its market is open. Friday's close
+    // to Tuesday's open is about 89 hours, which doubling the heartbeat (48h)
+    // does not survive.
+    const holidayWeekendSeconds = 89 * 60 * 60;
+    expect(chainlinkFeedMaxAgeSeconds(86400)).toBeGreaterThan(
+      holidayWeekendSeconds,
+    );
+    expect(chainlinkFeedMaxAgeSeconds(86400)).toBe(5 * 24 * 60 * 60);
+  });
+
+  test("keeps doubling when that already exceeds the closure floor", () => {
+    expect(chainlinkFeedMaxAgeSeconds(4 * 24 * 60 * 60)).toBe(
+      8 * 24 * 60 * 60,
+    );
   });
 });
 

--- a/src/price-sync/fetchers/chainlinkFeeds.ts
+++ b/src/price-sync/fetchers/chainlinkFeeds.ts
@@ -16,6 +16,25 @@ const DEFAULT_MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11";
 // chain's batch rather than just skipping the bad feed.
 const MAX_CHAINLINK_HEARTBEAT_SECONDS = 7 * 24 * 60 * 60;
 
+// A daily heartbeat means an equity feed: it publishes only while its market is
+// open, so the longest gap between rounds is a market closure, not the
+// heartbeat. Doubling the heartbeat gives 48h, which a plain weekend already
+// outlives -- Friday's close is unreadable by Sunday evening while the market
+// does not reopen until Monday. Five days clears a holiday weekend (Friday
+// close to Tuesday open is about 89h) and still catches a genuinely dead feed
+// within the week. Sub-daily feeds are continuous, so they keep the tight
+// window that doubling gives them.
+const CONTINUOUS_FEED_MAX_HEARTBEAT_SECONDS = 24 * 60 * 60;
+const MARKET_CLOSURE_MAX_AGE_SECONDS = 5 * 24 * 60 * 60;
+
+// Exported for the tests that pin the weekend behaviour.
+export function chainlinkFeedMaxAgeSeconds(heartbeatSeconds: number): number {
+  const doubled = heartbeatSeconds * 2;
+  return heartbeatSeconds >= CONTINUOUS_FEED_MAX_HEARTBEAT_SECONDS
+    ? Math.max(doubled, MARKET_CLOSURE_MAX_AGE_SECONDS)
+    : doubled;
+}
+
 const CHAINLINK_AGGREGATOR_ABI = [
   {
     type: "function",
@@ -337,7 +356,7 @@ export function discoverChainlinkFeeds(
     const feed: ChainlinkFeedConfig = {
       tokenAddress: matchingTokens[0].address,
       feedAddress: getAddress(value.proxyAddress),
-      maxAgeSeconds: value.heartbeat * 2,
+      maxAgeSeconds: chainlinkFeedMaxAgeSeconds(value.heartbeat),
     };
     const feeds = catalogFeedsBySymbol.get(symbol) ?? [];
     feeds.push({ feed, rank: feedRank(value) });


### PR DESCRIPTION
Fixes the weekend disappearance of Robinhood-chain stock prices (~40 of ~60 tokens reporting `usd_price: null`).

## Cause

Chainlink equity feeds publish only while their market is open, so the longest gap between rounds is a market closure, not the heartbeat. Two individually reasonable rules combined badly:

1. `maxAgeSeconds = heartbeat * 2` gives a daily-heartbeat feed a 48h window. Friday's closing round is unreadable by Sunday ~20:00 UTC, but the market does not reopen until Monday 13:30.
2. Hourly retention deleted rows where `"timestamp" < NOW() - INTERVAL '1 day'`. That column holds the round's own `updatedAt`, not the write time, so Friday's close was pruned Saturday evening — and `shouldReportChainlinkRound` refuses to re-emit an unchanged round, so nothing replaced it.

Production evidence: source `cl1` on chain 4663 had only ever written 3 distinct tokens (ETH, USDG, USDE — all crypto feeds), while `4663:cl1` logged `0/0 updates inserted` every 60s. Chains 1/8453/42161 held 345/856/3259 `cl1` rows.

## Changes

- **`chainlinkFeedMaxAgeSeconds`** floors the staleness window at 5 days for feeds with a heartbeat >= 24h. Clears a holiday weekend (Friday close → Tuesday open ≈ 89h; Labor Day is next Monday) while still catching a dead feed within the week. Sub-daily feeds are continuous and keep the tight doubled window. Well inside the existing `MAX_PRICE_VALIDITY_MS` of 30 days. This one change fixes `valid_until`, the fetch-side staleness throw, and the weekend-restart hole.
- **Migration 00117** stops retention deleting an observation still inside its validity window. Preferred over exempting the newest row per key: the history table has had no PK since 00073 and the insert has no `ON CONFLICT`, so restart re-reports create duplicate rows a max-per-key subquery would have to tie-break. `EXPLAIN` against production confirms it still uses `erc20_tokens_usd_prices_history_covering_idx`.

The round dedupe is deliberately untouched — with the row persisted and valid, there is nothing to re-emit.

## Rollout

Deploying restarts the price worker, and its first poll re-reports every feed, so the missing prices repopulate on rollout rather than waiting for Monday's open.

## Tradeoff

This shows Friday's closing price through the weekend (up to ~65h old) instead of showing nothing. Worth surfacing the observation timestamp downstream so consumers can see the age.

Tests: 40 pass / 0 fail in `src/price-sync`; `eslint .` clean.

Separate from #158, which raises the quoter price-impact cap for STONX.

https://claude.ai/code/session_01JydAsawJzNq2QaRD2Jf9w9