### PR TITLE
Add covering index for pair OHLC swap scans

### DIFF
--- a/migrations/00117_swaps_ohlc_covering_index/index.sql
+++ b/migrations/00117_swaps_ohlc_covering_index/index.sql
@@ -1,0 +1,30 @@
+-- The pair OHLC route (getPairOhlcHistory) locates swaps by
+-- (pool_key_id, block_time) but projects delta0, delta1 and event_id, none of
+-- which the existing index carries. Every qualifying row therefore costs a
+-- heap fetch, and a single pool's swaps are scattered across the whole 11 GB
+-- table because inserts interleave all chains and pools.
+--
+-- Measured on a 15 day window for one pair (2641 rows): the current index
+-- touches 1963 buffers of which 1789 are random reads, 164 ms cold. The same
+-- rows read index-only touch 32 buffers, 2.7 ms. The INCLUDE payload averages
+-- 28.4 bytes/row.
+--
+-- Same key columns as the index it replaces, so every existing consumer is
+-- served identically; a btree scans backward at no cost, which covers the
+-- pool_market_depth view's ORDER BY block_time DESC (00056). That view selects
+-- only event_id and block_time, so it gains an index-only scan too.
+CREATE INDEX IF NOT EXISTS swaps_pool_key_id_block_time_ohlc_idx
+    ON swaps (pool_key_id, block_time)
+    INCLUDE (event_id, delta0, delta1);
+
+DROP INDEX IF EXISTS swaps_pool_key_id_block_time_idx;
+
+-- Index-only scans skip the heap only for pages marked all-visible. swaps is
+-- append-only, but the server defaults (insert_scale_factor 0.2) mean an
+-- insert-vacuum only every ~9M rows at current size, so the newest pages --
+-- exactly the ones every chart request reads -- would never be all-visible and
+-- would keep doing heap fetches.
+ALTER TABLE swaps SET (
+    autovacuum_vacuum_insert_scale_factor = 0.0,
+    autovacuum_vacuum_insert_threshold = 20000
+);


### PR DESCRIPTION
## Problem

`GET /price/:chainId/:base/:quote/ohlc` is slow and gets worse with range. Cache-busted against `prod-api.ekubo.org`, STONX/USDG on chain 4663:

| interval | range | candles | TTFB |
|---|---|---|---|
| 61 | 1 h | 1 | 1.06 s |
| 3611 | 60 h | 45 | 2.21 s |
| 21601 | 360 h | 60 | **8.85 s** |

The SQL itself is fine. `getPairOhlcHistory` locates rows via `swaps (pool_key_id, block_time DESC)` but projects `delta0`, `delta1` and `event_id`, none of which that index carries — so every qualifying row costs a heap fetch, and one pool's swaps are scattered across the whole 11 GB table because inserts interleave all chains and pools.

`EXPLAIN (ANALYZE, BUFFERS)`, 15-day window, 2 641 rows:

```
Index Scan using swaps_pool_key_id_block_time_idx
  Buffers: shared hit=174 read=1789      -- 0.68 random pages per row
Execution Time: 165.971 ms   (cold)
```

## Fix

Covering index → the scan becomes index-only. Same rows, same aggregate output:

```
Index Only Scan using <covering idx>
  Heap Fetches: 0   Buffers: shared hit=6 read=26
Execution Time: 2.729 ms
```

**1 963 buffers → 32.** Buffer counts are cache-independent, so this is a fair comparison. Verified by building the index on a replica, running the full OHLC aggregate, then dropping it.

Sizing: `INCLUDE` payload averages 28.4 bytes/row (sampled) → ~2.2 GB. It *replaces* the existing 961 MB index, so net ~+1.2 GB against an 11 GB heap.

## Why chain 4663 hurts most

Same request on mainnet ETH/USDC — a busier pair — is far faster: 0.16 s at `interval=61`, 1.01 s at `21601`. More data but 9x faster is only consistent with buffer-cache residency: mainnet pages stay hot, the Robinhood-chain pair is cold on nearly every request so each heap fetch is real I/O. The 61x smaller page footprint also makes the working set small enough to stay resident.

## Autovacuum change

`swaps` is append-only with no per-table settings; server defaults (`insert_scale_factor 0.2`) mean an insert-vacuum only every ~9 M rows at current size. The newest pages — exactly what every chart reads — would never be all-visible and would keep hitting the heap, so the index would look good on history and disappointing on the live tail.

## ⚠️ Rollout — needs a decision

`postgres-shift` runs **all** migrations inside a single `sql.begin` transaction, so `CREATE INDEX CONCURRENTLY` is not possible through the runner. As written this is a plain `CREATE INDEX` (matching the convention in `00112_token_price_history_covering_index`), which takes a `SHARE` lock and **blocks inserts to `swaps` for the duration of a ~2.2 GB build on 45 M rows**.

Two options — I'd suggest the second:
1. Merge as-is and accept a multi-minute indexer write stall.
2. Run `CREATE INDEX CONCURRENTLY swaps_pool_key_id_block_time_ohlc_idx ...` against prod out of band first; the migration's `IF NOT EXISTS` then makes it a no-op and keeps other environments consistent.

## Related

Pairs with EkuboProtocol/api — that PR removes a redundant `swaps.chain_id` predicate which would otherwise defeat this index-only scan. **Merge this one first.**

## Caveats

Measured against a replica ~4 days stale (latest `block_time` 2026-08-26). Schema and data shape match and buffer counts are hardware-independent, so the conclusion carries, but absolute timings on prod will differ. `pg_stat_statements` is not loaded there.

There is also a residual ~1 s floor on chain 4663 even for a 1-candle request that this does **not** explain or fix — ~10 rows of heap fetches cannot account for a full second. This PR eliminates the range-scaling term. Isolating the floor needs prod-side instrumentation (`pg_stat_statements`, or a `Server-Timing` header from the handler).

https://claude.ai/code/session_01PTETzoQpnhpyzt57axcF1N