### PR TITLE
Retry null block results on the same RPC before failing over

### DIFF
--- a/src/_shared/nullBlockRetry.test.ts
+++ b/src/_shared/nullBlockRetry.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import type { Transport } from "viem";
+import { withNullBlockRetry } from "./nullBlockRetry";
+
+function transportReturning(
+  results: unknown[],
+): { transport: Transport; calls: { method: string }[] } {
+  const calls: { method: string }[] = [];
+  let index = 0;
+
+  const transport = ((): unknown => ({
+    config: {},
+    value: {},
+    request: async (args: { method: string }) => {
+      calls.push({ method: args.method });
+      return index < results.length ? results[index++] : results.at(-1);
+    },
+  })) as Transport;
+
+  return { transport, calls };
+}
+
+const options = {} as never;
+const getBlock = { method: "eth_getBlockByNumber", params: ["0x1", false] };
+
+describe("withNullBlockRetry", () => {
+  it("retries a null block on the same transport and returns the block", async () => {
+    const { transport, calls } = transportReturning([null, null, { number: "0x1" }]);
+
+    const wrapped = withNullBlockRetry(transport, { retryDelayMs: 0 })(options);
+
+    expect(await wrapped.request(getBlock)).toEqual({ number: "0x1" });
+    expect(calls).toHaveLength(3);
+  });
+
+  it("throws after exhausting retries so a fallback transport is tried", async () => {
+    const { transport, calls } = transportReturning([null]);
+
+    const wrapped = withNullBlockRetry(transport, {
+      retryCount: 2,
+      retryDelayMs: 0,
+      url: "https://a.rpc",
+    })(options);
+
+    await expect(wrapped.request(getBlock)).rejects.toThrow(
+      /returned a null block after 2 retries on https:\/\/a\.rpc/,
+    );
+    expect(calls).toHaveLength(3);
+  });
+
+  it("passes other methods through without retrying", async () => {
+    const { transport, calls } = transportReturning([null]);
+
+    const wrapped = withNullBlockRetry(transport, { retryDelayMs: 0 })(options);
+
+    expect(await wrapped.request({ method: "eth_blockNumber" })).toBeNull();
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/src/_shared/nullBlockRetry.ts
+++ b/src/_shared/nullBlockRetry.ts
@@ -1,0 +1,56 @@
+import type { Transport } from "viem";
+
+// Block lookups can return a null result when an RPC node is briefly behind the
+// head it just advertised. That is a successful JSON-RPC response, so neither
+// viem's transport retries nor the stream's own retry helper cover it: the
+// caller simply sees a null block and throws, which exits the process.
+//
+// Retrying the same transport gives a lagging node time to catch up, which
+// keeps these lookups on the primary RPC instead of failing over to a more
+// expensive one on every transient miss.
+const RETRIED_METHODS = new Set(["eth_getBlockByHash", "eth_getBlockByNumber"]);
+
+const DEFAULT_RETRY_COUNT = 5;
+const DEFAULT_RETRY_DELAY_MS = 600;
+
+export function withNullBlockRetry(
+  transport: Transport,
+  {
+    retryCount = DEFAULT_RETRY_COUNT,
+    retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+    url,
+  }: { retryCount?: number; retryDelayMs?: number; url?: string } = {},
+): Transport {
+  return ((options) => {
+    const inner = transport(options);
+
+    return {
+      ...inner,
+      async request(args: { method: string; params?: unknown }) {
+        if (!RETRIED_METHODS.has(args.method)) {
+          return inner.request(args as never);
+        }
+
+        for (let attempt = 0; ; attempt++) {
+          const result = await inner.request(args as never);
+
+          if (result !== null) {
+            return result;
+          }
+
+          if (attempt >= retryCount) {
+            // Throw rather than returning null so that a fallback transport
+            // treats this as a failure and tries the next RPC.
+            throw new Error(
+              `${args.method} returned a null block after ${retryCount} retries${
+                url ? ` on ${url}` : ""
+              }: ${JSON.stringify(args.params)}`,
+            );
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+        }
+      },
+    };
+  }) as Transport;
+}

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -10,6 +10,7 @@ import {
   loadOptionalHexAddress,
   type HexAddress,
 } from "./_shared/loadHexAddresses";
+import { withNullBlockRetry } from "./_shared/nullBlockRetry";
 import { parseEvmRpcUrls } from "./_shared/streamEndpoints";
 import { createLogProcessorsV2 } from "./evm/logProcessorsV2";
 import { createLogProcessorsV3 } from "./evm/logProcessorsV3";
@@ -156,7 +157,9 @@ export async function createEvmEntrypoint(
   ];
 
   const createTransportFromUrl = (url: string) =>
-    rateLimitedHttp(url, { rps: 100, retryCount: 0 });
+    withNullBlockRetry(rateLimitedHttp(url, { rps: 100, retryCount: 0 }), {
+      url,
+    });
 
   const evmRpcUrls = parseEvmRpcUrls(process.env.EVM_RPC_URL);
 


### PR DESCRIPTION
Block lookups return a null result when an RPC node is briefly behind the head it just advertised. That is a successful JSON-RPC response, so neither viem's transport retries nor the stream's own retry helper cover it: the caller sees a null block and throws, which exits the process.

On rhc-mainnet the two configured RPCs disagreed about the head by ~25 blocks, so a failover mid-sequence produced a head the other node did not have yet. That crashed the indexer 77 times in 38 minutes, and one restart found the stored cursor non-canonical and rewound to the last finalized cursor, deleting 8547 blocks (~15 minutes) before re-indexing them.

Wrap each transport so a null block on eth_getBlockByHash or eth_getBlockByNumber is retried on the same node, which lets a lagging primary catch up instead of failing over to a more expensive RPC on every transient miss. Throw once retries are exhausted so a fallback transport still treats it as a failure and tries the next node.

Claude-Session: https://claude.ai/code/session_012etaKEn7GT8yoTwQRUc42T