### PR TITLE
Store the pool-state poll's last_event_id so the quoter's predicate can use an index

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,33 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
+### 2026-09-05: Indexable `last_event_id` for the pool-state poll
+
+**`00123_pool_last_event_id`. Schema change; no consumer changes.**
+
+quoter-service polls `all_pool_states_view` every 5 s per chain with
+`last_event_id > $3`. That column was `GREATEST()` over five state tables, so
+the predicate could only be a post-join filter and every poll walked every pool
+on the chain through the view's ~10 side-table joins — 96.8 ms and ~112k
+buffers per call, the largest single CPU consumer on the instance (5.9% of the
+box on its own in a 10-minute sample).
+
+New table `pool_last_event_id (pool_key_id, chain_id, core_address,
+last_event_id)` stores that value, maintained by row triggers on
+`pool_states`, `twamm_pool_states`, `boosted_fees_pool_states`,
+`limit_order_pool_states` and `ve33_pool_states` (`AFTER INSERT OR UPDATE OF
+last_event_id OR DELETE`, recomputed exactly from the five sources so reorgs
+that lower it are honoured). The view's `last_event_id` column now reads from
+it through an inner join, and the index `(chain_id, core_address,
+last_event_id)` lets the poll's predicate drive the plan. Column list, order
+and types of the view are unchanged — `CREATE OR REPLACE VIEW` — so neither
+quoter-service nor the API needs a change. `recompute_pool_last_event_id(id)`
+is available for manual repair.
+
+Deploy: `CREATE TRIGGER` takes `SHARE ROW EXCLUSIVE` on five tables the
+workers write mid-transaction; the migration locks `blocks` first (the #173
+pattern) so it cannot deadlock. The swap is a single short transaction.
+
 ### 2026-09-04: Stop writing empty blocks; chain head moves to `indexer_cursor`
 
 **`00122_indexer_cursor_head_block`. Coordinated deploy across three repos —

--- a/README.md
+++ b/README.md
@@ -181,16 +181,32 @@ buffers per call, the largest single CPU consumer on the instance (5.9% of the
 box on its own in a 10-minute sample).
 
 New table `pool_last_event_id (pool_key_id, chain_id, core_address,
-last_event_id)` stores that value, maintained by row triggers on
-`pool_states`, `twamm_pool_states`, `boosted_fees_pool_states`,
-`limit_order_pool_states` and `ve33_pool_states` (`AFTER INSERT OR UPDATE OF
-last_event_id OR DELETE`, recomputed exactly from the five sources so reorgs
-that lower it are honoured). The view's `last_event_id` column now reads from
-it through an inner join, and the index `(chain_id, core_address,
-last_event_id)` lets the poll's predicate drive the plan. Column list, order
-and types of the view are unchanged — `CREATE OR REPLACE VIEW` — so neither
-quoter-service nor the API needs a change. `recompute_pool_last_event_id(id)`
-is available for manual repair.
+last_event_id)` stores that value. Each of `pool_states`, `twamm_pool_states`,
+`boosted_fees_pool_states`, `limit_order_pool_states` and `ve33_pool_states`
+gets **two** triggers: `<table>_maintain_pool_last_event_id` (`AFTER INSERT OR
+DELETE`) and `<table>_maintain_pool_last_event_id_upd` (`AFTER UPDATE OF
+last_event_id`, guarded by `WHEN (OLD.last_event_id IS DISTINCT FROM
+NEW.last_event_id)`). An upward move — every swap and position update — is a
+single primary-key update; inserts, deletes and downward moves recompute the
+value exactly from the five sources. It tracks those sources; whether they go
+down on a reorg is their own recompute functions' behaviour, unchanged from
+the live `GREATEST`, and the quoter relies on `fork_counter` for reorgs.
+
+The view's `last_event_id` column now reads from the table through an inner
+join placed inside the first eight relations of the join list (the planner's
+`join_collapse_limit`; further down, the index could never drive the plan).
+Column list, order and types are unchanged — `CREATE OR REPLACE VIEW` — so
+neither quoter-service nor the API needs a change.
+
+**Operator notes.** Repair one pool with `SELECT
+recompute_pool_last_event_id(<pool_key_id>)`; resync everything with `SELECT
+recompute_pool_last_event_id(pool_key_id) FROM pool_states` — required after
+any bulk rewrite done with triggers disabled, since a missing row silently
+drops the pool from the view and a stale-low value stops the quoter refetching
+it. Post-deploy parity check: `SELECT (SELECT count(*) FROM pool_states),
+(SELECT count(*) FROM pool_last_event_id), (SELECT count(*) FROM
+all_pool_states_view)` — all three must match. Then watch the `apsv` poll in
+`pg_stat_statements`: mean should fall from ~97 ms to low single digits.
 
 Deploy: `CREATE TRIGGER` takes `SHARE ROW EXCLUSIVE` on five tables the
 workers write mid-transaction; the migration locks `blocks` first (the #173

--- a/migrations/00123_pool_last_event_id/index.sql
+++ b/migrations/00123_pool_last_event_id/index.sql
@@ -43,11 +43,15 @@
 --
 -- Correctness notes.
 --
--- * The trigger recomputes the GREATEST from the five sources rather than
---   taking a running max, so it is exact under reorgs: when a fork is
---   discarded, cascades remove events, the state functions rewrite the state
---   rows with lower last_event_ids, and the stored value follows them down.
---   The quoter already handles that via fork_counter.
+-- * The stored value tracks its five sources exactly: a downward move or a
+--   delete in any of them triggers a full recompute rather than a running
+--   max. Note what that does and does not promise. It follows the state
+--   tables; whether those go down on a reorg is up to their own recompute
+--   functions (twamm/boosted/limit-order freeze GREATEST(own events,
+--   pool_states.last_event_id) into their rows and only re-derive it on
+--   pool_states INSERT/DELETE), which is exactly the behaviour the live
+--   GREATEST had. The quoter relies on fork_counter for reorgs, not on this
+--   value going down.
 -- * Membership matches the view's existing inner join on pool_states: a pool
 --   has a pool_last_event_id row exactly while it has a pool_states row.
 -- * last_event_id is indexed and changes on every state write, so updates
@@ -77,7 +81,9 @@ CREATE INDEX pool_last_event_id_chain_id_core_address_last_event_id_idx
 
 -- Exact recompute for one pool from the five state tables. Removes the row
 -- when the pool no longer has a pool_states row, mirroring the view's inner
--- join.
+-- join. Also the repair tool: SELECT recompute_pool_last_event_id(pool_key_id)
+-- FROM pool_states resyncs everything (needed after any bulk rewrite done
+-- with the triggers disabled).
 CREATE OR REPLACE FUNCTION recompute_pool_last_event_id(p_pool_key_id int8)
     RETURNS VOID
     LANGUAGE plpgsql
@@ -98,8 +104,13 @@ BEGIN
              LEFT JOIN ve33_pool_states vps ON vps.pool_key_id = pk.pool_key_id
     WHERE pk.pool_key_id = p_pool_key_id
     ON CONFLICT (pool_key_id) DO UPDATE
-        SET last_event_id = EXCLUDED.last_event_id
-        WHERE pool_last_event_id.last_event_id IS DISTINCT FROM EXCLUDED.last_event_id;
+        SET last_event_id = EXCLUDED.last_event_id,
+            -- immutable in practice, but the view's join needs them to match
+            -- pool_keys, so a repair must be able to re-sync them
+            chain_id      = EXCLUDED.chain_id,
+            core_address  = EXCLUDED.core_address
+        WHERE (pool_last_event_id.last_event_id, pool_last_event_id.chain_id, pool_last_event_id.core_address)
+                  IS DISTINCT FROM (EXCLUDED.last_event_id, EXCLUDED.chain_id, EXCLUDED.core_address);
 
     DELETE
     FROM pool_last_event_id
@@ -114,6 +125,33 @@ CREATE OR REPLACE FUNCTION trg_pool_last_event_id()
 AS
 $$
 BEGIN
+    -- The hot path. Every swap and position update moves
+    -- pool_states.last_event_id up to the new event id, so this branch is what
+    -- runs per event: a single primary-key update, no joins. An upward move in
+    -- any one source makes the new GREATEST max(stored, NEW), so a row that is
+    -- already >= NEW is left alone and nothing else needs reading.
+    IF TG_OP = 'UPDATE' AND NEW.last_event_id > OLD.last_event_id THEN
+        UPDATE pool_last_event_id
+        SET last_event_id = NEW.last_event_id
+        WHERE pool_key_id = NEW.pool_key_id
+          AND last_event_id < NEW.last_event_id;
+
+        IF FOUND THEN
+            RETURN NULL;
+        END IF;
+        -- Either the stored value already covers it, or the row is missing;
+        -- the full recompute below settles both.
+    END IF;
+
+    -- A pool without a pool_states row is out of the view whatever the other
+    -- tables say, so there is nothing to recompute.
+    IF TG_OP = 'DELETE' AND TG_TABLE_NAME = 'pool_states' THEN
+        DELETE FROM pool_last_event_id WHERE pool_key_id = OLD.pool_key_id;
+        RETURN NULL;
+    END IF;
+
+    -- INSERTs, DELETEs on the other tables, and downward moves (reorgs) can
+    -- change the answer in either direction: recompute it from the sources.
     PERFORM recompute_pool_last_event_id(COALESCE(NEW.pool_key_id, OLD.pool_key_id));
     RETURN NULL;
 END;
@@ -130,6 +168,14 @@ $$;
 -- leaves last_event_id where it was. INSERT and DELETE always change the
 -- answer, so they fire unconditionally. (A WHEN referencing OLD is not valid
 -- on an INSERT trigger, hence the split.)
+--
+-- Firing order: AFTER triggers on one table fire alphabetically, so on a
+-- pool_states INSERT or DELETE this one runs before the existing
+-- trg_pool_states_recompute_pool_state / trg_ps_recompute_lops, whose
+-- twamm/limit-order writes fire it again. The recompute is idempotent and the
+-- last one wins, so that is up to three ~0.06 ms recomputes on the rare
+-- events that create or remove a pool state (pool initialisation, reorg
+-- cascades), not on the per-event path above. Left as is on purpose.
 DO
 $$
     DECLARE
@@ -161,24 +207,10 @@ $$
     END;
 $$;
 
--- Seed every pool that is currently in the view.
-INSERT INTO pool_last_event_id (pool_key_id, chain_id, core_address, last_event_id)
-SELECT pk.pool_key_id,
-       pk.chain_id,
-       pk.core_address,
-       GREATEST(ps.last_event_id, tps.last_event_id, bps.last_event_id, lops.last_event_id, vps.last_event_id)
-FROM pool_keys pk
-         JOIN pool_states ps USING (pool_key_id)
-         LEFT JOIN twamm_pool_states tps ON tps.pool_key_id = pk.pool_key_id
-         LEFT JOIN boosted_fees_pool_states bps ON bps.pool_key_id = pk.pool_key_id
-         LEFT JOIN limit_order_pool_states lops ON lops.pool_key_id = pk.pool_key_id
-         LEFT JOIN ve33_pool_states vps ON vps.pool_key_id = pk.pool_key_id
-         -- Placed after the USING joins: another pool_key_id on the left side
-         -- would make them ambiguous. It is an inner join on pk's columns, so
-         -- the planner can still start from its index.
-         JOIN pool_last_event_id plei ON plei.pool_key_id = pk.pool_key_id
-                                     AND plei.chain_id = pk.chain_id
-                                     AND plei.core_address = pk.core_address;
+-- Seed every pool that is currently in the view, through the maintainer so
+-- the seed and the trigger cannot disagree (the 00098/00106/00120 convention).
+SELECT recompute_pool_last_event_id(pool_key_id)
+FROM pool_states;
 
 ANALYZE pool_last_event_id;
 
@@ -261,6 +293,17 @@ SELECT pk.pool_key_id,
 FROM pool_keys pk
          JOIN pool_states ps USING (pool_key_id)
          LEFT JOIN pool_tvl pt USING (pool_key_id)
+         -- Position matters twice over. It must come after the two USING
+         -- joins, or a second pool_key_id on the left side makes them
+         -- ambiguous. And it must sit inside the first eight relations: the
+         -- planner collapses a JOIN list only up to join_collapse_limit (8 by
+         -- default; 15 relations here), so a join placed further down is
+         -- planned after the first group is fixed and its index can never
+         -- drive the plan -- the predicate would go back to being a filter
+         -- over every pool. Verified against the real planner at 3,000 pools.
+         JOIN pool_last_event_id plei ON plei.pool_key_id = pk.pool_key_id
+                                     AND plei.chain_id = pk.chain_id
+                                     AND plei.core_address = pk.core_address
          LEFT JOIN erc20_tokens t0 ON t0.chain_id = pk.chain_id AND t0.token_address = pk.token0
          LEFT JOIN erc20_tokens_latest_price p0 ON p0.chain_id = pk.chain_id AND p0.token_address = pk.token0
          LEFT JOIN erc20_tokens t1 ON t1.chain_id = pk.chain_id AND t1.token_address = pk.token1
@@ -271,10 +314,4 @@ FROM pool_keys pk
          LEFT JOIN boosted_fees_pool_states bps ON bps.pool_key_id = pk.pool_key_id
          LEFT JOIN spline_pools sp ON sp.pool_key_id = pk.pool_key_id
          LEFT JOIN limit_order_pool_states lops ON lops.pool_key_id = pk.pool_key_id
-         LEFT JOIN ve33_pool_states vps ON vps.pool_key_id = pk.pool_key_id
-         -- Placed after the USING joins: another pool_key_id on the left side
-         -- would make them ambiguous. It is an inner join on pk's columns, so
-         -- the planner can still start from its index.
-         JOIN pool_last_event_id plei ON plei.pool_key_id = pk.pool_key_id
-                                     AND plei.chain_id = pk.chain_id
-                                     AND plei.core_address = pk.core_address;
+         LEFT JOIN ve33_pool_states vps ON vps.pool_key_id = pk.pool_key_id;

--- a/migrations/00123_pool_last_event_id/index.sql
+++ b/migrations/00123_pool_last_event_id/index.sql
@@ -1,0 +1,264 @@
+-- Make the quoter's pool-state poll indexable on last_event_id.
+--
+-- Measured on ekubo-db-nyc1 on 2026-09-05, after #171/#173.
+--
+-- The single largest consumer of CPU on the instance is quoter-service's
+-- pool-state sync: every 5 seconds, per chain, it runs
+--
+--     SELECT ... FROM all_pool_states_view
+--     WHERE chain_id = $1 AND core_address = $2 AND last_event_id > $3 AND (...)
+--
+-- 3,048,876 calls over 10 days at 96.8 ms and 112,558 buffers each; in a
+-- 10-minute steady-state sample it was 5.85% of the 4-vCPU box on its own, at
+-- 2.4 calls/s -- more than every remaining cron job combined. The predicate is
+-- incremental in intent: $3 is the quoter's watermark, and almost every poll
+-- should match a handful of pools or none.
+--
+-- It cannot be incremental in execution, because the view defines
+--
+--     GREATEST(ps.last_event_id, tps.last_event_id, bps.last_event_id,
+--              lops.last_event_id, vps.last_event_id) AS last_event_id
+--
+-- across five state tables. EXPLAIN shows that predicate as a top-level Filter
+-- on the joined row: nothing can index a GREATEST over five relations, so each
+-- poll walks every pool on the chain through the ~10 side-table probes the
+-- view joins (pool_states, twamm, oracle, spline, limit-order, ve33, boosted
+-- fees, tvl, tokens, prices) and only then discards the unchanged ones. The
+-- per-pool jsonb aggregates (ticks, twamm_orders, donations) run only for
+-- survivors, so the cost is the join-and-filter itself: ~1,500 pools x ~10
+-- probes x a few buffers each, every 5 s, on every chain.
+--
+-- The fix stores that GREATEST. pool_last_event_id holds one row per pool
+-- with the value, kept exact by row triggers on the five state tables, and
+-- the view's last_event_id column now reads from it through an inner join.
+-- chain_id and core_address are denormalised onto it (both immutable per
+-- pool) so that the index (chain_id, core_address, last_event_id) can drive
+-- the plan: the quoter's WHERE lands on pool_keys' columns, equivalence
+-- through the join carries it to plei's, and `last_event_id > $3` becomes an
+-- index range scan that yields only the changed pools. Everything else in
+-- the view then joins for those pools alone.
+--
+-- The view keeps its column list, names, order and types, so this is
+-- CREATE OR REPLACE and neither quoter-service nor the API changes.
+--
+-- Correctness notes.
+--
+-- * The trigger recomputes the GREATEST from the five sources rather than
+--   taking a running max, so it is exact under reorgs: when a fork is
+--   discarded, cascades remove events, the state functions rewrite the state
+--   rows with lower last_event_ids, and the stored value follows them down.
+--   The quoter already handles that via fork_counter.
+-- * Membership matches the view's existing inner join on pool_states: a pool
+--   has a pool_last_event_id row exactly while it has a pool_states row.
+-- * last_event_id is indexed and changes on every state write, so updates
+--   cannot be HOT; the table is ~5,000 rows, and fillfactor plus an
+--   aggressive autovacuum scale factor keep it compact, the same treatment
+--   00119 gave pool_states.
+--
+-- Deploy: CREATE TRIGGER takes SHARE ROW EXCLUSIVE on all five state tables,
+-- which workers hold ROW EXCLUSIVE on mid-transaction -- the lock-ordering
+-- deadlock #173 fixed. Parking the workers by locking blocks first is what
+-- makes that safe; it stays the first statement.
+
+SET LOCAL lock_timeout = '15min';
+
+LOCK TABLE blocks IN SHARE ROW EXCLUSIVE MODE;
+
+CREATE TABLE pool_last_event_id
+(
+    pool_key_id   int8    PRIMARY KEY REFERENCES pool_keys (pool_key_id),
+    chain_id      int8    NOT NULL,
+    core_address  NUMERIC NOT NULL,
+    last_event_id int8    NOT NULL
+) WITH (autovacuum_vacuum_scale_factor = 0.01, fillfactor = 70);
+
+CREATE INDEX pool_last_event_id_chain_id_core_address_last_event_id_idx
+    ON pool_last_event_id (chain_id, core_address, last_event_id);
+
+-- Exact recompute for one pool from the five state tables. Removes the row
+-- when the pool no longer has a pool_states row, mirroring the view's inner
+-- join.
+CREATE OR REPLACE FUNCTION recompute_pool_last_event_id(p_pool_key_id int8)
+    RETURNS VOID
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    INSERT INTO pool_last_event_id (pool_key_id, chain_id, core_address, last_event_id)
+    SELECT pk.pool_key_id,
+           pk.chain_id,
+           pk.core_address,
+           GREATEST(ps.last_event_id, tps.last_event_id, bps.last_event_id, lops.last_event_id,
+                    vps.last_event_id)
+    FROM pool_keys pk
+             JOIN pool_states ps USING (pool_key_id)
+             LEFT JOIN twamm_pool_states tps ON tps.pool_key_id = pk.pool_key_id
+             LEFT JOIN boosted_fees_pool_states bps ON bps.pool_key_id = pk.pool_key_id
+             LEFT JOIN limit_order_pool_states lops ON lops.pool_key_id = pk.pool_key_id
+             LEFT JOIN ve33_pool_states vps ON vps.pool_key_id = pk.pool_key_id
+    WHERE pk.pool_key_id = p_pool_key_id
+    ON CONFLICT (pool_key_id) DO UPDATE
+        SET last_event_id = EXCLUDED.last_event_id
+        WHERE pool_last_event_id.last_event_id IS DISTINCT FROM EXCLUDED.last_event_id;
+
+    DELETE
+    FROM pool_last_event_id
+    WHERE pool_key_id = p_pool_key_id
+      AND NOT EXISTS (SELECT 1 FROM pool_states ps WHERE ps.pool_key_id = p_pool_key_id);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION trg_pool_last_event_id()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    PERFORM recompute_pool_last_event_id(COALESCE(NEW.pool_key_id, OLD.pool_key_id));
+    RETURN NULL;
+END;
+$$;
+
+-- One trigger per state table that feeds the GREATEST. UPDATE OF last_event_id
+-- keeps writes to other columns (sqrt_ratio, liquidity, tick, ...) from
+-- firing it.
+DO
+$$
+    DECLARE
+        state_table TEXT;
+    BEGIN
+        FOREACH state_table IN ARRAY ARRAY [
+            'pool_states',
+            'twamm_pool_states',
+            'boosted_fees_pool_states',
+            'limit_order_pool_states',
+            've33_pool_states'
+            ]
+            LOOP
+                EXECUTE FORMAT(
+                        'CREATE TRIGGER %I AFTER INSERT OR UPDATE OF last_event_id OR DELETE ON %I '
+                            || 'FOR EACH ROW EXECUTE FUNCTION trg_pool_last_event_id()',
+                        state_table || '_maintain_pool_last_event_id',
+                        state_table
+                        );
+            END LOOP;
+    END;
+$$;
+
+-- Seed every pool that is currently in the view.
+INSERT INTO pool_last_event_id (pool_key_id, chain_id, core_address, last_event_id)
+SELECT pk.pool_key_id,
+       pk.chain_id,
+       pk.core_address,
+       GREATEST(ps.last_event_id, tps.last_event_id, bps.last_event_id, lops.last_event_id, vps.last_event_id)
+FROM pool_keys pk
+         JOIN pool_states ps USING (pool_key_id)
+         LEFT JOIN twamm_pool_states tps ON tps.pool_key_id = pk.pool_key_id
+         LEFT JOIN boosted_fees_pool_states bps ON bps.pool_key_id = pk.pool_key_id
+         LEFT JOIN limit_order_pool_states lops ON lops.pool_key_id = pk.pool_key_id
+         LEFT JOIN ve33_pool_states vps ON vps.pool_key_id = pk.pool_key_id
+         -- Placed after the USING joins: another pool_key_id on the left side
+         -- would make them ambiguous. It is an inner join on pk's columns, so
+         -- the planner can still start from its index.
+         JOIN pool_last_event_id plei ON plei.pool_key_id = pk.pool_key_id
+                                     AND plei.chain_id = pk.chain_id
+                                     AND plei.core_address = pk.core_address;
+
+ANALYZE pool_last_event_id;
+
+-- The view, verbatim from 00105 except for the last_event_id column and the
+-- join that supplies it.
+CREATE OR REPLACE VIEW all_pool_states_view AS
+SELECT pk.pool_key_id,
+       pk.chain_id,
+       pk.core_address,
+       pk.token0,
+       pk.token1,
+       pk.fee,
+       pk.tick_spacing,
+       pk.pool_extension,
+       pk.pool_config,
+       pk.pool_config_type,
+       pk.stableswap_center_tick,
+       pk.stableswap_amplification,
+       ps.sqrt_ratio,
+       ps.liquidity,
+       ps.tick,
+       plei.last_event_id                                        AS last_event_id,
+       (SELECT JSONB_AGG(JSONB_BUILD_OBJECT('t', ppptl.tick, 'd',
+                                            ppptl.net_liquidity_delta_diff::TEXT) ORDER BY ppptl.tick)
+        FROM per_pool_per_tick_liquidity ppptl
+        WHERE ppptl.pool_key_id = pk.pool_key_id)                AS ticks,
+       CASE
+           WHEN p0.value IS NULL OR p1.value IS NULL THEN NULL
+           ELSE (COALESCE(pt.balance0, 0)
+               / POWER(10::NUMERIC, COALESCE(t0.token_decimals, 0)))
+               * p0.value +
+                (COALESCE(pt.balance1, 0)
+               / POWER(10::NUMERIC, COALESCE(t1.token_decimals, 0)))
+               * p1.value
+           END                                                   AS pool_tvl_usd,
+
+       -- twamm state
+       EXTRACT(EPOCH FROM tps.last_virtual_execution_time)::int8 AS twamm_last_virtual_execution_time,
+       tps.token0_sale_rate                                      AS twamm_token0_sale_rate,
+       tps.token1_sale_rate                                      AS twamm_token1_sale_rate,
+       (SELECT JSONB_AGG(JSONB_BUILD_OBJECT('t', EXTRACT(EPOCH FROM tsrdm.time)::int8, 's0',
+                                            tsrdm.net_sale_rate_delta0::TEXT,
+                                            's1',
+                                            tsrdm.net_sale_rate_delta1::TEXT) ORDER BY tsrdm.time)
+        FROM twamm_sale_rate_deltas tsrdm
+        WHERE tsrdm.pool_key_id = pk.pool_key_id
+          AND time > last_virtual_execution_time)                AS twamm_orders,
+
+       -- boosted fees state
+       EXTRACT(EPOCH FROM bps.last_donated_time)::int8           AS boosted_fees_last_donated_time,
+       bps.donate_rate0                                          AS boosted_fees_donate_rate0,
+       bps.donate_rate1                                          AS boosted_fees_donate_rate1,
+       (SELECT JSONB_AGG(JSONB_BUILD_OBJECT('t', EXTRACT(EPOCH FROM bfrd.time)::int8, 's0',
+                                            bfrd.net_donate_rate_delta0::TEXT,
+                                            's1',
+                                            bfrd.net_donate_rate_delta1::TEXT) ORDER BY bfrd.time)
+        FROM boosted_fees_donate_rate_deltas bfrd
+        WHERE bfrd.pool_key_id = pk.pool_key_id
+          AND bfrd.time > bps.last_donated_time)                 AS boosted_fees_donations,
+
+       -- ve33 state
+       vps.swap_fee                                              AS ve33_swap_fee,
+       vps.pool_total_vote_weight                                AS ve33_pool_total_vote_weight,
+       EXTRACT(EPOCH FROM vps.last_pool_fees_accounted_block_timestamp)::int8
+                                                                  AS ve33_last_pool_fees_accounted_time,
+       vps.last_pool_fees_accounted_amount0                      AS ve33_last_pool_fees_accounted_amount0,
+       vps.last_pool_fees_accounted_amount1                      AS ve33_last_pool_fees_accounted_amount1,
+       vps.total_pool_fees_accounted0                            AS ve33_total_pool_fees_accounted0,
+       vps.total_pool_fees_accounted1                            AS ve33_total_pool_fees_accounted1,
+       EXTRACT(EPOCH FROM vps.last_pool_emissions_accrued_block_timestamp)::int8
+                                                                  AS ve33_last_pool_emissions_accrued_time,
+       vps.last_pool_emissions_accrued_amount                    AS ve33_last_pool_emissions_accrued_amount,
+       vps.total_pool_emissions_accrued                          AS ve33_total_pool_emissions_accrued,
+
+       ops.last_snapshot_block_timestamp                         AS oracle_last_snapshot_block_timestamp,
+       (mcpk.pool_key_id IS NOT NULL)                            AS is_mev_capture_pool,
+       (sp.pool_key_id IS NOT NULL)                              AS is_spline_pool,
+       (lops.pool_key_id IS NOT NULL)                            AS is_limit_order_pool,
+       (vps.pool_key_id IS NOT NULL)                             AS is_ve33_pool
+FROM pool_keys pk
+         JOIN pool_states ps USING (pool_key_id)
+         LEFT JOIN pool_tvl pt USING (pool_key_id)
+         LEFT JOIN erc20_tokens t0 ON t0.chain_id = pk.chain_id AND t0.token_address = pk.token0
+         LEFT JOIN erc20_tokens_latest_price p0 ON p0.chain_id = pk.chain_id AND p0.token_address = pk.token0
+         LEFT JOIN erc20_tokens t1 ON t1.chain_id = pk.chain_id AND t1.token_address = pk.token1
+         LEFT JOIN erc20_tokens_latest_price p1 ON p1.chain_id = pk.chain_id AND p1.token_address = pk.token1
+         LEFT JOIN twamm_pool_states tps ON pk.pool_key_id = tps.pool_key_id
+         LEFT JOIN oracle_pool_states ops ON ops.pool_key_id = pk.pool_key_id
+         LEFT JOIN mev_capture_pool_keys mcpk ON mcpk.pool_key_id = pk.pool_key_id
+         LEFT JOIN boosted_fees_pool_states bps ON bps.pool_key_id = pk.pool_key_id
+         LEFT JOIN spline_pools sp ON sp.pool_key_id = pk.pool_key_id
+         LEFT JOIN limit_order_pool_states lops ON lops.pool_key_id = pk.pool_key_id
+         LEFT JOIN ve33_pool_states vps ON vps.pool_key_id = pk.pool_key_id
+         -- Placed after the USING joins: another pool_key_id on the left side
+         -- would make them ambiguous. It is an inner join on pk's columns, so
+         -- the planner can still start from its index.
+         JOIN pool_last_event_id plei ON plei.pool_key_id = pk.pool_key_id
+                                     AND plei.chain_id = pk.chain_id
+                                     AND plei.core_address = pk.core_address;

--- a/migrations/00123_pool_last_event_id/index.sql
+++ b/migrations/00123_pool_last_event_id/index.sql
@@ -119,9 +119,17 @@ BEGIN
 END;
 $$;
 
--- One trigger per state table that feeds the GREATEST. UPDATE OF last_event_id
--- keeps writes to other columns (sqrt_ratio, liquidity, tick, ...) from
--- firing it.
+-- Two triggers per state table that feeds the GREATEST.
+--
+-- The state recompute functions (refresh_pool_state, recompute_*_pool_state)
+-- write every column on every call, including last_event_id, and an
+-- "UPDATE OF last_event_id" trigger fires whenever the column is in the SET
+-- list -- not only when the value moves. So the UPDATE trigger carries a WHEN
+-- clause: it is evaluated before the trigger fires, costs a column compare,
+-- and skips the function entirely for the overwhelmingly common rewrite that
+-- leaves last_event_id where it was. INSERT and DELETE always change the
+-- answer, so they fire unconditionally. (A WHEN referencing OLD is not valid
+-- on an INSERT trigger, hence the split.)
 DO
 $$
     DECLARE
@@ -136,9 +144,17 @@ $$
             ]
             LOOP
                 EXECUTE FORMAT(
-                        'CREATE TRIGGER %I AFTER INSERT OR UPDATE OF last_event_id OR DELETE ON %I '
+                        'CREATE TRIGGER %I AFTER INSERT OR DELETE ON %I '
                             || 'FOR EACH ROW EXECUTE FUNCTION trg_pool_last_event_id()',
                         state_table || '_maintain_pool_last_event_id',
+                        state_table
+                        );
+
+                EXECUTE FORMAT(
+                        'CREATE TRIGGER %I AFTER UPDATE OF last_event_id ON %I FOR EACH ROW '
+                            || 'WHEN (OLD.last_event_id IS DISTINCT FROM NEW.last_event_id) '
+                            || 'EXECUTE FUNCTION trg_pool_last_event_id()',
+                        state_table || '_maintain_pool_last_event_id_upd',
                         state_table
                         );
             END LOOP;

--- a/tests/migrations/all-migrations.test.ts
+++ b/tests/migrations/all-migrations.test.ts
@@ -19,5 +19,6 @@ test("all migrations apply successfully", async () => {
     `SELECT count(1) as result FROM information_schema.tables WHERE table_schema = 'public'`
   );
 
-  expect(result).toBe(84);
+  // 00123 adds pool_last_event_id.
+  expect(result).toBe(85);
 });

--- a/tests/migrations/migration-lock-ordering.test.ts
+++ b/tests/migrations/migration-lock-ordering.test.ts
@@ -8,21 +8,29 @@ import path from "node:path";
 // blocks before anything else is what makes the set deadlock-free, and it only
 // works if it really is the first statement. Guard that, since nothing else
 // would notice it moving.
-test("00120 parks the indexer workers before taking any other lock", async () => {
-  const file = path.resolve(
-    process.cwd(),
-    "migrations/00120_incremental_rewards_by_position/index.sql"
-  );
+async function leadingStatements(migration: string) {
+  const file = path.resolve(process.cwd(), `migrations/${migration}/index.sql`);
   const sql = await fs.readFile(file, "utf8");
-
-  const statements = sql
+  return sql
     .split("\n")
     .filter((line) => !line.trim().startsWith("--") && line.trim() !== "")
     .join("\n")
     .split(";")
     .map((s) => s.trim())
-    .filter(Boolean);
+    .filter(Boolean)
+    .slice(0, 2);
+}
 
-  expect(statements[0]).toBe("SET LOCAL lock_timeout = '15min'");
-  expect(statements[1]).toBe("LOCK TABLE blocks IN SHARE ROW EXCLUSIVE MODE");
-});
+// Every migration that takes DDL locks on tables the workers write
+// mid-transaction has to park them first. Add to this list when adding one.
+for (const migration of [
+  "00120_incremental_rewards_by_position",
+  "00123_pool_last_event_id",
+]) {
+  test(`${migration} parks the indexer workers before taking any other lock`, async () => {
+    expect(await leadingStatements(migration)).toEqual([
+      "SET LOCAL lock_timeout = '15min'",
+      "LOCK TABLE blocks IN SHARE ROW EXCLUSIVE MODE",
+    ]);
+  });
+}

--- a/tests/migrations/pool-last-event-id.test.ts
+++ b/tests/migrations/pool-last-event-id.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "bun:test";
-import { createClient, ensureIndexerCursor } from "../helpers/db.js";
+import { PGlite } from "@electric-sql/pglite";
+import {
+  createClient,
+  ensureIndexerCursor,
+  runMigrations,
+  runMigrationsThrough,
+} from "../helpers/db.js";
 
 type Client = Awaited<ReturnType<typeof createClient>>;
 
@@ -114,7 +120,9 @@ test("state rewrites that do not move last_event_id leave the stored row untouch
   expect(await rowVersion(client, pool)).toBe(before);
 
   // last_event_id in the SET list but unchanged -- what every state recompute
-  // function does on every call. The WHEN clause keeps this from firing.
+  // function does on every call. (The row also would not be rewritten without
+  // the WHEN clause, since the recompute upsert is guarded; the WHEN clause
+  // itself is asserted on the trigger definition below.)
   await client.query(
     `UPDATE pool_states SET liquidity = 6, last_event_id = last_event_id WHERE pool_key_id = $1`,
     [pool]
@@ -155,4 +163,67 @@ test("the driving index and the denormalised key columns are in place", async ()
     "pool_extension", "pool_config", "pool_config_type", "stableswap_center_tick",
     "stableswap_amplification", "sqrt_ratio", "liquidity", "tick", "last_event_id", "ticks",
   ]);
+});
+
+test("applying 00123 over existing pools seeds every one of them", async () => {
+  // The seed runs against real data in production, never in the other tests,
+  // which all start from empty tables. The first draft of this migration
+  // seeded zero rows and every test still passed.
+  const client = new PGlite("memory://upgrade");
+  await runMigrationsThrough(client, 122);
+  const pool = await seedPool(client, 7, "2000");
+  await setPoolState(client, pool, 100);
+  await client.query(
+    `INSERT INTO twamm_pool_states (pool_key_id, token0_sale_rate, token1_sale_rate,
+                                    last_virtual_execution_time,
+                                    last_virtual_order_execution_event_id, last_event_id)
+     VALUES ($1, 0, 0, '2024-01-01T00:00:00Z', 150, 150)`,
+    [pool]
+  );
+  const other = await seedPool(client, 8, "2000");
+  await setPoolState(client, other, 5);
+
+  await runMigrations(client, { files: ["00123_pool_last_event_id"] });
+
+  const { rows } = await client.query<{ pools: number; seeded: number; in_view: number }>(
+    `SELECT (SELECT count(*)::int FROM pool_states) AS pools,
+            (SELECT count(*)::int FROM pool_last_event_id) AS seeded,
+            (SELECT count(*)::int FROM all_pool_states_view) AS in_view`
+  );
+  expect(rows[0]).toEqual({ pools: 2, seeded: 2, in_view: 2 });
+  expect(await stored(client, pool)).toBe("150");
+  expect(await viewed(client, pool)).toBe("150");
+  expect(await stored(client, other)).toBe("5");
+});
+
+test("each state table has both triggers, and the UPDATE one only fires on a real move", async () => {
+  const client = await createClient();
+  const { rows } = await client.query<{ tgrelid: string; tgname: string; def: string }>(
+    `SELECT tgrelid::regclass::text AS tgrelid, tgname, pg_get_triggerdef(oid) AS def
+     FROM pg_trigger WHERE tgfoid = 'trg_pool_last_event_id'::regproc AND NOT tgisinternal
+     ORDER BY 1, 2`
+  );
+  const tables = ["boosted_fees_pool_states", "limit_order_pool_states", "pool_states",
+    "twamm_pool_states", "ve33_pool_states"];
+  expect(rows.map((r) => r.tgrelid)).toEqual(tables.flatMap((t) => [t, t]));
+  for (const t of tables) {
+    const [rowEvents, upd] = rows.filter((r) => r.tgrelid === t);
+    expect(rowEvents!.def).toMatch(/AFTER INSERT OR DELETE ON/);
+    expect(upd!.def).toMatch(/AFTER UPDATE OF last_event_id ON/);
+    // This is the guard that keeps every state rewrite from recomputing.
+    expect(upd!.def).toContain("WHEN ((old.last_event_id IS DISTINCT FROM new.last_event_id))");
+  }
+});
+
+test("a repair re-syncs the denormalised keys the view joins on", async () => {
+  const client = await createClient();
+  const pool = await seedPool(client, 7, "2000");
+  await setPoolState(client, pool, 100);
+
+  // Nothing does this today, but if it ever happened the pool would silently
+  // leave the view, so the documented repair has to put it back.
+  await client.query(`UPDATE pool_keys SET core_address = 2001 WHERE pool_key_id = $1`, [pool]);
+  expect(await viewed(client, pool)).toBeNull();
+  await client.query(`SELECT recompute_pool_last_event_id($1)`, [pool]);
+  expect(await viewed(client, pool)).toBe("100");
 });

--- a/tests/migrations/pool-last-event-id.test.ts
+++ b/tests/migrations/pool-last-event-id.test.ts
@@ -1,0 +1,144 @@
+import { expect, test } from "bun:test";
+import { createClient, ensureIndexerCursor } from "../helpers/db.js";
+
+type Client = Awaited<ReturnType<typeof createClient>>;
+
+async function seedPool(client: Client, chainId: number, coreAddress: string) {
+  await ensureIndexerCursor(client, chainId);
+  const {
+    rows: [{ pool_key_id }],
+  } = await client.query<{ pool_key_id: string }>(
+    `INSERT INTO pool_keys (chain_id, core_address, pool_id, token0, token1, fee,
+                            fee_denominator, tick_spacing, pool_extension)
+     VALUES ($1, $2, $3, 4000, 4001, 100, 1000000, 60, 0)
+     RETURNING pool_key_id`,
+    [chainId, coreAddress, String(chainId * 10)]
+  );
+  return Number(pool_key_id);
+}
+
+async function setPoolState(client: Client, poolKeyId: number, lastEventId: number) {
+  await client.query(
+    `INSERT INTO pool_states (pool_key_id, sqrt_ratio, liquidity, tick, last_event_id)
+     VALUES ($1, 1, 0, 0, $2)
+     ON CONFLICT (pool_key_id) DO UPDATE SET last_event_id = EXCLUDED.last_event_id`,
+    [poolKeyId, lastEventId]
+  );
+}
+
+async function stored(client: Client, poolKeyId: number) {
+  const { rows } = await client.query<{ last_event_id: string | null }>(
+    `SELECT last_event_id::text FROM pool_last_event_id WHERE pool_key_id = $1`,
+    [poolKeyId]
+  );
+  return rows[0]?.last_event_id ?? null;
+}
+
+async function viewed(client: Client, poolKeyId: number) {
+  const { rows } = await client.query<{ last_event_id: string | null }>(
+    `SELECT last_event_id::text FROM all_pool_states_view WHERE pool_key_id = $1`,
+    [poolKeyId]
+  );
+  return rows[0]?.last_event_id ?? null;
+}
+
+test("the stored value is the GREATEST over the five state tables, and the view reads it", async () => {
+  const client = await createClient();
+  const pool = await seedPool(client, 7, "2000");
+
+  // No pool_states row yet: not in the view, not in the table.
+  expect(await stored(client, pool)).toBeNull();
+  expect(await viewed(client, pool)).toBeNull();
+
+  await setPoolState(client, pool, 100);
+  expect(await stored(client, pool)).toBe("100");
+  expect(await viewed(client, pool)).toBe("100");
+
+  // A later twamm event raises it.
+  await client.query(
+    `INSERT INTO twamm_pool_states (pool_key_id, token0_sale_rate, token1_sale_rate,
+                                    last_virtual_execution_time,
+                                    last_virtual_order_execution_event_id, last_event_id)
+     VALUES ($1, 0, 0, '2024-01-01T00:00:00Z', 150, 150)`,
+    [pool]
+  );
+  expect(await stored(client, pool)).toBe("150");
+  expect(await viewed(client, pool)).toBe("150");
+
+  // A core event beyond that raises it again; one below it does not lower it.
+  await setPoolState(client, pool, 200);
+  expect(await stored(client, pool)).toBe("200");
+  await setPoolState(client, pool, 120);
+  expect(await stored(client, pool)).toBe("150");
+  expect(await viewed(client, pool)).toBe("150");
+});
+
+test("a reorg that removes the newest state lowers the stored value exactly", async () => {
+  const client = await createClient();
+  const pool = await seedPool(client, 7, "2000");
+  await setPoolState(client, pool, 100);
+  await client.query(
+    `INSERT INTO limit_order_pool_states (pool_key_id, last_event_id) VALUES ($1, 300)`,
+    [pool]
+  );
+  expect(await stored(client, pool)).toBe("300");
+
+  // It is recomputed from the sources, not tracked as a running max, so
+  // deleting the row that supplied the max drops it back.
+  await client.query(`DELETE FROM limit_order_pool_states WHERE pool_key_id = $1`, [pool]);
+  expect(await stored(client, pool)).toBe("100");
+  expect(await viewed(client, pool)).toBe("100");
+
+  // Losing pool_states removes the pool from both, matching the view's inner join.
+  await client.query(`DELETE FROM pool_states WHERE pool_key_id = $1`, [pool]);
+  expect(await stored(client, pool)).toBeNull();
+  expect(await viewed(client, pool)).toBeNull();
+});
+
+test("updates to other pool_states columns do not fire the trigger", async () => {
+  const client = await createClient();
+  const pool = await seedPool(client, 7, "2000");
+  await setPoolState(client, pool, 100);
+
+  const { rows: before } = await client.query<{ xmin: string }>(
+    `SELECT xmin::text FROM pool_last_event_id WHERE pool_key_id = $1`,
+    [pool]
+  );
+  await client.query(`UPDATE pool_states SET liquidity = 5, tick = 3 WHERE pool_key_id = $1`, [pool]);
+  const { rows: after } = await client.query<{ xmin: string }>(
+    `SELECT xmin::text FROM pool_last_event_id WHERE pool_key_id = $1`,
+    [pool]
+  );
+  // Same row version: nothing rewrote it.
+  expect(after[0]!.xmin).toBe(before[0]!.xmin);
+});
+
+test("the driving index and the denormalised key columns are in place", async () => {
+  const client = await createClient();
+  const pool = await seedPool(client, 7, "2000");
+  await setPoolState(client, pool, 100);
+
+  const { rows: idx } = await client.query<{ indexdef: string }>(
+    `SELECT indexdef FROM pg_indexes WHERE tablename = 'pool_last_event_id'
+       AND indexdef LIKE '%(chain_id, core_address, last_event_id)%'`
+  );
+  expect(idx).toHaveLength(1);
+
+  const { rows } = await client.query<{ chain_id: string; core_address: string }>(
+    `SELECT chain_id::text, core_address::text FROM pool_last_event_id WHERE pool_key_id = $1`,
+    [pool]
+  );
+  expect(rows[0]).toEqual({ chain_id: "7", core_address: "2000" });
+
+  // The view's column set is unchanged: same names, same order.
+  const { rows: cols } = await client.query<{ column_name: string }>(
+    `SELECT column_name FROM information_schema.columns
+     WHERE table_name = 'all_pool_states_view' ORDER BY ordinal_position`
+  );
+  const names = cols.map((c) => c.column_name);
+  expect(names.slice(0, 17)).toEqual([
+    "pool_key_id", "chain_id", "core_address", "token0", "token1", "fee", "tick_spacing",
+    "pool_extension", "pool_config", "pool_config_type", "stableswap_center_tick",
+    "stableswap_amplification", "sqrt_ratio", "liquidity", "tick", "last_event_id", "ticks",
+  ]);
+});

--- a/tests/migrations/pool-last-event-id.test.ts
+++ b/tests/migrations/pool-last-event-id.test.ts
@@ -95,22 +95,36 @@ test("a reorg that removes the newest state lowers the stored value exactly", as
   expect(await viewed(client, pool)).toBeNull();
 });
 
-test("updates to other pool_states columns do not fire the trigger", async () => {
+async function rowVersion(client: Client, poolKeyId: number) {
+  const { rows } = await client.query<{ xmin: string }>(
+    `SELECT xmin::text FROM pool_last_event_id WHERE pool_key_id = $1`,
+    [poolKeyId]
+  );
+  return rows[0]!.xmin;
+}
+
+test("state rewrites that do not move last_event_id leave the stored row untouched", async () => {
   const client = await createClient();
   const pool = await seedPool(client, 7, "2000");
   await setPoolState(client, pool, 100);
+  const before = await rowVersion(client, pool);
 
-  const { rows: before } = await client.query<{ xmin: string }>(
-    `SELECT xmin::text FROM pool_last_event_id WHERE pool_key_id = $1`,
-    [pool]
-  );
+  // Other columns only: the trigger is not even a candidate.
   await client.query(`UPDATE pool_states SET liquidity = 5, tick = 3 WHERE pool_key_id = $1`, [pool]);
-  const { rows: after } = await client.query<{ xmin: string }>(
-    `SELECT xmin::text FROM pool_last_event_id WHERE pool_key_id = $1`,
+  expect(await rowVersion(client, pool)).toBe(before);
+
+  // last_event_id in the SET list but unchanged -- what every state recompute
+  // function does on every call. The WHEN clause keeps this from firing.
+  await client.query(
+    `UPDATE pool_states SET liquidity = 6, last_event_id = last_event_id WHERE pool_key_id = $1`,
     [pool]
   );
-  // Same row version: nothing rewrote it.
-  expect(after[0]!.xmin).toBe(before[0]!.xmin);
+  expect(await rowVersion(client, pool)).toBe(before);
+
+  // And a real move does rewrite it.
+  await setPoolState(client, pool, 101);
+  expect(await rowVersion(client, pool)).not.toBe(before);
+  expect(await stored(client, pool)).toBe("101");
 });
 
 test("the driving index and the denormalised key columns are in place", async () => {


### PR DESCRIPTION
Follow-up to #171/#173. Targets the largest single CPU consumer left on `ekubo-db-nyc1`.

## The query

quoter-service's pool-state sync, every 5 seconds, per chain:

```sql
SELECT … FROM all_pool_states_view
WHERE chain_id = $1 AND core_address = $2 AND last_event_id > $3 AND (…)
```

3,048,876 calls over 10 days at **96.8 ms and ~112k buffers each**. In a 10-minute steady-state sample after #171 it was **5.85% of the 4-vCPU box on its own** at 2.4 calls/s — more than every remaining cron job combined.

## Why it's slow

The predicate is incremental in intent (`$3` is the quoter's watermark; most polls should match a handful of pools or none), but the view defines

```sql
GREATEST(ps.last_event_id, tps.last_event_id, bps.last_event_id, lops.last_event_id, vps.last_event_id) AS last_event_id
```

so `EXPLAIN` shows it as a top-level **Filter** on the joined row. Nothing can index a `GREATEST` over five relations, so every poll walks every pool on the chain through the view's ~10 side-table probes (pool_states, twamm, oracle, spline, limit-order, ve33, boosted fees, tvl, tokens, prices) and only then discards the unchanged ones. The per-pool jsonb aggregates run only for survivors, so the cost is the join-and-filter itself: ~1,500 pools × ~10 probes × a few buffers, every 5 s, on every chain.

## The fix

New table `pool_last_event_id (pool_key_id, chain_id, core_address, last_event_id)` stores the value; row triggers on the five state tables (`AFTER INSERT OR UPDATE OF last_event_id OR DELETE`) recompute it **exactly from the five sources** — not a running max — so a reorg that lowers a state's `last_event_id` is honoured (the quoter already handles that via `fork_counter`). `chain_id`/`core_address` are denormalised (immutable per pool) so the index `(chain_id, core_address, last_event_id)` can drive the plan: the quoter's WHERE lands on `pool_keys` columns, equivalence through the inner join carries it to the new table, and `last_event_id > $3` becomes an index range scan yielding only the changed pools; everything else in the view then joins for those alone.

The view is `CREATE OR REPLACE` with an identical column list, order and types — **no quoter-service or API change**. Membership matches the existing inner join on `pool_states`: a pool has a row exactly while it has a `pool_states` row. `recompute_pool_last_event_id(id)` exists for manual repair.

## What review found, and what changed (third commit)

Two findings would have defeated the PR outright; both were reproduced with the real planner/PGlite and are fixed:

- **The seed inserted zero rows.** Moving the `plei` join to the end of the FROM list was done with a text replace that also hit the seed `INSERT … SELECT`, which then inner-joined the empty table it was populating. Every pre-existing pool would have left the view on deploy, and the quoter would have loaded nothing. The seed now goes through the maintainer (`SELECT recompute_pool_last_event_id(pool_key_id) FROM pool_states`), and a new test applies `00123` over pre-existing state and asserts `pool_states` / `pool_last_event_id` / view row-count parity — the case none of the original tests exercised.
- **The index still couldn't drive the plan.** `plei` was the 15th relation; with the default `join_collapse_limit = 8` the planner fixes the first eight without it, so the predicate stayed a post-join filter. It now sits **fourth**, right after the two `USING` joins. Verified at 3,000 pools: the plan starts from `Index Scan using pool_last_event_id_chain_id_core_address_last_event_id_idx` with `chain_id`, `core_address` and `last_event_id > $3` all in the index condition, then PK probes for the matched pools only.

Smaller ones, also taken:
- **Upward-move fast path.** Every swap/position update sets `pool_states.last_event_id` to the new event id, so the `WHEN` clause never filtered the hot path; those now do a single primary-key update (`SET last_event_id = NEW … WHERE last_event_id < NEW`) instead of the six-way recompute. Inserts, deletes and downward moves still recompute exactly; a `pool_states` DELETE removes the row directly.
- The upsert re-syncs `chain_id`/`core_address`, so the documented repair can put a pool back if those ever changed (a test covers it).
- The reorg claim was overstated: the value tracks its five sources exactly, but twamm/boosted/limit-order freeze their own `GREATEST` and only re-derive it on `pool_states` INSERT/DELETE — same as the live `GREATEST` before; the quoter relies on `fork_counter`. Wording fixed in the migration and README.
- The `WHEN` clause is now asserted on `pg_get_triggerdef` for every `_upd` trigger; the xmin test couldn't observe it because the guarded upsert already suppressed the rewrite.
- README documents both triggers per table, the bulk resync, and the post-deploy parity check.

Noted, left as is: on a `pool_states` INSERT/DELETE the existing twamm/limit-order recompute triggers fire this one again (≤3 idempotent ~0.06 ms recomputes on pool init / reorg cascades) — commented in the migration.

## Deploy

`CREATE TRIGGER` takes `SHARE ROW EXCLUSIVE` on five tables the workers write mid-transaction — exactly the lock-ordering shape that deadlocked #171's first deploy. The migration locks `blocks` first (the #173 pattern), guarded by the lock-ordering test, and the whole thing is one short transaction (~5k-row seed). `CREATE OR REPLACE VIEW` briefly blocks readers of the view until commit.

**What to check after:** `pg_stat_statements` for the `apsv` poll — `mean_exec_time` should drop from ~97 ms to low single-digit ms and buffers/call from ~112k to hundreds.

## Cost of maintaining the value (measured on prod, 2026-09-05)

The triggers are on the five **state** tables, not on `blocks` or the event tables, so:

- **The per-block reorg-protection `DELETE FROM blocks … >= $2`** normally deletes zero rows, so it fires no cascades and no triggers — the hot path is untouched.
- **A real reorg** already pays the existing cascade → event-trigger → state-recompute chain (`recompute_twamm_pool_state` 1.9 ms mean, `recompute_boosted_fees_pool_state` 1.3 ms, `recompute_limit_order_pool_state` 60 ms). My trigger adds, per state row whose `last_event_id` actually moves, one recompute: a five-way primary-key join measured at **0.062 ms / 17 buffers** for one pool, plus an upsert that writes only if the value differs. Call it ~0.1 ms per fire, i.e. a low-single-digit percentage on top of the recompute it follows.
- **Steady state**: the state tables take ~104k writes/day (`pool_states` 64k, `ve33_pool_states` 39k, `twamm_pool_states` 0.7k). Even if every one fired, that's ~10 s/day — 0.003% of the box — against the ~5,000 s/day the poll itself was costing.

Second commit splits each trigger so the UPDATE path carries `WHEN (OLD.last_event_id IS DISTINCT FROM NEW.last_event_id)`: the recompute functions set every column on every call and `UPDATE OF` fires on mention, not on change, so rewrites that don't move the value now skip the function entirely.

## Validation

- `bun test` — 310 pass; `bun run lint` clean
- New coverage: stored value equals the GREATEST across state tables and the view reads it; a later twamm/limit-order event raises it and a lower core event doesn't lower it; deleting the row that supplied the max lowers it exactly (reorg); losing `pool_states` removes the pool from both; updates to non-`last_event_id` columns don't fire the trigger (checked via `xmin`); the driving index and denormalised keys exist; the view's first 17 columns are unchanged in name and order. The lock-ordering guard now covers 00123 too. Public table count bumped 84 → 85.

https://claude.ai/code/session_01EafuJ5i85zz2wqaNQidE3F

