### PR TITLE
Lock blocks first so the migration set cannot deadlock with the workers

### DIFF
--- a/migrations/00120_incremental_rewards_by_position/index.sql
+++ b/migrations/00120_incremental_rewards_by_position/index.sql
@@ -1,3 +1,33 @@
+-- Park every indexer worker before taking any other lock. THIS MUST STAY THE
+-- FIRST STATEMENT OF THIS FILE.
+--
+-- 00120, 00121 and 00122 run inside one transaction (scripts/migrate.ts), and
+-- between them they take table locks on ~20 relations one at a time -- index
+-- builds, trigger creation, the matview swap, ALTERs on blocks and
+-- indexer_cursor -- while 14 workers keep running short write transactions
+-- that touch the same relations in whatever order the block's events dictate.
+-- That is a textbook lock-ordering deadlock, and it happened on the first
+-- deploy attempt (2026-09-05 02:44:02, 40P01): the migration held
+-- indexer_cursor from ADD COLUMN and wanted blocks for DISABLE TRIGGER; a
+-- worker held blocks from its insert and wanted indexer_cursor for its cursor
+-- write. Postgres killed the migration 137 s in and DO rolled the deploy back.
+--
+-- Every worker transaction's first statement is the reorg-protection
+-- DELETE FROM blocks, which needs ROW EXCLUSIVE on blocks. SHARE ROW EXCLUSIVE
+-- conflicts with that but not with the ACCESS SHARE readers take, so once this
+-- lock is held every worker is parked at its first statement holding nothing,
+-- and no cycle is possible for the rest of the transaction. Acquiring it may
+-- itself wait a little for in-flight worker transactions to finish -- they
+-- hold nothing the migration wants yet, so that wait is bounded by one block's
+-- processing. The hourly delete_old_empty_blocks() job holds blocks for
+-- minutes; deploy outside the top of the hour.
+--
+-- lock_timeout is a backstop against waiting forever behind something idle in
+-- transaction; a deploy that hits it fails cleanly and is rerun.
+SET LOCAL lock_timeout = '15min';
+
+LOCK TABLE blocks IN SHARE ROW EXCLUSIVE MODE;
+
 -- Replace the DeFi Spring rewards matview with a table maintained incrementally
 -- by triggers, and drop the hourly refresh entirely.
 --

--- a/tests/migrations/migration-lock-ordering.test.ts
+++ b/tests/migrations/migration-lock-ordering.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+// 00120-00122 run in one transaction against live writers and take locks on
+// ~20 relations. The first deploy attempt deadlocked against a worker
+// (blocks vs indexer_cursor, 2026-09-05). Parking the workers by locking
+// blocks before anything else is what makes the set deadlock-free, and it only
+// works if it really is the first statement. Guard that, since nothing else
+// would notice it moving.
+test("00120 parks the indexer workers before taking any other lock", async () => {
+  const file = path.resolve(
+    process.cwd(),
+    "migrations/00120_incremental_rewards_by_position/index.sql"
+  );
+  const sql = await fs.readFile(file, "utf8");
+
+  const statements = sql
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("--") && line.trim() !== "")
+    .join("\n")
+    .split(";")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  expect(statements[0]).toBe("SET LOCAL lock_timeout = '15min'");
+  expect(statements[1]).toBe("LOCK TABLE blocks IN SHARE ROW EXCLUSIVE MODE");
+});


### PR DESCRIPTION
Follow-up to #171, whose first deploy **deadlocked and rolled back** (DO deployment `f1af6285`, 2026-09-05 02:44:02, `40P01`). Prod is unchanged: migration ledger at 119, no new columns, matview intact.

## What happened

00120–00122 run in one transaction (`postgres-shift` wraps the set in `sql.begin`) and take table locks on ~20 relations one at a time — index builds, trigger creation, the matview swap, `ALTER`s on `blocks` and `indexer_cursor` — while the 14 workers keep running short write transactions that touch the same relations in whatever order each block's events dictate. Lock-ordering deadlock. The DETAIL from the job log, OIDs resolved against prod:

> Process 1367366 (migration) waits for ShareRowExclusiveLock on **blocks** (`DISABLE TRIGGER`); blocked by 1272961.
> Process 1272961 (worker) waits for RowExclusiveLock on **indexer_cursor** (`writeCursor`); blocked by 1367366 (held since `ADD COLUMN` at 02:42:59).

## The fix

Every worker transaction's **first** statement is the reorg-protection `DELETE FROM blocks …`, which needs `ROW EXCLUSIVE` on `blocks`. Taking `SHARE ROW EXCLUSIVE` on `blocks` as the very first statement of 00120 parks every worker at that statement *holding nothing*, so no cycle is possible for the rest of the transaction. It doesn't conflict with the `ACCESS SHARE` that readers and cascade lookups take. Acquiring it waits at most one in-flight block per worker.

A test asserts the lock stays the first statement, since nothing else would notice it moving. `lock_timeout = 15min` is a backstop so a deploy stuck behind something idle-in-transaction fails cleanly instead of hanging.

## Timing from the failed run, useful for the retry

- 00120 rewards seed: **73 s** (I'd estimated 145)
- 00121, all 13 index builds: **< 1 s**
- 00122 ran 63 s before the deadlock

So the whole set should be ~2.5 min, during which the workers are parked and the rewards endpoint blocks on the matview swap. Deploy outside :00–:08 — `delete_old_empty_blocks` holds `blocks` for ~250 s at :00 and the rewards refresh holds the matview ~150 s at :05; neither deadlocks now, they'd just delay the start.

Companions unchanged and still gated behind this: EkuboProtocol/api#132, EkuboProtocol/quoter-service#48.

https://claude.ai/code/session_01EafuJ5i85zz2wqaNQidE3F