### PR TITLE
Wait for the indexer lock without holding a snapshot

### DIFF
--- a/src/_shared/advisoryLockPoll.test.ts
+++ b/src/_shared/advisoryLockPoll.test.ts
@@ -1,61 +1,51 @@
 import { describe, expect, it } from "bun:test";
 import { pollForAdvisoryLock } from "./advisoryLockPoll";
 
-function acquirerFailing(times: number): {
+function acquirerHeldFor(attempts: number): {
   tryAcquire: () => Promise<boolean>;
   calls: () => number;
 } {
-  let attempts = 0;
+  let seen = 0;
   return {
     tryAcquire: async () => {
-      attempts++;
-      return attempts > times;
+      seen++;
+      return seen > attempts;
     },
-    calls: () => attempts,
+    calls: () => seen,
   };
 }
 
 describe("pollForAdvisoryLock", () => {
-  it("returns immediately when the lock is free", async () => {
-    const { tryAcquire, calls } = acquirerFailing(0);
+  it("takes the lock immediately when it is free", async () => {
+    const { tryAcquire, calls } = acquirerHeldFor(0);
 
     await pollForAdvisoryLock(tryAcquire, { pollIntervalMs: 0 });
 
     expect(calls()).toBe(1);
   });
 
-  it("retries until the holder releases, as pg_advisory_lock would", async () => {
-    const { tryAcquire, calls } = acquirerFailing(3);
-    const contended: number[] = [];
+  it("waits for the predecessor to exit, however long the handoff takes", async () => {
+    // The deploy handoff is deliberate, so there is no deadline to give up at:
+    // a newcomer keeps waiting until the outgoing instance releases the lock.
+    const { tryAcquire, calls } = acquirerHeldFor(500);
+
+    await pollForAdvisoryLock(tryAcquire, { pollIntervalMs: 0 });
+
+    expect(calls()).toBe(501);
+  });
+
+  it("reports how long it has been waiting so a stuck handoff is visible", async () => {
+    const { tryAcquire } = acquirerHeldFor(3);
+    let clock = 1_000;
+    const waits: number[] = [];
 
     await pollForAdvisoryLock(tryAcquire, {
       pollIntervalMs: 0,
-      onContended: (attempt) => contended.push(attempt),
+      now: () => (clock += 5_000),
+      onContended: (waitedMs) => waits.push(waitedMs),
     });
 
-    expect(calls()).toBe(4);
-    expect(contended).toEqual([1, 2, 3]);
-  });
-
-  it("gives up once the deadline passes instead of waiting forever", async () => {
-    const { tryAcquire, calls } = acquirerFailing(Number.MAX_SAFE_INTEGER);
-    // A clock that jumps past the deadline after the first failed attempt, so a
-    // permanently held lock terminates rather than pinning the vacuum horizon.
-    let clock = 0;
-    const now = () => {
-      clock += 30_000;
-      return clock;
-    };
-
-    await expect(
-      pollForAdvisoryLock(tryAcquire, {
-        pollIntervalMs: 0,
-        maxWaitMs: 10_000,
-        description: "the indexer lock for chain ID 46630",
-        now,
-      }),
-    ).rejects.toThrow(/indexer lock for chain ID 46630/);
-
-    expect(calls()).toBe(1);
+    // Elapsed is measured from the first call, not from zero.
+    expect(waits).toEqual([5_000, 10_000, 15_000]);
   });
 });

--- a/src/_shared/advisoryLockPoll.test.ts
+++ b/src/_shared/advisoryLockPoll.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { pollForAdvisoryLock } from "./advisoryLockPoll";
+
+function acquirerFailing(times: number): {
+  tryAcquire: () => Promise<boolean>;
+  calls: () => number;
+} {
+  let attempts = 0;
+  return {
+    tryAcquire: async () => {
+      attempts++;
+      return attempts > times;
+    },
+    calls: () => attempts,
+  };
+}
+
+describe("pollForAdvisoryLock", () => {
+  it("returns immediately when the lock is free", async () => {
+    const { tryAcquire, calls } = acquirerFailing(0);
+
+    await pollForAdvisoryLock(tryAcquire, { pollIntervalMs: 0 });
+
+    expect(calls()).toBe(1);
+  });
+
+  it("retries until the holder releases, as pg_advisory_lock would", async () => {
+    const { tryAcquire, calls } = acquirerFailing(3);
+    const contended: number[] = [];
+
+    await pollForAdvisoryLock(tryAcquire, {
+      pollIntervalMs: 0,
+      onContended: (attempt) => contended.push(attempt),
+    });
+
+    expect(calls()).toBe(4);
+    expect(contended).toEqual([1, 2, 3]);
+  });
+
+  it("gives up once the deadline passes instead of waiting forever", async () => {
+    const { tryAcquire, calls } = acquirerFailing(Number.MAX_SAFE_INTEGER);
+    // A clock that jumps past the deadline after the first failed attempt, so a
+    // permanently held lock terminates rather than pinning the vacuum horizon.
+    let clock = 0;
+    const now = () => {
+      clock += 30_000;
+      return clock;
+    };
+
+    await expect(
+      pollForAdvisoryLock(tryAcquire, {
+        pollIntervalMs: 0,
+        maxWaitMs: 10_000,
+        description: "the indexer lock for chain ID 46630",
+        now,
+      }),
+    ).rejects.toThrow(/indexer lock for chain ID 46630/);
+
+    expect(calls()).toBe(1);
+  });
+});

--- a/src/_shared/advisoryLockPoll.ts
+++ b/src/_shared/advisoryLockPoll.ts
@@ -1,0 +1,50 @@
+// Only one indexer may run per chain, and that is enforced with a session-level
+// advisory lock. The obvious way to take it -- pg_advisory_lock -- blocks in the
+// server until the lock is free, and that wait happens inside a transaction, so
+// the waiting backend holds an open snapshot for as long as it blocks.
+//
+// On 2026-09-01 two workers for chain 46630 connected during a deploy. The loser
+// sat in pg_advisory_lock for 22 hours, pinning the vacuum horizon 486,642
+// transactions back. Autovacuum could not collect anything database-wide:
+// erc20_tokens_latest_price grew to 3.6M dead tuples and a 361 MB heap, and the
+// pool-state poll went from ~13 ms to 3.2 s before anyone noticed.
+//
+// Polling with pg_try_advisory_lock has the same effect for the caller -- wait
+// until the lock is available -- but each attempt is its own instant
+// transaction, so a loser holds no snapshot between tries. The wait is bounded
+// so that a duplicate worker eventually exits loudly rather than idling forever.
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_MAX_WAIT_MS = 5 * 60_000;
+
+export async function pollForAdvisoryLock(
+  tryAcquire: () => Promise<boolean>,
+  {
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    maxWaitMs = DEFAULT_MAX_WAIT_MS,
+    description = "an advisory lock",
+    now = Date.now,
+    onContended,
+  }: {
+    pollIntervalMs?: number;
+    maxWaitMs?: number;
+    description?: string;
+    now?: () => number;
+    onContended?: (attempt: number) => void;
+  } = {},
+): Promise<void> {
+  const deadline = now() + maxWaitMs;
+
+  for (let attempt = 1; ; attempt++) {
+    if (await tryAcquire()) return;
+
+    if (now() >= deadline) {
+      throw new Error(
+        `Gave up after ${Math.round(maxWaitMs / 1000)}s waiting for ${description}; ` +
+          `another process still holds it. Exiting rather than waiting with an open transaction.`,
+      );
+    }
+
+    onContended?.(attempt);
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+}

--- a/src/_shared/advisoryLockPoll.ts
+++ b/src/_shared/advisoryLockPoll.ts
@@ -1,50 +1,44 @@
-// Only one indexer may run per chain, and that is enforced with a session-level
-// advisory lock. The obvious way to take it -- pg_advisory_lock -- blocks in the
-// server until the lock is free, and that wait happens inside a transaction, so
-// the waiting backend holds an open snapshot for as long as it blocks.
+// Only one indexer may run per chain, enforced with a session-level advisory
+// lock. Contention on that lock is deliberate: a deployment starts the new
+// instances before the old ones exit, and each newcomer is meant to sit on the
+// lock until its predecessor releases it. A full deploy shows around eight
+// waiters at once, clearing within seconds. That handoff is the design and this
+// module preserves it -- a waiter still waits for as long as it takes.
 //
-// On 2026-09-01 two workers for chain 46630 connected during a deploy. The loser
-// sat in pg_advisory_lock for 22 hours, pinning the vacuum horizon 486,642
-// transactions back. Autovacuum could not collect anything database-wide:
-// erc20_tokens_latest_price grew to 3.6M dead tuples and a 361 MB heap, and the
-// pool-state poll went from ~13 ms to 3.2 s before anyone noticed.
+// What is not wanted is for the waiting to cost the database anything.
+// pg_advisory_lock blocks inside the server, and the blocked backend holds an
+// open transaction -- and so a snapshot -- for the entire wait. That pins the
+// vacuum horizon database-wide. On 2026-09-01 a chain-46630 handoff never
+// completed: the waiter sat there for 22 hours, held the horizon 486,642
+// transactions back, and autovacuum stopped being able to collect anything.
+// erc20_tokens_latest_price reached 3.6M dead tuples in a 361 MB heap and the
+// pool-state poll went from ~13 ms to 3.2 s.
 //
-// Polling with pg_try_advisory_lock has the same effect for the caller -- wait
-// until the lock is available -- but each attempt is its own instant
-// transaction, so a loser holds no snapshot between tries. The wait is bounded
-// so that a duplicate worker eventually exits loudly rather than idling forever.
-const DEFAULT_POLL_INTERVAL_MS = 5_000;
-const DEFAULT_MAX_WAIT_MS = 5 * 60_000;
+// pg_try_advisory_lock returns immediately instead of blocking, so each attempt
+// is its own instant transaction and a waiter holds no snapshot between tries.
+// The wait is unbounded, exactly as before; it simply no longer holds the
+// horizon while it waits. The interval is short so takeover stays prompt once
+// the predecessor exits.
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
 
 export async function pollForAdvisoryLock(
   tryAcquire: () => Promise<boolean>,
   {
     pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
-    maxWaitMs = DEFAULT_MAX_WAIT_MS,
-    description = "an advisory lock",
     now = Date.now,
     onContended,
   }: {
     pollIntervalMs?: number;
-    maxWaitMs?: number;
-    description?: string;
     now?: () => number;
-    onContended?: (attempt: number) => void;
+    onContended?: (waitedMs: number) => void;
   } = {},
 ): Promise<void> {
-  const deadline = now() + maxWaitMs;
+  const startedAt = now();
 
-  for (let attempt = 1; ; attempt++) {
+  for (;;) {
     if (await tryAcquire()) return;
 
-    if (now() >= deadline) {
-      throw new Error(
-        `Gave up after ${Math.round(maxWaitMs / 1000)}s waiting for ${description}; ` +
-          `another process still holds it. Exiting rather than waiting with an open transaction.`,
-      );
-    }
-
-    onContended?.(attempt);
+    onContended?.(now() - startedAt);
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 }

--- a/src/_shared/dao.ts
+++ b/src/_shared/dao.ts
@@ -1,6 +1,8 @@
 import type { Sql } from "postgres";
 import { type EventKey } from "./eventKey";
 import postgres from "postgres";
+import { pollForAdvisoryLock } from "./advisoryLockPoll";
+import { logger } from "./logger";
 
 export type NumericValue = bigint | number | `0x${string}`;
 export type AddressValue = bigint | `0x${string}`;
@@ -471,10 +473,25 @@ export class DAO {
   }
 
   public async acquireLock(): Promise<void> {
-    const rows = await this
-      .sql`SELECT pg_advisory_lock(hashtext('ekubo-indexer-' || ${this.chainId}));`;
-    if (!rows.length)
-      throw new Error(`Failed to acquire lock for chain ID ${this.chainId}`);
+    // Deliberately pg_try_advisory_lock in a poll rather than pg_advisory_lock:
+    // blocking in the server holds an open transaction, which pins the vacuum
+    // horizon for the whole wait. See advisoryLockPoll.ts.
+    await pollForAdvisoryLock(
+      async () => {
+        const [row] = await this.sql<{ acquired: boolean }[]>`
+            SELECT pg_try_advisory_lock(hashtext('ekubo-indexer-' || ${this.chainId})) AS acquired;`;
+        return row?.acquired === true;
+      },
+      {
+        description: `the indexer lock for chain ID ${this.chainId}`,
+        onContended: (attempt) =>
+          logger.warn({
+            message: `Indexer lock for chain ID ${this.chainId} is held by another process; retrying`,
+            chainId: this.chainId.toString(),
+            attempt,
+          }),
+      },
+    );
   }
 
   public async releaseLock(): Promise<void> {

--- a/src/_shared/dao.ts
+++ b/src/_shared/dao.ts
@@ -437,6 +437,11 @@ type UnwrapPromiseArray<T> = T extends any[]
     }
   : T;
 
+// How often to report an ongoing wait for the per-chain indexer lock. The wait
+// itself is expected during a deploy handoff; the log line is what makes an
+// unusually long one visible.
+const LOCK_WAIT_LOG_INTERVAL_MS = 30_000;
+
 // Data access object that manages inserts/deletes
 export class DAO {
   private readonly chainId: bigint;
@@ -473,9 +478,12 @@ export class DAO {
   }
 
   public async acquireLock(): Promise<void> {
-    // Deliberately pg_try_advisory_lock in a poll rather than pg_advisory_lock:
-    // blocking in the server holds an open transaction, which pins the vacuum
-    // horizon for the whole wait. See advisoryLockPoll.ts.
+    // Waiting here is normal: during a deploy the newcomer holds off until the
+    // outgoing instance for this chain exits. pg_try_advisory_lock is used
+    // rather than pg_advisory_lock so that waiting does not hold a snapshot and
+    // pin the vacuum horizon. See advisoryLockPoll.ts.
+    let nextLogAtMs = 0;
+
     await pollForAdvisoryLock(
       async () => {
         const [row] = await this.sql<{ acquired: boolean }[]>`
@@ -483,13 +491,15 @@ export class DAO {
         return row?.acquired === true;
       },
       {
-        description: `the indexer lock for chain ID ${this.chainId}`,
-        onContended: (attempt) =>
-          logger.warn({
-            message: `Indexer lock for chain ID ${this.chainId} is held by another process; retrying`,
+        onContended: (waitedMs) => {
+          if (waitedMs < nextLogAtMs) return;
+          nextLogAtMs = waitedMs + LOCK_WAIT_LOG_INTERVAL_MS;
+          logger.info({
+            message: `Waiting for the indexer lock for chain ID ${this.chainId}; another instance still holds it`,
             chainId: this.chainId.toString(),
-            attempt,
-          }),
+            waitedMs,
+          });
+        },
       },
     );
   }


### PR DESCRIPTION
Follow-up to the 2026-09-01 incident, where the production database sat near 100% CPU for hours. Independent of #165 — code only, no schema change.

## The contention is not the problem

Only one indexer may run per chain, enforced by a session-level advisory lock. Waiting on that lock is **deliberate and routine**: a deployment starts the new instances before the old ones exit, and each newcomer is meant to sit on the lock until its predecessor releases. Watching the #165 deploy roll, eight waiters appeared at once and cleared within ~30 seconds. That handoff is the design, and this PR keeps it exactly as it is — **the wait stays unbounded**.

## The problem is what waiting costs the database

`pg_advisory_lock` blocks *inside the server*, and a blocked backend holds an open transaction — and therefore a snapshot — for the entire wait. That pins the vacuum horizon database-wide.

On 2026-09-01 a chain-46630 handoff never completed. The waiter sat there **22 hours 49 minutes**, holding the horizon **486,642 transactions** back. Autovacuum could then collect nothing anywhere:

| | healthy | during the stuck handoff |
|---|---|---|
| `erc20_tokens_latest_price` dead tuples | ~19 | **3,632,252**, growing ~5,500/s |
| its heap | ~1.4 MB | **361 MB** |
| autovacuum runs | keeping up | 11,754, reclaiming nothing |
| `all_pool_states_view` poll | ~13 ms | **3,200 ms** |

A 35-pool testnet chain degraded the whole production database, and nothing about the *waiting* was wrong — only that the waiter held a snapshot while doing it.

## The fix

`pg_try_advisory_lock` on a 1 s poll instead of `pg_advisory_lock`.

Each attempt is its own instant transaction, so a waiter holds **no snapshot between tries** and a slow handoff — even a 22-hour one — costs the database nothing. Behaviour for the caller is unchanged: it still waits as long as the handoff takes. The interval is short so takeover stays prompt once the predecessor exits.

An ongoing wait is logged every 30 s with the elapsed time, which is what makes an unusually long handoff visible without changing what it does.

Polling lives in `src/_shared/advisoryLockPoll.ts` with an injectable clock and `tryAcquire`, following the `nullBlockRetry.ts` pattern, so it is unit-testable without two live sessions.

## Why not the alternatives

- **`idle_in_transaction_session_timeout` would not have caught this.** The stuck backend was `active`, blocked in a query — not idle in transaction. Worth knowing, since that is the usual reach for this class of bug.
- **`lock_timeout` around a blocking `pg_advisory_lock`** would bound the snapshot to a few seconds rather than eliminating it, and turns every contended acquisition into an error the caller has to classify. Polling gives a strictly stronger guarantee — zero snapshot — and keeps the retry explicit.
- **Giving up after a deadline** was in the first version of this PR and was wrong: it would break a legitimate handoff that happens to be slow. Removed.

## Still worth doing separately

Nothing alerted on a 22-hour transaction. An alert on `max(now() - xact_start)` is the control that would actually have caught this, and it stays valuable even with this fix — a long transaction from any source has the same effect.

## Validation

- `bun run lint` — clean
- `bun test` — 232 pass, 0 fail (53 files)
- `src/_shared/advisoryLockPoll.test.ts` covers: immediate acquisition when free; waiting through a 500-attempt handoff without giving up; and reporting elapsed wait time so a stuck handoff is visible

https://claude.ai/code/session_01G4NreiDyfGLKnZHNTDrpn1