### PR TITLE
Price-source table: HOT headroom for a repack; refresh months-stale statistics on four event tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,55 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
+### 2026-09-05: Price-source bloat, stale statistics, transfers index
+
+**`00125_price_source_bloat_and_stale_stats`. Schema change plus one manual
+operator step.**
+
+Three findings from the I/O sweep that followed 00124:
+
+- `erc20_tokens_latest_price_by_source` had become the largest live source of
+  disk reads on the instance (~1 GB per five minutes): 17,223 live rows in
+  978 MB, 85% dead tuples, after 87M price-sync updates that autovacuum never
+  caught up with. The migration sets `fillfactor=70` and
+  `autovacuum_vacuum_scale_factor=0.01` (what 00119 gave
+  `erc20_tokens_latest_price`), which prevents the bloat from returning but
+  does not remove it.
+
+  **Manual step, after the migration is applied:** repack the table once.
+  `VACUUM FULL` cannot run inside the migration transaction. At 17k live rows
+  it takes seconds, holding an exclusive lock that briefly blocks price-sync
+  writes (they retry):
+
+  ```sql
+  VACUUM (FULL, ANALYZE) erc20_tokens_latest_price_by_source;
+  ```
+
+  Expect the table to drop from ~978 MB to a few MB, and its `heap_blks_read`
+  in `pg_statio_user_tables` to go flat.
+
+- Planner statistics on the big event tables were months stale (statistics
+  reset at the 08-25 restart; the default 10% analyze threshold would not
+  re-fire for months). `nonfungible_token_transfers` reported 13,645 live rows
+  against 3.1M real, `protocol_fees_paid` 426 against 1.86M, and so on. The
+  migration runs `ANALYZE` on those tables and sets
+  `autovacuum_analyze_scale_factor=0.01` on them so it stays current. This is
+  what had the positions-history query estimating one row for a whole chain
+  and scanning millions of transfers per request.
+
+- New index `nonfungible_token_transfers_chain_id_token_id_idx (chain_id,
+  token_id)` for the positions-history query (`WITH transfers …`, 28k calls at
+  909 ms — the slowest API statement remaining), whose `emitter = $3 OR
+  nlm.locker = $4` predicate cannot use the existing `(chain_id, emitter,
+  token_id, …)` index.
+
+Deploy: `ANALYZE` and reloption changes take `SHARE UPDATE EXCLUSIVE` and do
+not block the workers. The `CREATE INDEX` does block inserts into
+`nonfungible_token_transfers` for the seconds it takes to build over ~3M rows
+and is placed first, while the transaction holds nothing else, so it cannot
+deadlock with a worker. No `LOCK TABLE blocks`. Expect the migration to run
+for about a minute, most of it the `ANALYZE` of `swaps` and `computed_rewards`.
+
 ### 2026-09-05: Index `generated_drop_proof` for the claims endpoint
 
 **`00124_index_generated_drop_proof_address`. Schema change; no consumer

--- a/README.md
+++ b/README.md
@@ -169,54 +169,69 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
-### 2026-09-05: Price-source bloat, stale statistics, transfers index
+### 2026-09-06: Price-source bloat and stale statistics
 
-**`00125_price_source_bloat_and_stale_stats`. Schema change plus one manual
-operator step.**
+**`00125_price_source_bloat_and_stale_stats`. Reloptions and `ANALYZE` only —
+no lock that conflicts with the workers — plus one manual operator step.**
 
-Three findings from the I/O sweep that followed 00124:
+Two findings from the I/O sweep that followed 00124:
 
-- `erc20_tokens_latest_price_by_source` had become the largest live source of
-  disk reads on the instance (~1 GB per five minutes): 17,223 live rows in
-  978 MB, 85% dead tuples, after 87M price-sync updates that autovacuum never
-  caught up with. The migration sets `fillfactor=70` and
-  `autovacuum_vacuum_scale_factor=0.01` (what 00119 gave
-  `erc20_tokens_latest_price`), which prevents the bloat from returning but
-  does not remove it.
+- `erc20_tokens_latest_price_by_source` is the largest live source of disk
+  reads on the instance (~1 GB per five minutes): 17,223 live rows in 978 MB
+  (594 MB heap + 384 MB index), ~6 MB of live data. Autovacuum is not behind
+  on it — it fires on essentially every naptime. The heap is the residue of the
+  2026-09-01 incident described under 00119: a worker blocked 22 hours inside
+  `pg_advisory_lock` pinned the vacuum horizon, and at ~90 updates/s that left
+  ~7M dead tuples vacuum could not remove until the session ended. Vacuum
+  reclaims that space in place; only a rewrite shrinks the heap.
 
-  **Manual step, after the migration is applied:** repack the table once.
-  `VACUUM FULL` cannot run inside the migration transaction. At 17k live rows
-  it takes seconds, holding an exclusive lock that briefly blocks price-sync
-  writes (they retry):
+  The migration sets `fillfactor=70` (HOT headroom after the repack; the
+  table's only index is its primary key) and
+  `autovacuum_vacuum_scale_factor=0.01` (matching 00119's setting on the
+  sibling table `erc20_tokens_latest_price`, which got `fillfactor=80`). Neither
+  prevents a repeat of the incident — that needs `lock_timeout` /
+  `statement_timeout` on the indexer role and an alert on `age(backend_xmin)`,
+  a separate change.
 
-  ```sql
-  VACUUM (FULL, ANALYZE) erc20_tokens_latest_price_by_source;
+  **Manual step, after the migration is applied:** rewrite the table once.
+  Preferred, because it rewrites without an exclusive lock:
+
+  ```sh
+  pg_repack -d defaultdb -t erc20_tokens_latest_price_by_source
   ```
 
-  Expect the table to drop from ~978 MB to a few MB, and its `heap_blks_read`
-  in `pg_statio_user_tables` to go flat.
+  (`pg_repack` 1.5.2 is available on the managed instance; it needs `CREATE
+  EXTENSION pg_repack` in `defaultdb` and a matching local client.) The
+  fallback is `VACUUM (FULL, ANALYZE) erc20_tokens_latest_price_by_source`,
+  which takes seconds at 17k live rows but holds `ACCESS EXCLUSIVE`: it blocks
+  the price sync's **reads** as well as its writes, and nothing in
+  `src/price-sync` retries a failed cycle, so prices go stale for the duration.
+  If using it, set `lock_timeout = '10s'` first and run outside :00–:02, when
+  the hourly `prune_erc20_tokens_usd_prices` DELETE is holding the table's
+  trigger path. Expect ~978 MB → a few MB and the table's `heap_blks_read` in
+  `pg_statio_user_tables` to go flat.
 
-- Planner statistics on the big event tables were months stale (statistics
+- Planner statistics on four large event tables were months stale (statistics
   reset at the 08-25 restart; the default 10% analyze threshold would not
-  re-fire for months). `nonfungible_token_transfers` reported 13,645 live rows
-  against 3.1M real, `protocol_fees_paid` 426 against 1.86M, and so on. The
-  migration runs `ANALYZE` on those tables and sets
-  `autovacuum_analyze_scale_factor=0.01` on them so it stays current. This is
-  what had the positions-history query estimating one row for a whole chain
-  and scanning millions of transfers per request.
+  re-fire for months): `nonfungible_token_transfers` reported 13,645 live rows
+  against 3.1M real, `nonfungible_token_owners` 10,751 against 2.35M,
+  `protocol_fees_paid` 426 against 1.86M, `position_fees_collected` 2,251
+  against 1.81M. This is what had the positions-history query (`WITH transfers
+  …`, 28k calls at 909 ms — the slowest API statement remaining) estimating one
+  row for a whole chain and scanning millions of transfers per request. The
+  migration runs `ANALYZE` on those four and sets
+  `autovacuum_analyze_scale_factor=0.01` on them so it stays current.
 
-- New index `nonfungible_token_transfers_chain_id_token_id_idx (chain_id,
-  token_id)` for the positions-history query (`WITH transfers …`, 28k calls at
-  909 ms — the slowest API statement remaining), whose `emitter = $3 OR
-  nlm.locker = $4` predicate cannot use the existing `(chain_id, emitter,
-  token_id, …)` index.
+  `ANALYZE` alone repairs the plan: with current statistics the existing
+  `(chain_id, emitter, token_id, …)` index serves `chain_id + token_id` by skip
+  scan. An extra `(chain_id, token_id)` index was tried in review and dropped —
+  it saved ~14 buffers a call against the skip scan and nothing at all under
+  stale statistics, the actual failure mode. The hourly tables are deliberately
+  not on the list; they autoanalyze every few days at the default threshold.
 
-Deploy: `ANALYZE` and reloption changes take `SHARE UPDATE EXCLUSIVE` and do
-not block the workers. The `CREATE INDEX` does block inserts into
-`nonfungible_token_transfers` for the seconds it takes to build over ~3M rows
-and is placed first, while the transaction holds nothing else, so it cannot
-deadlock with a worker. No `LOCK TABLE blocks`. Expect the migration to run
-for about a minute, most of it the `ANALYZE` of `swaps` and `computed_rewards`.
+Deploy: `ANALYZE` and reloption changes take `SHARE UPDATE EXCLUSIVE`, which
+does not conflict with the workers' writes, so this migration holds nothing a
+worker can wait on and needs no `LOCK TABLE blocks`. It runs in seconds.
 
 ### 2026-09-05: Index `generated_drop_proof` for the claims endpoint
 

--- a/migrations/00125_price_source_bloat_and_stale_stats/index.sql
+++ b/migrations/00125_price_source_bloat_and_stale_stats/index.sql
@@ -1,29 +1,45 @@
--- Three findings from the I/O sweep after 00124, measured on ekubo-db-nyc1 on
+-- Two findings from the I/O sweep after 00124, measured on ekubo-db-nyc1 on
 -- 2026-09-05 (cumulative counters since the 08-25 restart; live figures from a
--- 5-minute pg_statio delta).
+-- 5-minute pg_statio delta). This migration takes no lock that conflicts with
+-- the workers: ALTER TABLE ... SET (reloptions) and ANALYZE take SHARE UPDATE
+-- EXCLUSIVE, which is compatible with their ROW EXCLUSIVE writes. It is also
+-- why there is no LOCK TABLE blocks here -- that pattern is for DDL that would
+-- otherwise queue against a worker mid-transaction.
 --
 -- 1. erc20_tokens_latest_price_by_source is the largest live source of disk
 --    I/O on the instance: 1,031 MB read from disk in five minutes (~300 GB/day)
---    through 73,538 index scans. It holds 17,223 live rows in 978 MB -- 91,076
---    dead tuples, 85% of the table -- after 87M updates at 50% HOT with 16,648
---    autovacuum runs that never caught up. 00119 gave erc20_tokens_latest_price
---    fillfactor + an aggressive scale factor; this table, which the price sync
---    writes just as hard, got nothing. Every recompute_erc20_token_latest_price
---    (138 calls/s) walks its token's rows through pages that are mostly dead
---    tuples, and that cost is what shows up as 39k buffers per call on the
---    INSERT INTO erc20_tokens_usd_prices batches that fire it.
+--    through 73,538 index scans. It holds 17,223 live rows in 978 MB (594 MB
+--    heap, 384 MB index), i.e. ~6 MB of live data. Every
+--    recompute_erc20_token_latest_price (138 calls/s) walks its token's rows
+--    through pages that are almost entirely dead tuples, and that cost is
+--    what shows up as 39k buffers per call on the INSERT INTO
+--    erc20_tokens_usd_prices batches that fire it.
 --
---    The reloptions below stop the bloat from coming back; they do not remove
---    what is there, because fillfactor only applies to pages written after a
---    rewrite and a smaller scale factor makes autovacuum reclaim space in
---    place, never shrink the heap. The one-time repack is an operator step
---    (VACUUM FULL cannot run inside this migration's transaction) -- see the
---    README changelog. At 17k live rows it takes seconds.
+--    Where the bloat came from matters for what fixes it. Autovacuum is not
+--    behind on this table -- it fires on essentially every naptime (17,457
+--    runs in 17,555 minutes) and dead tuples sit at a minute or two of
+--    updates. The heap is the residue of the 2026-09-01 incident 00119
+--    describes: a worker blocked 22 hours inside pg_advisory_lock pinned the
+--    vacuum horizon, and at ~90 updates/s that is ~7M dead tuples vacuum could
+--    not remove until the session ended -- roughly the heap size measured.
+--    Vacuum reclaims that space in place; nothing shrinks the heap except a
+--    rewrite, which is the operator step in the README (pg_repack, not VACUUM
+--    FULL: the latter takes ACCESS EXCLUSIVE and freezes the price sync's
+--    reads as well as its writes).
 --
--- 2. Planner statistics on the big event tables are months out of date and
+--    fillfactor = 70 is set here so that, once repacked, updates have room to
+--    stay HOT (the table's only index is its primary key, so they are
+--    eligible). The vacuum scale factor matches the sibling table's setting
+--    from 00119; at this update rate the default threshold is crossed every
+--    naptime anyway, so it changes little -- what would actually prevent a
+--    repeat is not letting a session pin the horizon for a day, i.e.
+--    lock_timeout/statement_timeout on the indexer role and an alert on
+--    age(backend_xmin). That is a separate change.
+--
+-- 2. Planner statistics on four large event tables are months out of date and
 --    autoanalyze will not fix them. Statistics were reset at the 08-25
---    restart, and the default analyze threshold is 10% of the table, which for
---    these tables is hundreds of thousands of rows away:
+--    restart, and the default analyze threshold is 10% of the table -- for
+--    these, hundreds of thousands of rows away:
 --
 --      table                         n_live_tup   actual rows
 --      nonfungible_token_transfers       13,645     3,100,464
@@ -31,37 +47,25 @@
 --      protocol_fees_paid                   426     1,864,404
 --      position_fees_collected            2,251     1,808,361
 --
---    and hourly_volume_by_token / hourly_tvl_delta_by_token / hourly_price_data
---    show 0-1 autovacuum runs ever. The planner consequence is visible in the
---    positions-history query (WITH transfers ..., 28,048 calls at 909 ms, the
---    slowest API statement left): it estimates ONE row for chain_id = 4663 on
---    nonfungible_token_transfers, picks the (chain_id, block_number) index on
---    chain_id alone, and filters millions of rows by token_id. ANALYZE now,
---    and a 1% analyze threshold so it stays current.
+--    The consequence is visible in the positions-history query (WITH
+--    transfers ..., 28,048 calls at 909 ms, the slowest API statement left).
+--    Its predicate is token_id = $1 AND chain_id = $2 AND (emitter = $3 OR
+--    nlm.locker = $4). With current statistics the planner serves that from
+--    the existing (chain_id, emitter, token_id, ...) index -- PostgreSQL 18
+--    skip-scans over emitter -- in a few probes. With stale statistics it
+--    estimates ONE row for the whole chain, picks the (chain_id, block_number)
+--    index on chain_id alone, and filters millions of rows by token_id. ANALYZE
+--    alone repairs the plan; no new index is needed (one was tried and dropped
+--    in review: it saved ~14 buffers a call against the skip scan and nothing
+--    at all under stale statistics, which is the actual failure mode).
 --
--- 3. nonfungible_token_transfers has no index the positions-history query can
---    use. Its predicate is token_id = $1 AND chain_id = $2 AND (emitter = $3
---    OR nlm.locker = $4); the OR reaches into a LEFT JOINed table, so the
---    existing (chain_id, emitter, token_id, ...) index cannot serve it. A token
---    has ~10 transfers, so (chain_id, token_id) turns both of that query's
---    CTEs into a handful of probes.
---
--- Lock notes. ANALYZE and ALTER TABLE ... SET (reloptions) take SHARE UPDATE
--- EXCLUSIVE, which does not conflict with the workers' ROW EXCLUSIVE writes,
--- so they can run against live workers. CREATE INDEX takes SHARE, which does
--- block inserts into nonfungible_token_transfers (workers write it on every
--- position mint/transfer); it therefore goes FIRST, while this transaction
--- holds nothing else -- a worker mid-transaction can only make the index
--- build wait for it to finish, never form a cycle -- and the wait is the
--- ~3M-row build, seconds. No LOCK TABLE blocks: parking every worker for the
--- minute the ANALYZEs take would be a needless stall.
+--    ANALYZE now, and a 1% analyze threshold so it stays current. Only these
+--    four: the hourly_* tables already autoanalyze every few days at the
+--    default threshold, and swaps / computed_rewards had accurate estimates.
 
-CREATE INDEX nonfungible_token_transfers_chain_id_token_id_idx
-    ON nonfungible_token_transfers (chain_id, token_id);
-
--- 1. Stop the price-source table from bloating again.
+-- 1. Price-source table: HOT headroom for after the repack.
 ALTER TABLE erc20_tokens_latest_price_by_source
-    SET (autovacuum_vacuum_scale_factor = 0.01, fillfactor = 70);
+    SET (fillfactor = 70, autovacuum_vacuum_scale_factor = 0.01);
 
 -- 2. Fresh statistics now, and a threshold that keeps them fresh.
 DO
@@ -73,21 +77,11 @@ $$
             'nonfungible_token_transfers',
             'nonfungible_token_owners',
             'protocol_fees_paid',
-            'position_fees_collected',
-            'position_updates',
-            'pool_balance_change',
-            'swaps',
-            'hourly_volume_by_token',
-            'hourly_tvl_delta_by_token',
-            'hourly_price_data',
-            'erc20_tokens_latest_price_by_source'
+            'position_fees_collected'
             ]
             LOOP
                 EXECUTE FORMAT('ALTER TABLE %I SET (autovacuum_analyze_scale_factor = 0.01)', t);
                 EXECUTE FORMAT('ANALYZE %I', t);
             END LOOP;
-
-        ALTER TABLE incentives.computed_rewards SET (autovacuum_analyze_scale_factor = 0.01);
-        ANALYZE incentives.computed_rewards;
     END;
 $$;

--- a/migrations/00125_price_source_bloat_and_stale_stats/index.sql
+++ b/migrations/00125_price_source_bloat_and_stale_stats/index.sql
@@ -1,0 +1,93 @@
+-- Three findings from the I/O sweep after 00124, measured on ekubo-db-nyc1 on
+-- 2026-09-05 (cumulative counters since the 08-25 restart; live figures from a
+-- 5-minute pg_statio delta).
+--
+-- 1. erc20_tokens_latest_price_by_source is the largest live source of disk
+--    I/O on the instance: 1,031 MB read from disk in five minutes (~300 GB/day)
+--    through 73,538 index scans. It holds 17,223 live rows in 978 MB -- 91,076
+--    dead tuples, 85% of the table -- after 87M updates at 50% HOT with 16,648
+--    autovacuum runs that never caught up. 00119 gave erc20_tokens_latest_price
+--    fillfactor + an aggressive scale factor; this table, which the price sync
+--    writes just as hard, got nothing. Every recompute_erc20_token_latest_price
+--    (138 calls/s) walks its token's rows through pages that are mostly dead
+--    tuples, and that cost is what shows up as 39k buffers per call on the
+--    INSERT INTO erc20_tokens_usd_prices batches that fire it.
+--
+--    The reloptions below stop the bloat from coming back; they do not remove
+--    what is there, because fillfactor only applies to pages written after a
+--    rewrite and a smaller scale factor makes autovacuum reclaim space in
+--    place, never shrink the heap. The one-time repack is an operator step
+--    (VACUUM FULL cannot run inside this migration's transaction) -- see the
+--    README changelog. At 17k live rows it takes seconds.
+--
+-- 2. Planner statistics on the big event tables are months out of date and
+--    autoanalyze will not fix them. Statistics were reset at the 08-25
+--    restart, and the default analyze threshold is 10% of the table, which for
+--    these tables is hundreds of thousands of rows away:
+--
+--      table                         n_live_tup   actual rows
+--      nonfungible_token_transfers       13,645     3,100,464
+--      nonfungible_token_owners          10,751     2,347,419
+--      protocol_fees_paid                   426     1,864,404
+--      position_fees_collected            2,251     1,808,361
+--
+--    and hourly_volume_by_token / hourly_tvl_delta_by_token / hourly_price_data
+--    show 0-1 autovacuum runs ever. The planner consequence is visible in the
+--    positions-history query (WITH transfers ..., 28,048 calls at 909 ms, the
+--    slowest API statement left): it estimates ONE row for chain_id = 4663 on
+--    nonfungible_token_transfers, picks the (chain_id, block_number) index on
+--    chain_id alone, and filters millions of rows by token_id. ANALYZE now,
+--    and a 1% analyze threshold so it stays current.
+--
+-- 3. nonfungible_token_transfers has no index the positions-history query can
+--    use. Its predicate is token_id = $1 AND chain_id = $2 AND (emitter = $3
+--    OR nlm.locker = $4); the OR reaches into a LEFT JOINed table, so the
+--    existing (chain_id, emitter, token_id, ...) index cannot serve it. A token
+--    has ~10 transfers, so (chain_id, token_id) turns both of that query's
+--    CTEs into a handful of probes.
+--
+-- Lock notes. ANALYZE and ALTER TABLE ... SET (reloptions) take SHARE UPDATE
+-- EXCLUSIVE, which does not conflict with the workers' ROW EXCLUSIVE writes,
+-- so they can run against live workers. CREATE INDEX takes SHARE, which does
+-- block inserts into nonfungible_token_transfers (workers write it on every
+-- position mint/transfer); it therefore goes FIRST, while this transaction
+-- holds nothing else -- a worker mid-transaction can only make the index
+-- build wait for it to finish, never form a cycle -- and the wait is the
+-- ~3M-row build, seconds. No LOCK TABLE blocks: parking every worker for the
+-- minute the ANALYZEs take would be a needless stall.
+
+CREATE INDEX nonfungible_token_transfers_chain_id_token_id_idx
+    ON nonfungible_token_transfers (chain_id, token_id);
+
+-- 1. Stop the price-source table from bloating again.
+ALTER TABLE erc20_tokens_latest_price_by_source
+    SET (autovacuum_vacuum_scale_factor = 0.01, fillfactor = 70);
+
+-- 2. Fresh statistics now, and a threshold that keeps them fresh.
+DO
+$$
+    DECLARE
+        t TEXT;
+    BEGIN
+        FOREACH t IN ARRAY ARRAY [
+            'nonfungible_token_transfers',
+            'nonfungible_token_owners',
+            'protocol_fees_paid',
+            'position_fees_collected',
+            'position_updates',
+            'pool_balance_change',
+            'swaps',
+            'hourly_volume_by_token',
+            'hourly_tvl_delta_by_token',
+            'hourly_price_data',
+            'erc20_tokens_latest_price_by_source'
+            ]
+            LOOP
+                EXECUTE FORMAT('ALTER TABLE %I SET (autovacuum_analyze_scale_factor = 0.01)', t);
+                EXECUTE FORMAT('ANALYZE %I', t);
+            END LOOP;
+
+        ALTER TABLE incentives.computed_rewards SET (autovacuum_analyze_scale_factor = 0.01);
+        ANALYZE incentives.computed_rewards;
+    END;
+$$;

--- a/tests/migrations/migration-lock-ordering.test.ts
+++ b/tests/migrations/migration-lock-ordering.test.ts
@@ -21,8 +21,15 @@ async function leadingStatements(migration: string) {
     .slice(0, 2);
 }
 
-// Every migration that takes DDL locks on tables the workers write
-// mid-transaction has to park them first. Add to this list when adding one.
+// Every migration that takes a lock conflicting with ROW EXCLUSIVE on a table
+// the workers write mid-transaction -- CREATE INDEX (SHARE), CREATE TRIGGER
+// (SHARE ROW EXCLUSIVE), ALTER TABLE ... ADD COLUMN / DISABLE TRIGGER, DROP,
+// CREATE OR REPLACE VIEW over them -- has to park the workers first. Note that
+// a lock of that kind is held until COMMIT, so "placing it first" does not
+// shorten the stall; only parking makes the ordering safe. ANALYZE and
+// ALTER TABLE ... SET (reloptions) take SHARE UPDATE EXCLUSIVE, which does not
+// conflict with the workers, and migrations consisting only of those (00125)
+// need no lock. Add to this list when adding a conflicting one.
 for (const migration of [
   "00120_incremental_rewards_by_position",
   "00123_pool_last_event_id",

--- a/tests/migrations/price-source-bloat-and-stale-stats.test.ts
+++ b/tests/migrations/price-source-bloat-and-stale-stats.test.ts
@@ -3,69 +3,95 @@ import { createClient, ensureIndexerCursor } from "../helpers/db.js";
 
 type Client = Awaited<ReturnType<typeof createClient>>;
 
-async function reloptions(client: Client, schema: string, table: string) {
+async function reloptions(client: Client, table: string) {
   const { rows } = await client.query<{ reloptions: string[] | null }>(
-    `SELECT c.reloptions FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
-     WHERE n.nspname = $1 AND c.relname = $2 AND c.relkind = 'r'`,
-    [schema, table]
+    `SELECT reloptions FROM pg_class WHERE relname = $1 AND relkind = 'r'`,
+    [table]
   );
   return rows[0]?.reloptions ?? [];
 }
 
-test("the price-source table gets the anti-bloat treatment 00119 gave latest_price", async () => {
+test("the price-source table gets HOT headroom for after its repack", async () => {
   const client = await createClient();
-  const options = await reloptions(client, "public", "erc20_tokens_latest_price_by_source");
-  expect(options).toContain("autovacuum_vacuum_scale_factor=0.01");
+  const options = await reloptions(client, "erc20_tokens_latest_price_by_source");
   expect(options).toContain("fillfactor=70");
+  expect(options).toContain("autovacuum_vacuum_scale_factor=0.01");
 });
 
-test("the big event and hourly tables re-analyze at 1% churn instead of 10%", async () => {
+test("the four stale-statistics tables re-analyze at 1% churn instead of 10%", async () => {
   const client = await createClient();
-  for (const [schema, table] of [
-    ["public", "nonfungible_token_transfers"],
-    ["public", "nonfungible_token_owners"],
-    ["public", "protocol_fees_paid"],
-    ["public", "position_fees_collected"],
-    ["public", "position_updates"],
-    ["public", "pool_balance_change"],
-    ["public", "swaps"],
-    ["public", "hourly_volume_by_token"],
-    ["public", "hourly_tvl_delta_by_token"],
-    ["public", "hourly_price_data"],
-    ["incentives", "computed_rewards"],
-  ] as const) {
-    expect(await reloptions(client, schema, table)).toContain("autovacuum_analyze_scale_factor=0.01");
+  for (const table of [
+    "nonfungible_token_transfers",
+    "nonfungible_token_owners",
+    "protocol_fees_paid",
+    "position_fees_collected",
+  ]) {
+    expect(await reloptions(client, table)).toContain("autovacuum_analyze_scale_factor=0.01");
+  }
+  // Deliberately not on the list: they autoanalyze at the default threshold
+  // every few days already, and a 1% threshold would just re-sample them.
+  for (const table of ["hourly_price_data", "hourly_volume_by_token", "swaps"]) {
+    expect(await reloptions(client, table)).not.toContain("autovacuum_analyze_scale_factor=0.01");
   }
 });
 
-test("the positions-history lookup by token is an index probe, not a scan of the chain", async () => {
-  const client = await createClient();
-  await ensureIndexerCursor(client, 7);
-
-  // 40,000 transfers on one chain, ~10 per token, the shape production has.
+async function seedTransfers(client: Client, chainId: number) {
+  await ensureIndexerCursor(client, chainId);
   await client.query(
     `INSERT INTO blocks (chain_id, block_number, block_hash, block_time, num_events)
-     SELECT 7, b, b, '2024-01-01T00:00:00Z'::timestamptz + (b || ' seconds')::interval, 1
-     FROM generate_series(1, 4000) b`
+     SELECT $1::bigint, b, $1::bigint * 100000 + b, '2024-01-01T00:00:00Z'::timestamptz + (b || ' seconds')::interval, 1
+     FROM generate_series(1, 4000) b`,
+    [chainId]
   );
+  // (block_number, transaction_index) is unique per i, so the generated
+  // event_id primary key never collides; token_id repeats every 4000 rows,
+  // giving ~10 transfers per token. Two emitters, so the planner has something
+  // to skip over.
   await client.query(
     `INSERT INTO nonfungible_token_transfers
        (chain_id, block_number, transaction_index, event_index, transaction_hash, emitter, token_id, from_address, to_address)
-     -- (block_number, transaction_index) is unique per i, so the generated
-     -- event_id primary key never collides; token_id repeats every 4000 rows,
-     -- giving ~10 transfers per token.
-     SELECT 7, (i % 4000) + 1, i / 4000, 0, i, 999, (i % 4000) + 1, i, i + 1
-     FROM generate_series(0, 39999) i`
+     SELECT $1::bigint, (i % 4000) + 1, i / 4000, 0, $1::bigint * 1000000 + i, 900 + (i % 2), (i % 4000) + 1, i, i + 1
+     FROM generate_series(0, 39999) i`,
+    [chainId]
   );
-  await client.query(`ANALYZE nonfungible_token_transfers`);
+}
 
-  const { rows } = await client.query<{ "QUERY PLAN": string }>(
-    `EXPLAIN SELECT nft.transaction_hash, nft.block_number
-     FROM nonfungible_token_transfers nft
-     LEFT JOIN nft_locker_mappings nlm ON nlm.nft_address = nft.emitter AND nlm.chain_id = nft.chain_id
-     WHERE nft.token_id = 1234 AND nft.chain_id = 7 AND (nft.emitter = 999 OR nlm.locker = 999)`
-  );
-  const plan = rows.map((r) => r["QUERY PLAN"]).join("\n");
-  expect(plan).toContain("nonfungible_token_transfers_chain_id_token_id_idx");
-  expect(plan).not.toMatch(/Seq Scan on nonfungible_token_transfers/);
+function transfersRowEstimate(plan: string) {
+  const m = plan.match(/on nonfungible_token_transfers nft\s+\(cost=[^ ]+ rows=(\d+)/);
+  return m ? Number(m[1]) : null;
+}
+
+const POSITIONS_HISTORY_LOOKUP = `
+  EXPLAIN SELECT nft.transaction_hash, nft.block_number
+  FROM nonfungible_token_transfers nft
+  LEFT JOIN nft_locker_mappings nlm ON nlm.nft_address = nft.emitter AND nlm.chain_id = nft.chain_id
+  WHERE nft.token_id = 1234 AND nft.chain_id = 7 AND (nft.emitter = 900 OR nlm.locker = 900)`;
+
+async function plan(client: Client) {
+  const { rows } = await client.query<{ "QUERY PLAN": string }>(POSITIONS_HISTORY_LOOKUP);
+  return rows.map((r) => r["QUERY PLAN"]).join("\n");
+}
+
+test("stale statistics, not a missing index, are what made the positions-history lookup scan a chain", async () => {
+  const client = await createClient();
+
+  // Production's failure mode: statistics gathered before a chain existed,
+  // then that chain's rows arrive. Statistics are present (another chain's),
+  // so the planner trusts them and estimates ONE row for the new chain --
+  // which makes an index on chain_id alone look free, and token_id a filter.
+  await seedTransfers(client, 8);
+  await client.query(`ANALYZE nonfungible_token_transfers`);
+  await seedTransfers(client, 7);
+  expect(transfersRowEstimate(await plan(client))).toBe(1);
+
+  // ANALYZE alone repairs it: the estimate becomes the real ~10 transfers per
+  // token, and the existing (chain_id, emitter, token_id, ...) index serves
+  // chain_id + token_id by skip scan, with token_id in the index condition
+  // rather than a filter over the chain.
+  await client.query(`ANALYZE nonfungible_token_transfers`);
+  const fresh = await plan(client);
+  expect(transfersRowEstimate(fresh)).toBeGreaterThanOrEqual(5);
+  expect(fresh).toContain("nonfungible_token_transfers_chain_id_emitter_token_id_event_idx");
+  expect(fresh).toMatch(/Index Cond:.*token_id = '?1234/);
+  expect(fresh).not.toContain("idx_nonfungible_token_transfers_chain_block");
 });

--- a/tests/migrations/price-source-bloat-and-stale-stats.test.ts
+++ b/tests/migrations/price-source-bloat-and-stale-stats.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test";
+import { createClient, ensureIndexerCursor } from "../helpers/db.js";
+
+type Client = Awaited<ReturnType<typeof createClient>>;
+
+async function reloptions(client: Client, schema: string, table: string) {
+  const { rows } = await client.query<{ reloptions: string[] | null }>(
+    `SELECT c.reloptions FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = $1 AND c.relname = $2 AND c.relkind = 'r'`,
+    [schema, table]
+  );
+  return rows[0]?.reloptions ?? [];
+}
+
+test("the price-source table gets the anti-bloat treatment 00119 gave latest_price", async () => {
+  const client = await createClient();
+  const options = await reloptions(client, "public", "erc20_tokens_latest_price_by_source");
+  expect(options).toContain("autovacuum_vacuum_scale_factor=0.01");
+  expect(options).toContain("fillfactor=70");
+});
+
+test("the big event and hourly tables re-analyze at 1% churn instead of 10%", async () => {
+  const client = await createClient();
+  for (const [schema, table] of [
+    ["public", "nonfungible_token_transfers"],
+    ["public", "nonfungible_token_owners"],
+    ["public", "protocol_fees_paid"],
+    ["public", "position_fees_collected"],
+    ["public", "position_updates"],
+    ["public", "pool_balance_change"],
+    ["public", "swaps"],
+    ["public", "hourly_volume_by_token"],
+    ["public", "hourly_tvl_delta_by_token"],
+    ["public", "hourly_price_data"],
+    ["incentives", "computed_rewards"],
+  ] as const) {
+    expect(await reloptions(client, schema, table)).toContain("autovacuum_analyze_scale_factor=0.01");
+  }
+});
+
+test("the positions-history lookup by token is an index probe, not a scan of the chain", async () => {
+  const client = await createClient();
+  await ensureIndexerCursor(client, 7);
+
+  // 40,000 transfers on one chain, ~10 per token, the shape production has.
+  await client.query(
+    `INSERT INTO blocks (chain_id, block_number, block_hash, block_time, num_events)
+     SELECT 7, b, b, '2024-01-01T00:00:00Z'::timestamptz + (b || ' seconds')::interval, 1
+     FROM generate_series(1, 4000) b`
+  );
+  await client.query(
+    `INSERT INTO nonfungible_token_transfers
+       (chain_id, block_number, transaction_index, event_index, transaction_hash, emitter, token_id, from_address, to_address)
+     -- (block_number, transaction_index) is unique per i, so the generated
+     -- event_id primary key never collides; token_id repeats every 4000 rows,
+     -- giving ~10 transfers per token.
+     SELECT 7, (i % 4000) + 1, i / 4000, 0, i, 999, (i % 4000) + 1, i, i + 1
+     FROM generate_series(0, 39999) i`
+  );
+  await client.query(`ANALYZE nonfungible_token_transfers`);
+
+  const { rows } = await client.query<{ "QUERY PLAN": string }>(
+    `EXPLAIN SELECT nft.transaction_hash, nft.block_number
+     FROM nonfungible_token_transfers nft
+     LEFT JOIN nft_locker_mappings nlm ON nlm.nft_address = nft.emitter AND nlm.chain_id = nft.chain_id
+     WHERE nft.token_id = 1234 AND nft.chain_id = 7 AND (nft.emitter = 999 OR nlm.locker = 999)`
+  );
+  const plan = rows.map((r) => r["QUERY PLAN"]).join("\n");
+  expect(plan).toContain("nonfungible_token_transfers_chain_id_token_id_idx");
+  expect(plan).not.toMatch(/Seq Scan on nonfungible_token_transfers/);
+});


### PR DESCRIPTION
Two of the low-effort items from the I/O sweep that followed #175 (a 5-minute `pg_statio` delta plus the cumulative counters since 08-25). One migration, `00125_price_source_bloat_and_stale_stats` — reloptions and `ANALYZE` only, **no lock that conflicts with the workers** — plus one documented operator step.

The first commit also added a `(chain_id, token_id)` index on `nonfungible_token_transfers` and claimed autovacuum had fallen behind on the price-source table; review disproved both, and the second commit takes every finding. Details at the end.

## 1. `erc20_tokens_latest_price_by_source` is the largest live source of disk reads

| | |
|---|---|
| disk reads, 5-minute window | **1,031 MB** (~300 GB/day) via 73,538 index scans |
| size | **978 MB** (594 MB heap + 384 MB index) for **17,223 live rows** — ~6 MB of data |

Every `recompute_erc20_token_latest_price` (138/s) walks its token's rows through pages that are almost entirely dead tuples; that is also what shows up as 39k buffers per call on the `INSERT INTO erc20_tokens_usd_prices` batches that fire it.

**Where it came from matters for what fixes it.** Autovacuum is not behind — it fires on essentially every naptime (17,457 runs in 17,555 minutes) and dead tuples sit at a minute or two of updates. The heap is the residue of the 2026-09-01 incident 00119 describes: a worker blocked 22 hours in `pg_advisory_lock` pinned the vacuum horizon, and at ~90 updates/s that is ~7M dead tuples vacuum couldn't remove until the session ended. Vacuum reclaims in place; only a rewrite shrinks the heap.

The migration sets `fillfactor=70` (HOT headroom after the repack — the table's only index is its PK, so updates are HOT-eligible) and `autovacuum_vacuum_scale_factor=0.01` (parity with the sibling table; at this update rate it changes little). Neither prevents a repeat — that needs `lock_timeout`/`statement_timeout` on the indexer role and an alert on `age(backend_xmin)`, a separate change.

**Operator step after deploy — rewrite the table once.** Preferred: `pg_repack -d defaultdb -t erc20_tokens_latest_price_by_source` (1.5.2 is available on the instance; needs `CREATE EXTENSION pg_repack` and a matching local client). Fallback: `VACUUM (FULL, ANALYZE)` — seconds at 17k live rows, but `ACCESS EXCLUSIVE` blocks the price sync's **reads** as well as writes and nothing in `src/price-sync` retries a failed cycle, so set `lock_timeout = '10s'` and run outside :00–:02 (the hourly prune holds the table's trigger path). Expect ~978 MB → a few MB and the table's disk reads to go flat.

## 2. Planner statistics on four large event tables are months stale

Statistics were reset at the 08-25 restart and the default 10% analyze threshold won't re-fire for months:

| table | `n_live_tup` | actual rows |
|---|---|---|
| `nonfungible_token_transfers` | 13,645 | **3,100,464** |
| `nonfungible_token_owners` | 10,751 | 2,347,419 |
| `protocol_fees_paid` | 426 | 1,864,404 |
| `position_fees_collected` | 2,251 | 1,808,361 |

The consequence is the positions-history query (`WITH transfers …`, **28,048 calls at 909 ms** — the slowest API statement left): with current statistics the planner serves `chain_id = X AND token_id = Y` from the existing `(chain_id, emitter, token_id, …)` index by skip scan in a few probes; with stale statistics it estimates **one row** for the whole chain, picks the `(chain_id, block_number)` index on `chain_id` alone, and filters millions of rows by `token_id`. `ANALYZE` alone repairs it.

The migration runs `ANALYZE` on those four and sets `autovacuum_analyze_scale_factor=0.01` on them so it stays current. Only those four: the hourly tables already autoanalyze every 3–4 days at the default threshold (0–1 *vacuum* runs was the healthy HOT steady state, not staleness), and `swaps`/`computed_rewards` had accurate estimates.

## Locks

`ANALYZE` and `ALTER TABLE … SET (reloptions)` take `SHARE UPDATE EXCLUSIVE`, which does not conflict with the workers' `ROW EXCLUSIVE`, so the migration holds nothing a worker can wait on; no `LOCK TABLE blocks`; seconds to run.

## What review changed (second commit)

- **Dropped the `(chain_id, token_id)` index.** Measured in PGlite (PG 18.3, same skip-scan behaviour as prod's 18.6): the existing index serves the predicate with `token_id` in the index condition; the new one saved ~14 buffers a call and nothing at all under stale statistics. Not worth another index on a worker-written table — and dropping it is what makes the migration lock-free for the workers, retiring three further findings (the `SHARE` lock is held until `COMMIT`, not "for the build"; no `lock_timeout`; the lock-ordering rule's unwritten carve-out).
- **Bloat cause corrected** (the 09-01 horizon pin, not autovacuum), and the "prevents recurrence" claim removed.
- **Repack step corrected**: `pg_repack` first; `VACUUM FULL`'s real cost stated.
- **`ANALYZE` list trimmed** to the four evidenced tables; hourly tables and `computed_rewards` removed (the 1% threshold there would first fire in ~5 years).
- **00119 misattribution fixed**: `erc20_tokens_latest_price` got `fillfactor=80`; 70 went to `pool_states`/`pool_tvl`.
- **Test reproduces the actual defect**: statistics gathered before a chain existed → `rows=1` for that chain; after `ANALYZE` → `rows=10`, skip-scan index, `token_id` in the index condition, no chain-only index. The lock-ordering rule comment now states precisely which locks require parking and that placement doesn't shorten a held-until-commit lock.

## Validation

`bun test` 316 pass; lint clean.

## After deploy (measured 2026-09-06)

Merged `16c5414` 15:42:59 UTC; migration applied 15:47:28 (`ANALYZE` on the four tables took ~6 s); DO deployment `c88dca79` ACTIVE 15:48:25. Repack via the `VACUUM (FULL, ANALYZE)` fallback with `lock_timeout = '10s'` at 15:47:52 — **one second**; the price sync's newest row was 1.8 s old immediately after, 8,908 prices updated in the following two minutes.

| | before | after |
|---|---|---|
| `erc20_tokens_latest_price_by_source` size | 978 MB (594 MB heap), 17,223 live / ~91k dead | **5.2 MB** (3.2 MB heap), 17,272 live / 17 dead |
| its disk reads, 5-minute window | ~1,031 MB | **0.0 MB** |
| `nonfungible_token_transfers` statistics | `n_live_tup` 13,869, never analyzed | 3,100,209, analyzed 15:47:22 |
| positions-history plan (`WITH transfers …`) | chain-only index, `token_id` as a filter | `Index Cond: (chain_id = 4663 AND token_id = …)` on the existing emitter/token index |
| its mean per call (5-minute window, 3 calls) | 909 ms | **2.7 ms**, 4 disk blocks |

The endpoint is low-traffic, so the after-window has few calls; the plan is the structural evidence.

https://claude.ai/code/session_01EafuJ5i85zz2wqaNQidE3F
