### PR TITLE
Index generated_drop_proof by address for the claims endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,29 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
+### 2026-09-05: Index `generated_drop_proof` for the claims endpoint
+
+**`00124_index_generated_drop_proof_address`. Schema change; no consumer
+changes.**
+
+`incentives.generated_drop_proof` (3.1M rows, 2.6 GB, proofs inline) had only
+its primary key `(drop_id, id)`, while `GET /claims/:address` filters it by
+`address`. Every claims request was a sequential scan of the whole table:
+17,378 calls at 1,180 ms and 269k disk blocks each since 2026-08-25 — 35 TB of
+physical reads from a 2.6 GB table at a 20% cache-hit ratio, the largest
+source of I/O on the instance and the reason other hot tables were being
+evicted from the buffer cache. Adds `generated_drop_proof_address_idx
+(address)` and `generated_drop_proof_drop_id_amount_idx (drop_id, amount)` (the
+per-drop totals aggregate becomes an index-only scan), and runs `ANALYZE` on
+the table, whose column statistics had never been collected.
+
+Deploy: `CREATE INDEX` takes `SHARE` on a table only the out-of-band drop
+generator writes, so it does not interact with the indexer workers and does
+not use the `LOCK TABLE blocks` pattern. Expect tens of seconds for the build.
+After: the `WITH funded_roots …` statement in `pg_stat_statements` should drop
+from ~1.2 s to milliseconds, and `pg_statio_user_tables` should show the
+table's `heap_blks_read` flat.
+
 ### 2026-09-05: Indexable `last_event_id` for the pool-state poll
 
 **`00123_pool_last_event_id`. Schema change; no consumer changes.**

--- a/migrations/00124_index_generated_drop_proof_address/index.sql
+++ b/migrations/00124_index_generated_drop_proof_address/index.sql
@@ -1,0 +1,51 @@
+-- Index incentives.generated_drop_proof for the lookups the API actually does.
+--
+-- Measured on ekubo-db-nyc1 on 2026-09-05.
+--
+-- The table is 3,075,770 rows / 2.6 GB with the Merkle proofs stored inline,
+-- and it has exactly one index: its primary key (drop_id, id). The claims
+-- endpoint (GET /claims/:address, queries.ts "WITH funded_roots ...") filters
+-- it by address:
+--
+--     FROM incentives.generated_drop_proof gdp JOIN ... WHERE address = $1
+--
+-- With no index on address that is a sequential scan of the whole table per
+-- request. pg_stat_statements since 2026-08-25: 17,378 calls, 1,180 ms mean,
+-- 269,158 blocks read from disk per call -- 35 TB of physical reads from a
+-- 2.6 GB table, a 20% cache-hit ratio, and the single largest source of I/O
+-- on the instance by an order of magnitude. A second variant of the same
+-- query (460 calls, 10.9 s mean) and the drop-totals aggregate
+--
+--     SELECT drop_id, SUM(amount) FROM incentives.generated_drop_proof GROUP BY drop_id
+--
+-- (54 calls, 2.3 s, 255,679 disk blocks each) scan it the same way. The live
+-- plan at the time of writing:
+--
+--     Nested Loop
+--       -> Parallel Seq Scan on generated_drop_proof gdp  (cost=0.00..340642.64)
+--            Filter: (address = ...)
+--
+-- An address appears in at most one row per drop it was included in, so an
+-- index on address turns each claims request into a handful of index probes
+-- and heap fetches. The second index makes the per-drop totals an index-only
+-- scan over (drop_id, amount) instead of a scan of the proof-laden heap.
+--
+-- Beyond latency, this is what stops the table from evicting everything else
+-- from the buffer cache: 35 TB of reads through a 3.2 GB shared_buffers is why
+-- computed_rewards and swaps show poor hit ratios too.
+--
+-- Deploy: CREATE INDEX takes SHARE on generated_drop_proof, which only the
+-- out-of-band drop generator writes -- no indexer worker touches it -- so
+-- there is no lock-ordering exposure with the workers and no LOCK TABLE
+-- blocks here (that pattern is for migrations touching worker-written
+-- tables). The build is ~3M rows; expect tens of seconds.
+
+CREATE INDEX generated_drop_proof_address_idx
+    ON incentives.generated_drop_proof (address);
+
+CREATE INDEX generated_drop_proof_drop_id_amount_idx
+    ON incentives.generated_drop_proof (drop_id, amount);
+
+-- Column statistics were never collected on this table (n_live_tup showed
+-- 346 against 3.1M rows); give the planner real numbers for address.
+ANALYZE incentives.generated_drop_proof;

--- a/tests/migrations/generated-drop-proof-indexes.test.ts
+++ b/tests/migrations/generated-drop-proof-indexes.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { createClient } from "../helpers/db.js";
+
+type Client = Awaited<ReturnType<typeof createClient>>;
+
+async function seedProofs(client: Client, drops: number, perDrop: number) {
+  for (let d = 1; d <= drops; d++) {
+    await client.query(`INSERT INTO incentives.generated_drop (root) VALUES ($1)`, [String(1000 + d)]);
+  }
+  // Production rows are ~850 bytes because the Merkle proof (an array of
+  // 256-bit numerics) is stored inline, which is what makes a heap scan of
+  // this table expensive relative to its indexes. Seed a comparable width so
+  // the planner faces the same trade-off here.
+  await client.query(
+    `INSERT INTO incentives.generated_drop_proof (drop_id, id, address, amount, proof)
+     SELECT d, i, (d * 1000000 + i)::numeric, (i * 7)::numeric,
+            (SELECT array_agg((2::numeric ^ 250) + g) FROM generate_series(1, 24) g)
+     FROM generate_series(1, $1) d, generate_series(1, $2) i`,
+    [drops, perDrop]
+  );
+  // Index-only scans need the visibility map, which only VACUUM builds.
+  await client.query(`VACUUM ANALYZE incentives.generated_drop_proof`);
+}
+
+test("the claims lookup by address is an index scan, not a table scan", async () => {
+  const client = await createClient();
+  await seedProofs(client, 20, 2000); // 40,000 rows
+
+  const { rows } = await client.query<{ "QUERY PLAN": string }>(
+    `EXPLAIN SELECT gdp.drop_id, gdp.id, gdp.amount
+     FROM incentives.generated_drop_proof gdp
+     JOIN incentives.generated_drop gd ON gd.id = gdp.drop_id
+     WHERE gdp.address = 3000042::numeric`
+  );
+  const plan = rows.map((r) => r["QUERY PLAN"]).join("\n");
+  expect(plan).toContain("generated_drop_proof_address_idx");
+  expect(plan).not.toMatch(/Seq Scan on generated_drop_proof/);
+});
+
+test("the per-drop totals aggregate does not touch the proof-laden heap", async () => {
+  const client = await createClient();
+  await seedProofs(client, 20, 2000);
+
+  const { rows } = await client.query<{ "QUERY PLAN": string }>(
+    `EXPLAIN SELECT drop_id, SUM(amount) FROM incentives.generated_drop_proof GROUP BY drop_id`
+  );
+  const plan = rows.map((r) => r["QUERY PLAN"]).join("\n");
+  expect(plan).toContain("generated_drop_proof_drop_id_amount_idx");
+  expect(plan).toMatch(/Index Only Scan/);
+});
+
+test("both indexes exist with the expected definitions", async () => {
+  const client = await createClient();
+  const { rows } = await client.query<{ indexname: string; indexdef: string }>(
+    `SELECT indexname, indexdef FROM pg_indexes
+     WHERE schemaname = 'incentives' AND tablename = 'generated_drop_proof' ORDER BY indexname`
+  );
+  const defs = Object.fromEntries(rows.map((r) => [r.indexname, r.indexdef]));
+  expect(defs["generated_drop_proof_address_idx"]).toMatch(/\(address\)$/);
+  expect(defs["generated_drop_proof_drop_id_amount_idx"]).toMatch(/\(drop_id, amount\)$/);
+  expect(defs["generated_drop_proof_pkey"]).toBeDefined();
+});


### PR DESCRIPTION
Fixes the largest source of I/O on `ekubo-db-nyc1` — the reason two rewards tables show ~20% cache-hit ratios and the thing that makes a smaller-memory node a non-starter.

## The problem

`incentives.generated_drop_proof` is **3,075,770 rows / 2.6 GB** with the Merkle proofs stored inline, and it had exactly one index: its primary key `(drop_id, id)`. `GET /claims/:address` (`queries.ts`, the `WITH funded_roots …` statement) filters it by `address`:

```sql
FROM incentives.generated_drop_proof gdp JOIN … WHERE address = $1
```

Live plan at the time of writing:

```
Nested Loop
  -> Parallel Seq Scan on generated_drop_proof gdp  (cost=0.00..340642.64)
       Filter: (address = …)
```

Every claims request scanned the whole table. `pg_stat_statements` since 2026-08-25: **17,378 calls, 1,180 ms mean, 269,158 disk blocks per call — 35 TB of physical reads** from a 2.6 GB table at a 20% cache-hit ratio. A second variant of the same query (460 calls, 10.9 s) and the per-drop totals aggregate (`SELECT drop_id, SUM(amount) … GROUP BY drop_id`; 54 calls, 2.3 s, 255k disk blocks each) scan it the same way.

That volume through a 3.2 GB `shared_buffers` is also why `computed_rewards` (22% hit) and `swaps` (67%) look cache-starved: this table keeps evicting them.

## The fix — `00124_index_generated_drop_proof_address`

- `generated_drop_proof_address_idx (address)` — an address appears in at most one row per drop it was included in, so a claims request becomes a handful of index probes and heap fetches.
- `generated_drop_proof_drop_id_amount_idx (drop_id, amount)` — the per-drop totals aggregate becomes an index-only scan instead of a scan of the proof-laden heap.
- `ANALYZE` — the table's column statistics had never been collected (`n_live_tup` read 346 against 3.1M rows).

No API change. No `LOCK TABLE blocks`: only the out-of-band drop generator writes this table, so `CREATE INDEX`'s `SHARE` lock doesn't interact with the indexer workers (that pattern is for worker-written tables). Expect tens of seconds for the build.

## Tests

Plan tests seed 40,000 rows at **production width** (24-element numeric proof arrays) and `VACUUM ANALYZE` first — with narrow rows PGlite's planner correctly prefers a seq scan for the aggregate, which isn't the trade-off production faces; with the real width it picks the index-only scan. Assertions: the address lookup is an `Index Scan` on the new index and not a seq scan; the aggregate is an `Index Only Scan` on the covering index; both definitions are as expected. `bun test` 313 pass; lint clean.

## Is it still the live problem? (measured 2026-09-05 ~22:00 UTC)

A 5-minute `pg_statio_user_tables` delta, physical reads only:

| table | disk in 5 min | at this rate |
|---|---|---|
| `generated_drop_proof` | **4,675 MB** | **1.3 TB/day** |
| `computed_rewards` | 30 MB | 8 GB/day |
| `swaps` | 30 MB | 8.5 GB/day |
| `erc20_tokens_usd_prices` | 27 MB | 7.7 GB/day |

So `computed_rewards`' 7.4 TB cumulative was historical (the 240×/day matview refresh 00119 removed); `generated_drop_proof` is ~98% of what still reads from disk, and it's all the claims endpoint.

## After deploy (merged `103aa73`, migration applied 23:29:05 UTC, DO `a612705a` ACTIVE 23:29:57)

Live plan now:

```
Nested Loop  (cost=0.70..37.60 rows=28)
  -> Index Scan using generated_drop_proof_address_idx on generated_drop_proof gdp
       Index Cond: (address = …)
  -> Index Only Scan using generated_drop_pkey on generated_drop gd
```

Estimated cost **340,642 → 37.6**. Measured on the `WITH funded_roots …` statement itself, windows immediately either side of the migration:

| | window | calls | mean | disk blocks / call | table read from disk |
|---|---|---|---|---|---|
| before | 200 s | 5 | **766 ms** | **292,692** | **16,152 MB** |
| after | 301 s | 3 | **2.0 ms** | **13** | **0 MB** |

Small sample in five minutes (the endpoint runs ~1.2×/min), but the plan is the structural proof and the table's physical reads went from ~5 GB per minute to zero.

https://claude.ai/code/session_01EafuJ5i85zz2wqaNQidE3F

