### PR TITLE
Reduce write amplification on hot tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,13 @@ week. Nothing in the API filters on `valid_until`. Sets
 `pool_states`, `pool_tvl` and `erc20_tokens_latest_price`.
 
 **Cron change.** `refresh_computed_rewards_by_position` moves from `* */6 * * *`
-to `0 */6 * * *`. The old expression put `*/6` in the hour field and left the
+to `5 * * * *`. The old expression put `*/6` in the hour field and left the
 minute field wide, so the job fired every minute during hours 0, 6, 12 and 18 —
-240 runs/day totalling 4h52m of database time instead of 4 runs totalling ~7m.
-If the matview is meant to track the hourly `compute_incentive_rewards` job
-rather than run six-hourly, change the schedule instead of accepting this one.
+240 runs/day totalling 4h52m of database time. Reward periods land on hourly
+boundaries, so the new cadence is hourly rather than the six-hourly one the
+broken expression was reaching for; minute 5 leaves four minutes after
+`compute_incentive_rewards` (minute 1) for the boundary blocks to be indexed.
+24 runs/day of ~100 s is ~40m/day.
 
 **Manual intervention required — the migration alone does not recover the
 CPU.** `fillfactor` only applies to pages written after a rewrite, and lowering

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ transaction, so the rewrite cannot live in the migration. After migrating, run
 against all networks sharing the database:
 
 ```sql
--- ~5,000 live rows each; currently 22 MB, 15 MB and 75 MB.
+-- pool_states/pool_tvl hold ~5,000 live rows in 22 MB and 15 MB.
+-- erc20_tokens_latest_price holds ~7,700 live rows in 361 MB heap
+-- + 280 MB indexes as of 2026-09-02, so it is the one that matters.
 VACUUM (FULL, ANALYZE) pool_states;
 VACUUM (FULL, ANALYZE) pool_tvl;
 VACUUM (FULL, ANALYZE) erc20_tokens_latest_price;

--- a/README.md
+++ b/README.md
@@ -191,33 +191,40 @@ broken expression was reaching for; minute 5 leaves four minutes after
 `compute_incentive_rewards` (minute 1) for the boundary blocks to be indexed.
 24 runs/day of ~100 s is ~40m/day.
 
-**Manual intervention required — the migration alone does not recover the
-CPU.** `fillfactor` only applies to pages written after a rewrite, and lowering
-the scale factor lets autovacuum reclaim space in place but never shrinks an
-already-bloated heap. `scripts/migrate.ts` runs each migration inside a
-transaction, so the rewrite cannot live in the migration. After migrating, run
-against all networks sharing the database:
+**Manual intervention required, BEFORE this migration is deployed.** The
+migration drops `erc20_tokens_latest_price_valid_until_idx`, and
+`refresh_expired_erc20_token_latest_prices` (~1 call/sec) then has to find
+expired rows by sequential scan. That is only cheap once the heap matches its
+live rows. Measured on 2026-09-02 against the bloated 46,147-page heap:
 
-```sql
--- pool_states/pool_tvl hold ~5,000 live rows in 22 MB and 15 MB.
--- erc20_tokens_latest_price holds ~7,700 live rows in 361 MB heap
--- + 280 MB indexes as of 2026-09-02, so it is the one that matters.
-VACUUM (FULL, ANALYZE) pool_states;
-VACUUM (FULL, ANALYZE) pool_tvl;
-VACUUM (FULL, ANALYZE) erc20_tokens_latest_price;
-```
+| | buffers | time |
+|---|---|---|
+| index scan (today) | 50 | 0.14 ms |
+| seq scan on bloated heap | 46,147 (45,155 read from disk) | 103.6 ms |
+| seq scan after repack (~250 pages) | ~250 | sub-ms |
 
-Each takes seconds at these sizes but holds `ACCESS EXCLUSIVE`, which stalls the
-indexer and price-sync for the duration. `pg_repack` 1.5.2 is available on the
-managed instance and does the same rewrite without the exclusive lock if a stall
-is unacceptable:
+**Repack first, then deploy.** Deploying the migration against an unrepacked
+table makes that once-a-second query 750x more expensive.
 
 ```sh
-pg_repack -d defaultdb -t pool_states -t pool_tvl -t erc20_tokens_latest_price
+# ~7,700 live rows in a 361 MB heap + 280 MB of indexes.
+pg_repack -d defaultdb -t erc20_tokens_latest_price -t pool_states -t pool_tvl
 ```
 
+`pg_repack` 1.5.2 is available on the managed instance and rewrites without an
+exclusive lock. `VACUUM (FULL, ANALYZE)` on the same three tables is equivalent
+and takes seconds, but holds `ACCESS EXCLUSIVE` and will stall the indexer and
+price-sync for the duration.
+
+Note also that `fillfactor` only applies to pages written after a rewrite, and
+that lowering `autovacuum_vacuum_scale_factor` lets autovacuum reclaim space in
+place but never shrinks an already-bloated heap. `scripts/migrate.ts` runs each
+migration inside a transaction, so the rewrite cannot live in the migration —
+hence the manual step.
+
 Downstream consumers are unaffected: no column, view or function signature
-changes. Deploy order does not matter.
+changes, so the order in which the indexer components roll is irrelevant — the
+only ordering that matters is repack before migrate.
 
 ### 2026-08-09: Freshness-aware prioritized token prices
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,52 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
+### 2026-09-02: Reduce write amplification on hot tables
+
+Three CPU fixes measured from `pg_stat_statements` on `ekubo-db-nyc1` over
+2026-08-25 to 2026-09-01.
+
+**Schema changes.** Drops `erc20_tokens_latest_price_valid_until_idx` (added in
+00116). Its only consumer is `refresh_expired_erc20_token_latest_prices`, which
+reads ~4,316 of the table's ~7,360 rows per scan and takes `FOR UPDATE`, so it
+was barely filtering while blocking HOT on all 47.9M updates the table takes per
+week. Nothing in the API filters on `valid_until`. Sets
+`autovacuum_vacuum_scale_factor = 0.01` and a lowered `fillfactor` on
+`pool_states`, `pool_tvl` and `erc20_tokens_latest_price`.
+
+**Cron change.** `refresh_computed_rewards_by_position` moves from `* */6 * * *`
+to `0 */6 * * *`. The old expression put `*/6` in the hour field and left the
+minute field wide, so the job fired every minute during hours 0, 6, 12 and 18 —
+240 runs/day totalling 4h52m of database time instead of 4 runs totalling ~7m.
+If the matview is meant to track the hourly `compute_incentive_rewards` job
+rather than run six-hourly, change the schedule instead of accepting this one.
+
+**Manual intervention required — the migration alone does not recover the
+CPU.** `fillfactor` only applies to pages written after a rewrite, and lowering
+the scale factor lets autovacuum reclaim space in place but never shrinks an
+already-bloated heap. `scripts/migrate.ts` runs each migration inside a
+transaction, so the rewrite cannot live in the migration. After migrating, run
+against all networks sharing the database:
+
+```sql
+-- ~5,000 live rows each; currently 22 MB, 15 MB and 75 MB.
+VACUUM (FULL, ANALYZE) pool_states;
+VACUUM (FULL, ANALYZE) pool_tvl;
+VACUUM (FULL, ANALYZE) erc20_tokens_latest_price;
+```
+
+Each takes seconds at these sizes but holds `ACCESS EXCLUSIVE`, which stalls the
+indexer and price-sync for the duration. `pg_repack` 1.5.2 is available on the
+managed instance and does the same rewrite without the exclusive lock if a stall
+is unacceptable:
+
+```sh
+pg_repack -d defaultdb -t pool_states -t pool_tvl -t erc20_tokens_latest_price
+```
+
+Downstream consumers are unaffected: no column, view or function signature
+changes. Deploy order does not matter.
+
 ### 2026-08-09: Freshness-aware prioritized token prices
 
 Per-source `confidence` now lives in `erc20_token_price_sources`, seeded by the migration and never written by the worker, with the quoter ranked highest. `erc20_tokens_usd_prices` gains a nullable `valid_until` that each observation carries (legacy rows are treated as valid for five minutes past their timestamp). The compact `erc20_tokens_latest_price_by_source` cache tracks those expirations, while the physical, primary-keyed `erc20_tokens_latest_price` table stores the fresh maximum-confidence aggregate for fast quoter reads. The price worker reconciles expirations once per second, promoting a lower-confidence source when needed. The `all_pool_states_view` definition remains unchanged. Apply migrations before deploying the updated price-sync worker. Consumers selecting every column from `erc20_tokens_latest_price` must account for its new `confidence` and `valid_until` columns and the synthetic `AVG` source on tied values; consumers of `erc20_tokens_usd_prices` gain a nullable column. No manual backfill is required.

--- a/migrations/00119_reduce_hot_table_write_amplification/index.sql
+++ b/migrations/00119_reduce_hot_table_write_amplification/index.sql
@@ -1,0 +1,115 @@
+-- Three unrelated causes of avoidable CPU on the production database, measured
+-- from pg_stat_statements over 2026-08-25 -> 2026-09-01 (7d10h) on
+-- ekubo-db-nyc1 (gd-4vcpu-16gb, pg 18.6).
+
+-- 1. refresh_computed_rewards_by_position runs 240x/day, not 4x/day.
+--
+-- 00071 set this job's schedule to '* */6 * * *'. The */6 is in the hour field,
+-- so the minute field is left as "every minute" and the job fires 60 times an
+-- hour during hours 0, 6, 12 and 18 -- not once every six hours. Each refresh
+-- of incentives.computed_rewards_by_position_materialized (308 MB) takes ~100 s,
+-- so the runs queue back to back and spill into the following hour. Measured
+-- run counts per hour over 24 h: 51/9, 52/8, 58/2, 42/14 for the four windows.
+--
+-- That is 240 runs/day totalling 4 h 52 m of database time where 4 runs
+-- totalling ~7 m were intended, and it accounts for ~10% of all database time
+-- (the 39,048 s pg_temp_* entry in pg_stat_statements is REFRESH ...
+-- CONCURRENTLY's internal diff, plus 7,180 s more in a second temp scan).
+--
+-- Assumption: six-hourly was the intent, since */6 was placed in the hour
+-- field. The upstream compute_incentive_rewards job runs hourly, so
+-- '5 * * * *' would also be defensible if the matview is meant to track it
+-- closely -- this migration does not assume that.
+DO
+$$
+    DECLARE
+        has_pg_cron BOOLEAN;
+        job_id      INT;
+    BEGIN
+        SELECT EXISTS (SELECT 1
+                       FROM pg_extension
+                       WHERE extname = 'pg_cron')
+        INTO has_pg_cron;
+
+        IF NOT has_pg_cron THEN
+            RAISE NOTICE 'pg_cron not installed; skipping computed rewards refresh reschedule.';
+            RETURN;
+        END IF;
+
+        SELECT jobid
+        INTO job_id
+        FROM cron.job
+        WHERE jobname = 'refresh_computed_rewards_by_position';
+
+        IF job_id IS NOT NULL THEN
+            PERFORM cron.unschedule(job_id);
+        END IF;
+
+        PERFORM cron.schedule(
+                'refresh_computed_rewards_by_position',
+                '0 */6 * * *',
+                'REFRESH MATERIALIZED VIEW CONCURRENTLY incentives.computed_rewards_by_position_materialized'
+                );
+    END;
+$$;
+
+-- 2. pool_states and pool_tvl are 15-20x bloated on ~5,000 real rows.
+--
+--     table         real rows   heap    dead tuples
+--     pool_states       4,969   22 MB   40.8%
+--     pool_tvl         ~4,900   15 MB   56.8%
+--
+-- Both take ~440,000 updates per week. HOT is already working on them (99.3% of
+-- updates are HOT), but with the server default scale factor of 0.2 autovacuum
+-- only triggers after ~20% of the table is dead, and at this write rate the
+-- steady state sits far above that; autovacuum ran 253 and 337 times in the
+-- window and still never brought them down. Neither table had any reloptions.
+--
+-- This matters because both are on the hot path of the all_pool_states_view
+-- poll, which is the single largest consumer of database time at 34.4%
+-- (2,208,760 calls, 62 ms mean, 100% buffer cache hit -- pure CPU). One
+-- EXPLAIN (ANALYZE, BUFFERS) of that query on the largest chain touched 20,272
+-- buffers, of which pool_states accounted for 10,328 and pool_tvl for 4,377.
+--
+-- The pool_tvl term is the bloat-driven one: 4,377 buffers to read 4,718 rows
+-- collapses to a few hundred once the heap is the size its live rows justify.
+-- The pool_states term is mostly not bloat -- 10,328 buffers over 3,256 index
+-- probes is 3.17 buffers per probe, already about the floor for root + leaf +
+-- heap -- so the honest expectation for the poll query is a 25-35% reduction,
+-- not an order of magnitude.
+--
+-- NOTE: fillfactor applies only to pages written after a rewrite, and lowering
+-- the scale factor makes autovacuum reclaim space in place but never returns
+-- existing bloat to a smaller heap. This migration prevents the bloat from
+-- coming back; it does not remove what is already there. See the operator step
+-- in the README breaking changelog.
+ALTER TABLE pool_states
+    SET (autovacuum_vacuum_scale_factor = 0.01, fillfactor = 70);
+
+ALTER TABLE pool_tvl
+    SET (autovacuum_vacuum_scale_factor = 0.01, fillfactor = 70);
+
+-- 3. erc20_tokens_latest_price gets 47.9M updates and zero HOT updates.
+--
+--     47,897,002 updates, 0 HOT, 7,360 live rows vs 749,363 dead (99% dead),
+--     75 MB heap + 63 MB indexes, 10,617 autovacuum runs in the window.
+--
+-- A HOT update requires that no indexed column change. 00116 added an index on
+-- valid_until, and recompute_erc20_token_latest_price writes valid_until on
+-- every price refresh (it derives from the observation timestamp, so it moves
+-- essentially every time). Every update therefore writes a new heap tuple plus
+-- entries in both indexes, and autovacuum runs almost continuously without
+-- keeping up -- that autovacuum load is itself a standing CPU cost.
+--
+-- The index earns very little. Its only consumer is
+-- refresh_expired_erc20_token_latest_prices, which scans
+-- "WHERE valid_until <= p_as_of FOR UPDATE SKIP LOCKED" over a 7,360-row
+-- table; production shows 1,272,763 scans reading 5,493,381,022 tuples, i.e.
+-- ~4,316 tuples per scan. It is selecting most of the table on each call, so
+-- it is barely filtering, and FOR UPDATE forces the heap access anyway. On a
+-- table this small a sequential scan is the better plan. Nothing in the API
+-- filters on valid_until.
+DROP INDEX IF EXISTS erc20_tokens_latest_price_valid_until_idx;
+
+ALTER TABLE erc20_tokens_latest_price
+    SET (autovacuum_vacuum_scale_factor = 0.01, fillfactor = 80);

--- a/migrations/00119_reduce_hot_table_write_amplification/index.sql
+++ b/migrations/00119_reduce_hot_table_write_amplification/index.sql
@@ -96,6 +96,14 @@ ALTER TABLE pool_tvl
 --     47,897,002 updates, 0 HOT, 7,360 live rows vs 749,363 dead (99% dead),
 --     75 MB heap + 63 MB indexes, 10,617 autovacuum runs in the window.
 --
+-- Caveat on those dead-tuple figures: the measurement window overlapped an
+-- incident on 2026-09-01 in which a duplicate chain-46630 worker blocked on
+-- pg_advisory_lock inside an open transaction for 22 h, pinning the vacuum
+-- horizon 486,642 XIDs back. The dead-tuple ratio is therefore inflated and is
+-- not the steady state. The cumulative counters (47.9M updates, 0 HOT) and the
+-- HOT-blocking mechanism below are unaffected -- those are what motivate this
+-- change.
+--
 -- A HOT update requires that no indexed column change. 00116 added an index on
 -- valid_until, and recompute_erc20_token_latest_price writes valid_until on
 -- every price refresh (it derives from the observation timestamp, so it moves

--- a/migrations/00119_reduce_hot_table_write_amplification/index.sql
+++ b/migrations/00119_reduce_hot_table_write_amplification/index.sql
@@ -119,6 +119,13 @@ ALTER TABLE pool_tvl
 -- it is barely filtering, and FOR UPDATE forces the heap access anyway. On a
 -- table this small a sequential scan is the better plan. Nothing in the API
 -- filters on valid_until.
+--
+-- ORDERING REQUIREMENT: "a table this small" means once the heap matches its
+-- live rows. Against the bloated 46,147-page heap the same lookup measured
+-- 46,147 buffers / 103.6 ms by seq scan versus 50 buffers / 0.14 ms via the
+-- index. The repack described in the README's breaking changelog must happen
+-- BEFORE this migration is deployed, or a once-a-second query gets 750x more
+-- expensive until it does.
 DROP INDEX IF EXISTS erc20_tokens_latest_price_valid_until_idx;
 
 ALTER TABLE erc20_tokens_latest_price

--- a/migrations/00119_reduce_hot_table_write_amplification/index.sql
+++ b/migrations/00119_reduce_hot_table_write_amplification/index.sql
@@ -16,10 +16,12 @@
 -- (the 39,048 s pg_temp_* entry in pg_stat_statements is REFRESH ...
 -- CONCURRENTLY's internal diff, plus 7,180 s more in a second temp scan).
 --
--- Assumption: six-hourly was the intent, since */6 was placed in the hour
--- field. The upstream compute_incentive_rewards job runs hourly, so
--- '5 * * * *' would also be defensible if the matview is meant to track it
--- closely -- this migration does not assume that.
+-- Rescheduled to '5 * * * *' rather than to the six-hourly cadence the broken
+-- expression was reaching for. Reward periods land on hourly boundaries, so
+-- hourly is the cadence that actually matches the data; minute 5 leaves four
+-- minutes after compute_incentive_rewards (job 'compute_incentive_rewards',
+-- minute 1) for the boundary blocks to be indexed before the matview reads
+-- them. At 24 runs/day of ~100 s this is ~40 m/day, down from 4 h 52 m.
 DO
 $$
     DECLARE
@@ -47,7 +49,7 @@ $$
 
         PERFORM cron.schedule(
                 'refresh_computed_rewards_by_position',
-                '0 */6 * * *',
+                '5 * * * *',
                 'REFRESH MATERIALIZED VIEW CONCURRENTLY incentives.computed_rewards_by_position_materialized'
                 );
     END;

--- a/tests/migrations/reduce-hot-table-write-amplification.test.ts
+++ b/tests/migrations/reduce-hot-table-write-amplification.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import { createClient } from "../helpers/db.js";
+
+type Client = Awaited<ReturnType<typeof createClient>>;
+
+async function reloptions(client: Client, table: string) {
+  const { rows } = await client.query<{ reloptions: string[] | null }>(
+    `SELECT reloptions FROM pg_class WHERE relname = $1 AND relkind = 'r'`,
+    [table]
+  );
+  return rows[0]?.reloptions ?? [];
+}
+
+test("hot tables carry an aggressive autovacuum scale factor and fillfactor", async () => {
+  const client = await createClient();
+
+  for (const [table, fillfactor] of [
+    ["pool_states", "fillfactor=70"],
+    ["pool_tvl", "fillfactor=70"],
+    ["erc20_tokens_latest_price", "fillfactor=80"],
+  ] as const) {
+    const options = await reloptions(client, table);
+    expect(options).toContain("autovacuum_vacuum_scale_factor=0.01");
+    expect(options).toContain(fillfactor);
+  }
+});
+
+test("the valid_until index is gone so latest-price updates can go HOT", async () => {
+  const client = await createClient();
+
+  const { rows } = await client.query<{ indexname: string }>(
+    `SELECT indexname FROM pg_indexes WHERE tablename = 'erc20_tokens_latest_price'`
+  );
+  const names = rows.map((row) => row.indexname);
+
+  expect(names).not.toContain("erc20_tokens_latest_price_valid_until_idx");
+  // The primary key is what recompute_erc20_token_latest_price upserts against
+  // and must survive; without it the ON CONFLICT target disappears.
+  expect(names).toContain("erc20_tokens_latest_price_pkey");
+});


### PR DESCRIPTION
Three unrelated causes of avoidable CPU on `ekubo-db-nyc1`, measured from `pg_stat_statements` over 2026-08-25 → 2026-09-01 (7d10h). Migration `00119`.

## 1. `refresh_computed_rewards_by_position` runs 240x/day

00071 set the schedule to `* */6 * * *`. The `*/6` is in the **hour** field, so the minute field stays "every minute" and the job fires 60 times an hour during hours 0, 6, 12 and 18. Each refresh of the 308 MB matview takes ~100 s, so runs queue back to back and spill into the next hour. Measured runs per hour over 24 h: 51/9, 52/8, 58/2, 42/14 across the four windows.

**240 runs/day totalling 4h52m of database time — about 10% of all database time.**

Rescheduled to `5 * * * *`. Note this is *hourly*, not the six-hourly cadence the broken expression was reaching for: reward periods land on hourly boundaries, so hourly is the cadence that matches the data, and minute 5 leaves four minutes after `compute_incentive_rewards` (minute 1) for the boundary blocks to be indexed before the matview reads them.

24 runs/day of ~100 s is ~40m/day, down from 4h52m.

## 2. `pool_states` / `pool_tvl` are 15–20x bloated

| table | real rows | heap | dead |
|---|---|---|---|
| `pool_states` | 4,969 | 22 MB | 40.8% |
| `pool_tvl` | ~4,900 | 15 MB | 56.8% |

Both take ~440k updates/week. HOT already works on them (99.3% HOT), but the server default `autovacuum_vacuum_scale_factor` of 0.2 only triggers after 20% of the table is dead, and the steady state sits well above that — autovacuum ran 253 and 337 times in the window and never brought them down. Neither table had any reloptions.

This matters because both sit on the hot path of the `all_pool_states_view` poll, **the single largest consumer of database time at 34.4%** (2.2M calls, 62 ms mean, 100% cache hit — pure CPU). One `EXPLAIN (ANALYZE, BUFFERS)` on the largest chain touched 20,272 buffers: 10,328 from `pool_states`, 4,377 from `pool_tvl`.

Set `autovacuum_vacuum_scale_factor = 0.01` and `fillfactor = 70` on both.

**Sizing the win honestly:** the `pool_tvl` term is the bloat-driven one (4,377 buffers for 4,718 rows). The `pool_states` term mostly is not — 10,328 buffers over 3,256 index probes is 3.17 per probe, already about the floor for root + leaf + heap. So expect **25–35% off the poll query, not an order of magnitude.**

## 3. `erc20_tokens_latest_price`: 47.9M updates, **zero** HOT updates

7,360 live rows vs 749,363 dead (99% dead), 75 MB heap + 63 MB indexes, 10,617 autovacuum runs in the window.

HOT requires that no indexed column change. 00116 added an index on `valid_until`, and `recompute_erc20_token_latest_price` writes `valid_until` on every refresh (it derives from the observation timestamp, so it moves essentially every time). Every update writes a new heap tuple plus both index entries, and autovacuum runs near-continuously without keeping up — that autovacuum load is itself a standing CPU cost.

The index earns very little. Its only consumer is `refresh_expired_erc20_token_latest_prices` (`WHERE valid_until <= p_as_of FOR UPDATE SKIP LOCKED`): production shows 1,272,763 scans reading 5,493,381,022 tuples ≈ **4,316 tuples per scan on a 7,360-row table**. It selects most of the table each call, and `FOR UPDATE` forces heap access anyway. Nothing in the `api` repo filters on `valid_until` (checked).

Dropped, plus `fillfactor = 80` and the same scale factor.

## ⚠️ The migration alone does not recover the CPU

`fillfactor` only applies to pages written after a rewrite, and a lower scale factor lets autovacuum reclaim space in place but never shrinks an already-bloated heap. `scripts/migrate.ts` wraps each migration in a transaction, so the rewrite cannot live in the migration.

**After migrating**, run one of these — full commands and trade-offs are in the README breaking changelog:

```sql
VACUUM (FULL, ANALYZE) pool_states;
VACUUM (FULL, ANALYZE) pool_tvl;
VACUUM (FULL, ANALYZE) erc20_tokens_latest_price;
```

Seconds each at these sizes, but `ACCESS EXCLUSIVE` stalls the indexer and price-sync. `pg_repack` 1.5.2 is available on the managed instance and avoids the lock if that stall is unacceptable.

Without this step someone will re-check `pg_stat_statements`, see the poll query unchanged, and conclude the analysis was wrong.

## Deliberately excluded

- **The real fix for the 34.4% poll query.** `last_event_id > $3` cannot prune anything: it is a `GREATEST()` over five joined tables computed inside the view, so Postgres materializes the full 14-way join for every pool on the chain and then filters, usually to zero rows. The incremental poll does full work every call and returns nothing. Fixing it means maintaining the state in a real table with a plain indexed `last_event_id` — too involved for this PR.
- **Prepared statements for that poll.** `EXPLAIN` showed 43 ms/call of planning (1,843 buffers just to plan). `pg_stat_statements.track_planning` is off, so this is *additional hidden load* on top of the 34.4%. Lives in the `api` repo.
- **`delete_old_empty_blocks`** (9.0% of database time, hourly, 199 s mean, worst 7m17s on the 5.4 GB `blocks` table). Its plan and indexes are fine; it is delete volume. Running it every 10 minutes would smooth the burst — the function already takes an advisory lock so overlap is safe — but that is burst smoothing, not a CPU reduction, and mixing it in muddies the validation story. Follow-up.

## Validation

- `bun run lint` — clean
- `bun test` — 231 pass, 0 fail (53 files)
- New `tests/migrations/reduce-hot-table-write-amplification.test.ts` asserts the reloptions are set and the index is gone (PGlite has no pg_cron, so the schedule is not covered)

To confirm in production: `SELECT pg_stat_statements_reset();` after the vacuum step, then re-check after 24 h.

## Disk, while I was in there

62 GB of the 100 GiB plan (~62%). Not urgent and not addressed here, but disk looks more likely than CPU to force a resize — `swaps` is 18 GB, `pool_balance_change` 11 GB, `computed_rewards` 9.2 GB, all append-heavy. Worth a growth alert.
