### PR TITLE
Only fail startup on a conflicting chain ID

### DIFF
--- a/src/_shared/rpcChainId.test.ts
+++ b/src/_shared/rpcChainId.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import { assertRpcChainIds } from "./rpcChainId";
+
+const SEPOLIA = 11155111n;
+
+function answering(chainId: bigint) {
+  return async () => chainId;
+}
+
+function failing(message: string) {
+  return async (): Promise<bigint> => {
+    throw new Error(message);
+  };
+}
+
+describe("assertRpcChainIds", () => {
+  it("accepts a list where every transport agrees", async () => {
+    await assertRpcChainIds(
+      [
+        { url: "a", getChainId: answering(SEPOLIA) },
+        { url: "b", getChainId: answering(SEPOLIA) },
+      ],
+      SEPOLIA,
+    );
+  });
+
+  it("tolerates a paywalled transport when another one answers", async () => {
+    // The eth-sepolia outage: drpc paywalled Sepolia while 0xrpc.io stayed
+    // healthy, and the all-or-nothing check crash-looped the worker anyway.
+    const unreachable: string[] = [];
+
+    await assertRpcChainIds(
+      [
+        {
+          url: "https://sepolia.drpc.org",
+          getChainId: failing("chain is not available on free plan"),
+        },
+        { url: "https://0xrpc.io/sep", getChainId: answering(SEPOLIA) },
+      ],
+      SEPOLIA,
+      { onUnreachable: (url) => unreachable.push(url) },
+    );
+
+    expect(unreachable).toEqual(["https://sepolia.drpc.org"]);
+  });
+
+  it("tolerates a rate-limited transport, which is transient", async () => {
+    await assertRpcChainIds(
+      [
+        {
+          url: "https://bsc.drpc.org",
+          getChainId: failing("You reached Public endpoint rate limit"),
+        },
+        { url: "https://working", getChainId: answering(SEPOLIA) },
+      ],
+      SEPOLIA,
+    );
+  });
+
+  it("still rejects a transport serving a different chain", async () => {
+    // The property the check exists for: a reachable endpoint pointed at the
+    // wrong network would write its blocks under this indexer's chain_id.
+    await expect(
+      assertRpcChainIds(
+        [
+          { url: "https://right", getChainId: answering(SEPOLIA) },
+          { url: "https://wrong", getChainId: answering(1n) },
+        ],
+        SEPOLIA,
+      ),
+    ).rejects.toThrow(/\[https:\/\/wrong=1\].*conflict.*11155111/);
+  });
+
+  it("rejects when no transport can answer at all", async () => {
+    await expect(
+      assertRpcChainIds(
+        [
+          { url: "a", getChainId: failing("down") },
+          { url: "b", getChainId: failing("down") },
+        ],
+        SEPOLIA,
+      ),
+    ).rejects.toThrow(/No EVM_RPC_URL transport/);
+  });
+});

--- a/src/_shared/rpcChainId.ts
+++ b/src/_shared/rpcChainId.ts
@@ -1,0 +1,65 @@
+// Guards against a misconfigured EVM_RPC_URL writing another chain's blocks
+// under this indexer's chain_id.
+//
+// Once an indexer has a cursor the stream catches this on its own: the stored
+// cursor carries a block hash, and a stream serving a different chain rejects
+// it as not canonical. That protection does not exist on a fresh start, where
+// there is no stored hash to check against, so the chain ID is asserted up
+// front instead.
+//
+// The distinction that matters is between a transport that disagrees and one
+// that cannot answer. dRPC's public endpoints return "chain is not available
+// on free plan" and "You reached Public endpoint rate limit"; neither says
+// anything about which chain the endpoint serves. Treating those as fatal is
+// what left eth-sepolia crash-looping from 2026-07-31, with a healthy fallback
+// URL configured the whole time. So an unreachable transport is reported and
+// skipped, and only an answer that conflicts is fatal.
+export interface ChainIdProbe {
+  url: string;
+  getChainId: () => Promise<bigint>;
+}
+
+export async function assertRpcChainIds(
+  probes: ChainIdProbe[],
+  expectedChainId: bigint,
+  {
+    onUnreachable,
+  }: { onUnreachable?: (url: string, error: unknown) => void } = {},
+): Promise<void> {
+  const results = await Promise.allSettled(
+    probes.map(async ({ url, getChainId }) => ({
+      url,
+      chainId: await getChainId(),
+    })),
+  );
+
+  const answered: { url: string; chainId: bigint }[] = [];
+
+  results.forEach((result, index) => {
+    if (result.status === "fulfilled") {
+      answered.push(result.value);
+    } else {
+      onUnreachable?.(probes[index]!.url, result.reason);
+    }
+  });
+
+  if (answered.length === 0) {
+    throw new Error(
+      `No EVM_RPC_URL transport could report a chain ID for chain ID ${expectedChainId}`,
+    );
+  }
+
+  const conflicting = answered.filter(
+    ({ chainId }) => chainId !== expectedChainId,
+  );
+
+  if (conflicting.length > 0) {
+    const details = conflicting
+      .map(({ url, chainId }) => `${url}=${chainId}`)
+      .join(", ");
+
+    throw new Error(
+      `EVM_RPC_URL transports return chain IDs [${details}] which conflict with environment chain ID ${expectedChainId}`,
+    );
+  }
+}

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -11,6 +11,7 @@ import {
   type HexAddress,
 } from "./_shared/loadHexAddresses";
 import { withNullBlockRetry } from "./_shared/nullBlockRetry";
+import { assertRpcChainIds } from "./_shared/rpcChainId";
 import { parseEvmRpcUrls } from "./_shared/streamEndpoints";
 import { createLogProcessorsV2 } from "./evm/logProcessorsV2";
 import { createLogProcessorsV3 } from "./evm/logProcessorsV3";
@@ -176,34 +177,22 @@ export async function createEvmEntrypoint(
     transport: fallback(evmRpcTransports.map(({ transport }) => transport)),
   });
 
-  const [clientChainId, transportChainIds] = await Promise.all([
-    publicClient.getChainId(),
-    Promise.all(
-      evmRpcTransports.map(async ({ url, transport }) => ({
-        url,
-        chainId: BigInt(
-          await createPublicClient({
-            transport,
-          }).getChainId(),
-        ),
-      })),
-    ),
-  ]);
-
-  const uniqueChainIds = new Set<bigint>([
-    BigInt(clientChainId),
-    ...transportChainIds.map(({ chainId }) => chainId),
-  ]);
-
-  if (uniqueChainIds.size !== 1 || !uniqueChainIds.has(chainId)) {
-    const transportDetails = transportChainIds
-      .map(({ url, chainId }) => `${url}=${chainId}`)
-      .join(", ");
-
-    throw new Error(
-      `EVM_RPC_URL transports return chain IDs [${transportDetails}] which conflict with environment chain ID ${chainId}`,
-    );
-  }
+  await assertRpcChainIds(
+    evmRpcTransports.map(({ url, transport }) => ({
+      url,
+      getChainId: async () =>
+        BigInt(await createPublicClient({ transport }).getChainId()),
+    })),
+    chainId,
+    {
+      onUnreachable: (url, error) =>
+        logger.warn({
+          message: `RPC could not report a chain ID; continuing without it`,
+          url,
+          error: error instanceof Error ? error.message : String(error),
+        }),
+    },
+  );
 
   const mergeGetLogsFilter = process.env.MERGE_GET_LOGS_FILTER;
 


### PR DESCRIPTION
Stacked on #167 — based on `fix-sepolia-rpc`, not `main`, so the two land in a single push and one deploy. Review independently; merge this into #167 first, then #167 into main.

## The problem

`src/evm.ts` validated the chain ID by calling `getChainId()` on **every** configured transport inside a bare `Promise.all`, on a transport built with `retryCount: 0`. Any single transport that fails rejects the whole thing and exits the process — even when other transports answer correctly and the `fallback()` client would work fine.

That conflates two different signals:

- a transport that **cannot answer** says nothing about which chain it serves
- a transport that **answers with a different chain ID** is a real misconfiguration

This is what kept `eth-sepolia` crash-looping for 32 days (#167). `sepolia.drpc.org` returned *"chain is not available on free plan"*, and a healthy `0xrpc.io/sep` was configured the entire time — but one dead endpoint in the list was enough to exit before the fallback was ever used.

It is not limited to permanent paywalls. Testing the dRPC endpoints now, `bsc.drpc.org` returns *"You reached Public endpoint rate limit"* — **transient**. Six of eleven chain configs reference dRPC; `base-mainnet`, `base-sepolia` and `arb-sepolia` all list one and would crash-loop the same way on a bad minute, with healthy alternatives configured.

## What this keeps

The check is still worth making, for one specific reason. Once an indexer has a cursor, the stream catches a wrong chain by itself: the stored cursor carries a block hash, and a stream serving a different chain rejects it as not canonical (`runtime.ts:305`). **That protection does not exist on a fresh start** — with no stored hash there is nothing to check against, so a misconfigured `EVM_RPC_URL` would write another chain's blocks under this indexer's `chain_id` unnoticed.

So the guarantee is preserved exactly: a transport that answers with the wrong chain ID is still fatal, and startup still fails if *no* transport can answer at all. Only "unreachable" stops being fatal — it is logged and skipped.

Worth noting on the alternative of checking the chain ID on received blocks: EVM block headers carry no chain ID, and only `number`, `hash` and `timestamp` reach the runtime (`parseCommonBlockHeader`). The block hash is the usable chain fingerprint, and the canonical-cursor check above is already exactly that — which is why this probe only needs to cover the fresh-start gap.

## Validation

- `bun run lint` — clean
- `bun test` — 239 pass, 0 fail (55 files)
- New `src/_shared/rpcChainId.test.ts` covers: agreement across transports; tolerating the paywalled endpoint from the real outage; tolerating a rate-limited one; **still rejecting a transport on the wrong chain**; and rejecting when nothing answers

https://claude.ai/code/session_01G4NreiDyfGLKnZHNTDrpn1