### PR TITLE
Market depth refresh: fence the median subquery, linearise the tick math

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,11 @@ this needed already existed from 00118.
   one-hour window. Against that estimate a hash join over a sequential scan of
   all 46M swaps beats 5,000 index probes, and that is what it picked: ~20 s and
   ~11 GB read from disk per refresh, 96 times a day, roughly a terabyte.
-  Forcing the index with `enable_seqscan = off` makes it *worse* (measured: ran
-  past 170 s) because the flattened shape re-probes per output row. `OFFSET 0`
-  is the fix — the standard optimisation fence, no semantic change. That step
-  now runs in 0.29 s entirely from cache.
+  Forcing the index with `enable_seqscan = off` does not help either: measured,
+  it ran past 170 s and the statement timeout cut it off before the plan could
+  be captured. The estimate is what is wrong, so `OFFSET 0` is the fix — the
+  standard optimisation fence, no semantic change. That step now runs in 0.29 s
+  entirely from cache.
 
 - **The tick math was quadratic in disguise.** Every `(pool, depth)` pair
   intersected the depth band against every one of the pool's tick segments (the

--- a/README.md
+++ b/README.md
@@ -169,6 +169,67 @@ This log records indexer deployments that:
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
 
+### 2026-09-06: Market depth refresh, 25 s → 10 s, and a 10-minute schedule
+
+**`00126_faster_pool_market_depth`. Redefines `pool_market_depth_view` and
+reschedules its cron job. Same columns, same values, no consumer changes.**
+
+`refresh_pool_market_depth` was the most expensive job left on the instance:
+25.1 s average over 24 hours (35.5 s over 7 days, max 169.7 s), every 15
+minutes. Two independent causes, neither of them a missing index — the index
+this needed already existed from 00118.
+
+- **The median-tick step read the whole `swaps` table.** Its `LATERAL`
+  subquery had no `LIMIT`/`OFFSET`, so the planner pulled it up into a plain
+  join, lost the per-pool correlation, and estimated ~513k rows per pool for a
+  one-hour window. Against that estimate a hash join over a sequential scan of
+  all 46M swaps beats 5,000 index probes, and that is what it picked: ~20 s and
+  ~11 GB read from disk per refresh, 96 times a day, roughly a terabyte.
+  Forcing the index with `enable_seqscan = off` makes it *worse* (measured: ran
+  past 170 s) because the flattened shape re-probes per output row. `OFFSET 0`
+  is the fix — the standard optimisation fence, no semantic change. That step
+  now runs in 0.29 s entirely from cache.
+
+- **The tick math was quadratic in disguise.** Every `(pool, depth)` pair
+  intersected the depth band against every one of the pool's tick segments (the
+  largest pool has 1,763), so a pool cost `ticks × 41` range intersections. It
+  is now one ordered pass per pool: prefix sums of each segment's token
+  amounts, and a band's amount is the difference of the cumulative value at its
+  two edges. The largest pool goes from 1,689 ms to 93 ms.
+
+The rewrite is **exact, not approximate**. `NUMERIC` `+ - *` are
+arbitrary-precision and lossless; the only rounding is inside `POWER()` and the
+`1/p` divisions, and both definitions evaluate those at the same tick values,
+so the reassociated sums agree digit for digit. Verified two ways: on
+production, both definitions in a single snapshot returned the same 69,150 rows
+with zero differing values (24.5 s → 10.0 s); and in
+`tests/migrations/faster-pool-market-depth.test.ts`, which snapshots the old
+view's output, applies the migration, and asserts strict equality over a
+fixture covering bands inside the tick range, bands running off both ends, a
+pool whose liquidity returns to zero mid-range, a pool priced from
+`pool_states` because it never swapped, a pool with no ticks, and a pool whose
+fee is wider than the tightest bands.
+
+Watch for one trap if this is ever touched again: deriving the band edge prices
+as `p(last) × p(offset)` via exponent laws is one extra rounding step and
+drifts ~1e-12 relative. Each edge price is computed directly from its own tick.
+
+**Schedule.** The `REFRESH … CONCURRENTLY` diff costs ~0.19 s on top of
+computing the view, so a run goes 25.1 s → ~10.5 s. The job moves from every 15
+minutes to every **10**: 1,512 s/day against today's 2,410, a 37% cut, while
+the worst-case lag between a liquidity change and the pools table drops from 25
+minutes to 20 (the API's own 600 s cache is the other half of that). Every 5
+minutes was considered and not taken — it would cost ~3,000 s/day, *more* than
+today, for a further 5 minutes. It is a one-token change in the migration's
+`DO` block if that trade is wanted later.
+
+Deploy: `CREATE OR REPLACE VIEW` takes `ACCESS EXCLUSIVE` on the view alone and
+only `ACCESS SHARE` on the tables it reads, so unlike 00120 and 00123 it holds
+nothing the workers can wait on and needs no `LOCK TABLE blocks`. The one lock
+it can wait behind is a cron refresh already reading the view, hence the
+15-minute `lock_timeout`. The migration does not refresh the matview; the next
+cron run picks up the new definition.
+
 ### 2026-09-06: Price-source bloat and stale statistics
 
 **`00125_price_source_bloat_and_stale_stats`. Reloptions and `ANALYZE` only —

--- a/migrations/00126_faster_pool_market_depth/index.sql
+++ b/migrations/00126_faster_pool_market_depth/index.sql
@@ -9,10 +9,11 @@
 --    window. Against that estimate a hash join over a sequential scan of all
 --    46M swaps beats 5,000 index probes, so that is what it chose: ~20 s and
 --    ~11 GB of buffer reads per refresh, 96 times a day. Forcing the index with
---    enable_seqscan = off does NOT fix it -- measured, it ran past 170 s,
---    because the flattened shape re-probes per output row. The fix is to stop
---    the pull-up: OFFSET 0 is the standard optimisation fence and changes no
---    semantics. Measured on production, read-only: the median-tick step goes
+--    enable_seqscan = off does NOT fix it -- measured, it ran past 170 s and
+--    the statement timeout cut it off (the plan it picked instead was not
+--    captured). The estimate is the problem, so the fix is to stop the pull-up:
+--    OFFSET 0 is the standard optimisation fence and changes no semantics.
+--    Measured on production, read-only: the median-tick step goes
 --    from ~20 s to 0.29 s, and the refresh as a whole from 35 s to 14 s.
 --    The ORDER BY block_time DESC in that subquery is dropped with it; it never
 --    meant anything to PERCENTILE_CONT and only invited a sort.
@@ -43,7 +44,8 @@
 -- takes ACCESS EXCLUSIVE on the view alone and only ACCESS SHARE on the tables
 -- it reads, which does not conflict with the workers' ROW EXCLUSIVE. The one
 -- lock this can wait on is a concurrent cron refresh reading the view, hence
--- the bounded lock_timeout; the deploy is retried rather than left hanging.
+-- the bounded lock_timeout: past it the migration fails, App Platform rolls the
+-- deploy back, and it is re-run by hand rather than left hanging.
 SET LOCAL lock_timeout = '15min';
 
 CREATE OR REPLACE VIEW pool_market_depth_view AS
@@ -110,10 +112,18 @@ WITH depth_percentages AS (SELECT (POWER(1.21, GENERATE_SERIES(0, 40)) * 0.00005
                            t.tick,
                            t.net_liquidity_delta_diff                            AS delta,
                            SUM(t.net_liquidity_delta_diff) OVER w                AS liquidity,
-                           POWER(1.0000005::NUMERIC, t.tick)                     AS price,
-                           LAG(POWER(1.0000005::NUMERIC, t.tick)) OVER w         AS previous_price
+                           POWER(1.0000005::NUMERIC, t.tick)                     AS price
                     FROM per_pool_per_tick_liquidity t
                     WINDOW w AS (PARTITION BY t.pool_key_id ORDER BY t.tick ROWS UNBOUNDED PRECEDING)),
+     -- One POWER() per tick: the previous boundary's price is read off the
+     -- previous row rather than raised again.
+     pool_ticks_spanned AS (SELECT pool_key_id,
+                                   tick,
+                                   delta,
+                                   liquidity,
+                                   price,
+                                   LAG(price) OVER (PARTITION BY pool_key_id ORDER BY tick) AS previous_price
+                            FROM pool_ticks),
      -- Cumulative token amounts held below each tick boundary.
      pool_ticks_cumulative AS (SELECT pool_key_id,
                                       tick,
@@ -128,7 +138,7 @@ WITH depth_percentages AS (SELECT (POWER(1.21, GENERATE_SERIES(0, 40)) * 0.00005
                                               ELSE (liquidity - delta) *
                                                    (1::NUMERIC / previous_price - 1::NUMERIC / price)
                                           END) OVER w AS cumulative0
-                               FROM pool_ticks
+                               FROM pool_ticks_spanned
                                WINDOW w AS (PARTITION BY pool_key_id ORDER BY tick ROWS UNBOUNDED PRECEDING)),
      -- Interleave the edges with the tick boundaries so each edge can read the
      -- cumulative state of the last boundary at or before it. is_edge breaks the

--- a/migrations/00126_faster_pool_market_depth/index.sql
+++ b/migrations/00126_faster_pool_market_depth/index.sql
@@ -1,0 +1,228 @@
+-- pool_market_depth_materialized is refreshed by pg_cron and its runs averaged
+-- 35.5 s over the 7 days to 2026-09-06 (max 169.7 s). Two independent problems,
+-- both fixed here without adding an index -- the index this needs already
+-- exists (swaps_pool_key_id_block_time_ohlc_idx, added in 00118).
+--
+-- 1. The median-tick step read the whole swaps table. Its LATERAL subquery had
+--    no LIMIT/OFFSET, so the planner pulled it up into a plain join, lost the
+--    per-pool correlation, and estimated ~513k rows per pool for the one-hour
+--    window. Against that estimate a hash join over a sequential scan of all
+--    46M swaps beats 5,000 index probes, so that is what it chose: ~20 s and
+--    ~11 GB of buffer reads per refresh, 96 times a day. Forcing the index with
+--    enable_seqscan = off does NOT fix it -- measured, it ran past 170 s,
+--    because the flattened shape re-probes per output row. The fix is to stop
+--    the pull-up: OFFSET 0 is the standard optimisation fence and changes no
+--    semantics. Measured on production, read-only: the median-tick step goes
+--    from ~20 s to 0.29 s, and the refresh as a whole from 35 s to 14 s.
+--    The ORDER BY block_time DESC in that subquery is dropped with it; it never
+--    meant anything to PERCENTILE_CONT and only invited a sort.
+--
+-- 2. The tick math was quadratic in disguise. For every (pool, depth) pair it
+--    intersected the depth band with every one of the pool's tick segments --
+--    the largest pool has 1,763 -- so a pool cost ticks x 41 range
+--    intersections. Rewritten here as one ordered pass per pool: prefix sums of
+--    each segment's token amounts, then each depth band's amount is the
+--    difference of the cumulative value at its two edges. The biggest pool goes
+--    from 1,689 ms to 93 ms, and the whole refresh from 14 s to 10 s.
+--
+-- Measured end to end on production against the deployed definition, in one
+-- snapshot so both saw identical data: 24.5 s -> 10.0 s for the same 69,150
+-- rows, every value identical.
+--
+-- The rewrite is exact, not approximate. NUMERIC + - * are arbitrary-precision
+-- and lossless; the only rounding is inside POWER() and the 1/p divisions, and
+-- both definitions evaluate those at exactly the same tick values, so the
+-- reassociated sums agree bit for bit. That is asserted against the old
+-- definition in tests/migrations/faster-pool-market-depth.test.ts and was
+-- verified row by row against production before this shipped. (An earlier draft
+-- derived the edge prices as p(last) * p(offset) via exponent laws; that is one
+-- extra rounding step and drifted ~1e-12 relative, so each edge price is
+-- computed directly from its own tick instead.)
+--
+-- No LOCK TABLE blocks preamble, unlike 00120 and 00123: CREATE OR REPLACE VIEW
+-- takes ACCESS EXCLUSIVE on the view alone and only ACCESS SHARE on the tables
+-- it reads, which does not conflict with the workers' ROW EXCLUSIVE. The one
+-- lock this can wait on is a concurrent cron refresh reading the view, hence
+-- the bounded lock_timeout; the deploy is retried rather than left hanging.
+SET LOCAL lock_timeout = '15min';
+
+CREATE OR REPLACE VIEW pool_market_depth_view AS
+WITH depth_percentages AS (SELECT (POWER(1.21, GENERATE_SERIES(0, 40)) * 0.00005)::FLOAT AS depth_percent),
+     depth_bands AS (SELECT depth_percent,
+                            FLOOR(LN(1::NUMERIC + depth_percent) / LN(1.000001))::INT4 AS depth_in_ticks
+                     FROM depth_percentages),
+     -- The most recent swap that left the pool with liquidity, per pool. Already
+     -- fenced by its own LIMIT 1, and served by swaps (pool_key_id, event_id).
+     last_pool_swaps AS (SELECT pk.pool_key_id,
+                                ls.block_time
+                         FROM pool_keys pk
+                                  LEFT JOIN LATERAL (
+                             SELECT s.block_time
+                             FROM swaps s
+                             WHERE s.pool_key_id = pk.pool_key_id
+                               AND s.liquidity_after <> 0
+                             ORDER BY s.event_id DESC
+                             LIMIT 1
+                             ) ls ON TRUE),
+     -- Median tick over the hour ending at that swap. OFFSET 0 keeps this
+     -- correlated so it can use swaps (pool_key_id, block_time).
+     median_ticks AS (SELECT lps.pool_key_id,
+                             PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY s.tick_after) AS median_tick
+                      FROM last_pool_swaps lps
+                               JOIN LATERAL (
+                          SELECT s.tick_after
+                          FROM swaps s
+                          WHERE s.pool_key_id = lps.pool_key_id
+                            AND s.block_time BETWEEN (lps.block_time - INTERVAL '1 hour') AND lps.block_time
+                            AND s.liquidity_after <> 0
+                          OFFSET 0
+                          ) s ON TRUE
+                      WHERE lps.block_time IS NOT NULL
+                      GROUP BY lps.pool_key_id),
+     pool_params AS (SELECT pk.pool_key_id,
+                            COALESCE(ROUND(mt.median_tick)::INT4, ps.tick)                              AS last_tick,
+                            CEIL(LOG(1::NUMERIC + (pk.fee / pk.fee_denominator)) / LOG(1.000001))::INT4 AS fee_in_ticks
+                     FROM pool_keys pk
+                              LEFT JOIN pool_states ps ON ps.pool_key_id = pk.pool_key_id
+                              LEFT JOIN median_ticks mt ON mt.pool_key_id = pk.pool_key_id),
+     -- Four edges per (pool, depth): the band below the current tick holds
+     -- token1, the band above holds token0, and both start one fee width out.
+     band_edges AS (SELECT pp.pool_key_id,
+                           db.depth_percent,
+                           e.side,
+                           e.edge,
+                           POWER(1.0000005::NUMERIC, e.tick) AS edge_price,
+                           e.tick
+                    FROM pool_params pp
+                             CROSS JOIN depth_bands db
+                             CROSS JOIN LATERAL (
+                        VALUES ('below', 'lo', pp.last_tick - db.depth_in_ticks),
+                               ('below', 'hi', pp.last_tick - pp.fee_in_ticks),
+                               ('above', 'lo', pp.last_tick + pp.fee_in_ticks),
+                               ('above', 'hi', pp.last_tick + db.depth_in_ticks)
+                        ) AS e(side, edge, tick)
+                    WHERE pp.last_tick IS NOT NULL
+                      AND pp.fee_in_ticks < db.depth_in_ticks),
+     -- One ordered pass per pool. liquidity is what is active in
+     -- [tick, next tick), so liquidity - delta is what was active in
+     -- [previous tick, tick) -- the segment ending at this row.
+     pool_ticks AS (SELECT t.pool_key_id,
+                           t.tick,
+                           t.net_liquidity_delta_diff                            AS delta,
+                           SUM(t.net_liquidity_delta_diff) OVER w                AS liquidity,
+                           POWER(1.0000005::NUMERIC, t.tick)                     AS price,
+                           LAG(POWER(1.0000005::NUMERIC, t.tick)) OVER w         AS previous_price
+                    FROM per_pool_per_tick_liquidity t
+                    WINDOW w AS (PARTITION BY t.pool_key_id ORDER BY t.tick ROWS UNBOUNDED PRECEDING)),
+     -- Cumulative token amounts held below each tick boundary.
+     pool_ticks_cumulative AS (SELECT pool_key_id,
+                                      tick,
+                                      liquidity,
+                                      price,
+                                      SUM(CASE
+                                              WHEN previous_price IS NULL THEN 0
+                                              ELSE (liquidity - delta) * (price - previous_price)
+                                          END) OVER w AS cumulative1,
+                                      SUM(CASE
+                                              WHEN previous_price IS NULL THEN 0
+                                              ELSE (liquidity - delta) *
+                                                   (1::NUMERIC / previous_price - 1::NUMERIC / price)
+                                          END) OVER w AS cumulative0
+                               FROM pool_ticks
+                               WINDOW w AS (PARTITION BY pool_key_id ORDER BY tick ROWS UNBOUNDED PRECEDING)),
+     -- Interleave the edges with the tick boundaries so each edge can read the
+     -- cumulative state of the last boundary at or before it. is_edge breaks the
+     -- tie so an edge sitting exactly on a boundary sees that boundary.
+     edges_and_ticks AS (SELECT pool_key_id, tick, 0 AS is_edge, liquidity, price, cumulative1, cumulative0,
+                                NULL::FLOAT AS depth_percent, NULL::TEXT AS side, NULL::TEXT AS edge,
+                                NULL::NUMERIC AS edge_price
+                         FROM pool_ticks_cumulative
+                         UNION ALL
+                         SELECT pool_key_id, tick, 1, NULL, NULL, NULL, NULL,
+                                depth_percent, side, edge, edge_price
+                         FROM band_edges),
+     segments AS (SELECT *,
+                         SUM(1 - is_edge) OVER (PARTITION BY pool_key_id ORDER BY tick, is_edge
+                             ROWS UNBOUNDED PRECEDING) AS segment
+                  FROM edges_and_ticks),
+     -- Broadcast each boundary's state to the edges that fall after it. An edge
+     -- below a pool's first tick lands in segment 0, which holds no boundary, so
+     -- its cumulative amounts are NULL and COALESCE to zero -- correct, there is
+     -- no liquidity down there.
+     edges_on_segment AS (SELECT pool_key_id, depth_percent, side, edge, edge_price, is_edge,
+                                 MAX(liquidity) OVER s   AS boundary_liquidity,
+                                 MAX(price) OVER s       AS boundary_price,
+                                 MAX(cumulative1) OVER s AS boundary_cumulative1,
+                                 MAX(cumulative0) OVER s AS boundary_cumulative0
+                          FROM segments
+                          WINDOW s AS (PARTITION BY pool_key_id, segment)),
+     edge_amounts AS (SELECT pool_key_id,
+                             depth_percent,
+                             side,
+                             edge,
+                             COALESCE(boundary_cumulative1 +
+                                      boundary_liquidity * (edge_price - boundary_price), 0) AS amount1,
+                             COALESCE(boundary_cumulative0 +
+                                      boundary_liquidity * (1::NUMERIC / boundary_price -
+                                                            1::NUMERIC / edge_price), 0)     AS amount0
+                      FROM edges_on_segment
+                      WHERE is_edge = 1),
+     band_amounts AS (SELECT pool_key_id,
+                             depth_percent,
+                             MAX(amount0) FILTER (WHERE side = 'above' AND edge = 'hi') -
+                             MAX(amount0) FILTER (WHERE side = 'above' AND edge = 'lo') AS amount0,
+                             MAX(amount1) FILTER (WHERE side = 'below' AND edge = 'hi') -
+                             MAX(amount1) FILTER (WHERE side = 'below' AND edge = 'lo') AS amount1
+                      FROM edge_amounts
+                      GROUP BY pool_key_id, depth_percent)
+SELECT pool_key_id,
+       depth_percent,
+       FLOOR(amount0) AS depth0,
+       FLOOR(amount1) AS depth1
+FROM band_amounts
+-- The old definition emitted a row only where a tick segment overlapped the
+-- band, which is exactly the case where at least one side is non-zero.
+WHERE amount0 <> 0
+   OR amount1 <> 0;
+
+-- Cadence. Computing the view is what a run costs; the CONCURRENTLY diff on top
+-- is ~0.19 s, from the mean of its two internal pg_temp statements. So a run
+-- goes from 25.1 s (24 h average) to ~10.5 s, and the job's daily CPU from
+-- 2,410 s to 1,008 s if the schedule is left alone.
+--
+-- Half of that saving is spent on freshness here. Market depth drives the APR
+-- denominators, the depth column and the pool page's depth card, and it lagged
+-- a liquidity change by up to 15 minutes before the API's own 600 s cache; at
+-- every 10 minutes that worst case goes from 25 to 20 minutes and the job still
+-- costs 1,512 s/day, 37% below today. Every 5 minutes would cost ~3,000 s/day,
+-- which is *more* than today (0.87% of the four vCPUs against 0.70%) -- worth
+-- knowing before reaching for it, and a one-token change here.
+--
+-- Buffer traffic falls either way, and that is the bigger win: ~11 GB read from
+-- disk per run becomes ~0.5 GB of cache hits, about a terabyte a day.
+DO
+$$
+    DECLARE
+        has_pg_cron BOOLEAN;
+        job_id      INT;
+    BEGIN
+        SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') INTO has_pg_cron;
+
+        IF NOT has_pg_cron THEN
+            RAISE NOTICE 'pg_cron not installed; skipping market depth refresh reschedule.';
+            RETURN;
+        END IF;
+
+        SELECT jobid INTO job_id FROM cron.job WHERE jobname = 'refresh_pool_market_depth';
+
+        IF job_id IS NOT NULL THEN
+            PERFORM cron.unschedule(job_id);
+        END IF;
+
+        PERFORM cron.schedule(
+                'refresh_pool_market_depth',
+                '*/10 * * * *',
+                'REFRESH MATERIALIZED VIEW CONCURRENTLY pool_market_depth_materialized'
+                );
+    END
+$$;

--- a/tests/migrations/faster-pool-market-depth.test.ts
+++ b/tests/migrations/faster-pool-market-depth.test.ts
@@ -1,0 +1,245 @@
+import { expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+import {
+  createClient,
+  ensureIndexerCursor,
+  runMigrations,
+  runMigrationsThrough,
+} from "../helpers/db.js";
+
+type Client = Awaited<ReturnType<typeof createClient>>;
+
+const CHAIN_ID = 7;
+const BASE_TIME = new Date("2024-01-01T12:00:00Z");
+
+async function seedBlock(client: Client, blockNumber: number, at: Date) {
+  await client.query(
+    `INSERT INTO blocks (chain_id, block_number, block_hash, block_time, num_events)
+     VALUES ($1, $2, $3, $4, 1)
+     ON CONFLICT DO NOTHING`,
+    [CHAIN_ID, blockNumber, String(blockNumber), at]
+  );
+}
+
+async function seedPool(
+  client: Client,
+  poolId: number,
+  { fee = 100, feeDenominator = 1_000_000 } = {}
+) {
+  const {
+    rows: [{ pool_key_id }],
+  } = await client.query<{ pool_key_id: string }>(
+    `INSERT INTO pool_keys (chain_id, core_address, pool_id, token0, token1, fee,
+                            fee_denominator, tick_spacing, pool_extension)
+     VALUES ($1, 2000, $2, 4000, 4001, $3, $4, 60, 0)
+     RETURNING pool_key_id`,
+    [CHAIN_ID, String(poolId), fee, feeDenominator]
+  );
+  return Number(pool_key_id);
+}
+
+async function seedTicks(
+  client: Client,
+  poolKeyId: number,
+  ticks: [tick: number, delta: string][]
+) {
+  for (const [tick, delta] of ticks) {
+    await client.query(
+      `INSERT INTO per_pool_per_tick_liquidity (pool_key_id, tick, net_liquidity_delta_diff,
+                                                total_liquidity_on_tick)
+       VALUES ($1, $2, $3::numeric, abs($3::numeric))`,
+      [poolKeyId, tick, delta]
+    );
+  }
+}
+
+let nextEvent = 0;
+
+async function seedSwap(
+  client: Client,
+  poolKeyId: number,
+  blockNumber: number,
+  tickAfter: number,
+  liquidityAfter: string
+) {
+  nextEvent += 1;
+  await client.query(
+    `INSERT INTO swaps (chain_id, block_number, transaction_index, event_index, transaction_hash,
+                        emitter, pool_key_id, locker, delta0, delta1, sqrt_ratio_after, tick_after,
+                        liquidity_after)
+     VALUES ($1, $2, $3, 0, $4, 2000, $5, 3000, 1, -1, 1, $6, $7::numeric)`,
+    [CHAIN_ID, blockNumber, nextEvent, String(nextEvent), poolKeyId, tickAfter, liquidityAfter]
+  );
+}
+
+async function setPoolState(client: Client, poolKeyId: number, tick: number) {
+  await client.query(
+    `INSERT INTO pool_states (pool_key_id, sqrt_ratio, liquidity, tick, last_event_id)
+     VALUES ($1, 1, 0, $2, 1)
+     ON CONFLICT (pool_key_id) DO UPDATE SET tick = EXCLUDED.tick`,
+    [poolKeyId, tick]
+  );
+}
+
+/**
+ * Six pools chosen to cover every branch the rewrite touches: bands that fall
+ * inside the tick range, bands that run off both ends of it, a pool whose
+ * liquidity returns to zero in the middle, a pool priced from pool_states
+ * because it has never swapped, a pool with no ticks at all, and a pool whose
+ * fee is wider than the tightest depth bands.
+ */
+async function seedFixture(client: Client) {
+  await ensureIndexerCursor(client, CHAIN_ID);
+  await seedBlock(client, 1, new Date(BASE_TIME.getTime() - 4 * 60 * 60 * 1000));
+  await seedBlock(client, 2, new Date(BASE_TIME.getTime() - 40 * 60 * 1000));
+  await seedBlock(client, 3, new Date(BASE_TIME.getTime() - 10 * 60 * 1000));
+  await seedBlock(client, 4, BASE_TIME);
+
+  // 1. Wide tick range, so most bands land strictly inside it.
+  const wide = await seedPool(client, 1);
+  await seedTicks(client, wide, [
+    [-120_000, "1000000000000000000"],
+    [-40_000, "5000000000000000000"],
+    [-500, "70000000000000000000"],
+    [500, "-70000000000000000000"],
+    [40_000, "-5000000000000000000"],
+    [120_000, "-1000000000000000000"],
+  ]);
+  await seedSwap(client, wide, 2, 40, "76000000000000000000");
+  await seedSwap(client, wide, 3, 60, "76000000000000000000");
+  await seedSwap(client, wide, 4, 20, "76000000000000000000");
+  // Older than the one-hour window: must not move the median.
+  await seedSwap(client, wide, 1, 90_000, "76000000000000000000");
+
+  // 2. Narrow tick range, so every band runs off both ends.
+  const narrow = await seedPool(client, 2);
+  await seedTicks(client, narrow, [
+    [-300, "9000000000000000000"],
+    [300, "-9000000000000000000"],
+  ]);
+  await seedSwap(client, narrow, 3, 0, "9000000000000000000");
+
+  // 3. Liquidity drops back to zero between two populated ranges.
+  const gapped = await seedPool(client, 3);
+  await seedTicks(client, gapped, [
+    [-8_000, "3000000000000000000"],
+    [-2_000, "-3000000000000000000"],
+    [2_000, "4000000000000000000"],
+    [8_000, "-4000000000000000000"],
+  ]);
+  await seedSwap(client, gapped, 3, -1_000, "3000000000000000000");
+
+  // 4. Never swapped: last_tick has to come from pool_states.
+  const unswapped = await seedPool(client, 4);
+  await seedTicks(client, unswapped, [
+    [-5_000, "2000000000000000000"],
+    [5_000, "-2000000000000000000"],
+  ]);
+  await setPoolState(client, unswapped, 1_200);
+
+  // 5. No ticks at all: contributes no rows to either definition.
+  const empty = await seedPool(client, 5);
+  await seedSwap(client, empty, 3, 0, "1000000000000000000");
+
+  // 6. A 1% fee is wider than the tightest bands, which are skipped entirely.
+  const expensive = await seedPool(client, 6, { fee: 10_000 });
+  await seedTicks(client, expensive, [
+    [-30_000, "6000000000000000000"],
+    [30_000, "-6000000000000000000"],
+  ]);
+  await seedSwap(client, expensive, 3, 100, "6000000000000000000");
+
+  return { wide, narrow, gapped, unswapped, empty, expensive };
+}
+
+async function marketDepth(client: Client, relation: string) {
+  const { rows } = await client.query<{
+    pool_key_id: string;
+    depth_percent: number;
+    depth0: string;
+    depth1: string;
+  }>(
+    `SELECT pool_key_id::text, depth_percent, depth0::text, depth1::text
+     FROM ${relation}
+     ORDER BY pool_key_id, depth_percent`
+  );
+  return rows;
+}
+
+test("the rewritten view returns exactly what the old definition returned", async () => {
+  const client = new PGlite("memory://temp");
+  await runMigrationsThrough(client, 125);
+  const pools = await seedFixture(client);
+
+  const before = await marketDepth(client, "pool_market_depth_view");
+
+  // The fixture has to actually exercise the thing, or parity is vacuous.
+  expect(before.length).toBeGreaterThan(100);
+  expect(new Set(before.map((r) => r.pool_key_id)).size).toBe(5);
+  expect(before.some((r) => BigInt(r.depth0) > 0n)).toBe(true);
+  expect(before.some((r) => BigInt(r.depth1) > 0n)).toBe(true);
+
+  await runMigrations(client, { files: ["00126_faster_pool_market_depth"] });
+
+  const after = await marketDepth(client, "pool_market_depth_view");
+
+  // Exact, not approximate: NUMERIC + - * are lossless and both definitions
+  // round POWER() and 1/p at the same ticks, so every digit has to match.
+  expect(after).toEqual(before);
+
+  // The pool with no ticks is absent from both.
+  expect(after.some((r) => r.pool_key_id === String(pools.empty))).toBe(false);
+  // The 1% fee pool keeps only the bands wider than its fee.
+  const expensiveRows = after.filter(
+    (r) => r.pool_key_id === String(pools.expensive)
+  );
+  expect(expensiveRows.length).toBeGreaterThan(0);
+  expect(expensiveRows.length).toBeLessThan(41);
+
+  await client.close();
+});
+
+test("the materialized view and its concurrent refresh still work on the new definition", async () => {
+  const client = new PGlite("memory://temp");
+  await runMigrationsThrough(client, 125);
+  await seedFixture(client);
+  await runMigrations(client, { files: ["00126_faster_pool_market_depth"] });
+
+  // This is what the cron job runs; it needs the unique index from 00024 and it
+  // is the step that would fail if the replaced view changed shape.
+  await client.exec(
+    `REFRESH MATERIALIZED VIEW CONCURRENTLY pool_market_depth_materialized`
+  );
+
+  expect(await marketDepth(client, "pool_market_depth_materialized")).toEqual(
+    await marketDepth(client, "pool_market_depth_view")
+  );
+
+  await client.close();
+});
+
+test("the median still ignores swaps older than the hour before the last one", async () => {
+  const client = new PGlite("memory://temp");
+  await runMigrationsThrough(client, 126);
+  await ensureIndexerCursor(client, CHAIN_ID);
+  await seedBlock(client, 1, new Date(BASE_TIME.getTime() - 4 * 60 * 60 * 1000));
+  await seedBlock(client, 2, BASE_TIME);
+
+  const pool = await seedPool(client, 20);
+  await seedTicks(client, pool, [
+    [-50_000, "4000000000000000000"],
+    [50_000, "-4000000000000000000"],
+  ]);
+  await seedSwap(client, pool, 2, 0, "4000000000000000000");
+  const inWindowOnly = await marketDepth(client, "pool_market_depth_view");
+
+  // A swap four hours before the newest one: outside the window, so the median
+  // tick -- and therefore every depth -- must not move. OFFSET 0 is only a
+  // planner fence, and this is what proves it stayed one.
+  await seedSwap(client, pool, 1, 45_000, "4000000000000000000");
+  expect(await marketDepth(client, "pool_market_depth_view")).toEqual(
+    inWindowOnly
+  );
+
+  await client.close();
+});


### PR DESCRIPTION
`refresh_pool_market_depth` is the most expensive job left on the instance: **25.1 s** average over the last 24 hours (35.5 s over 7 days, max 169.7 s), every 15 minutes. This migration takes a run to **~10.5 s** and moves the schedule to every 10 minutes.

No new index. The index this needed already existed — `swaps_pool_key_id_block_time_ohlc_idx`, added in 00118. There were two independent problems.

## 1. The median-tick step read the whole `swaps` table

The `LATERAL` subquery that collects an hour of ticks per pool had no `LIMIT` or `OFFSET`, so the planner pulled it up into a plain join, lost the per-pool correlation, and estimated **~513k rows per pool** for the one-hour window. Against that estimate a hash join over a sequential scan of all 46M swaps beats 5,000 index probes, so that is what it chose: **~20 s and ~11 GB read from disk per refresh**, 96 times a day — roughly a terabyte.

`enable_seqscan = off` does not help either. Measured: it ran past 170 s and the statement timeout cut it off before the plan could be captured. The estimate is what is wrong, so the fix is to stop the pull-up. `OFFSET 0` is the standard optimisation fence and changes nothing semantically.

| median-tick step | before | after |
|---|---|---|
| execution | ~20 s | **0.29 s** |
| buffers | ~1.45M read from disk | 65,520, all hits |
| plan | `Seq Scan on swaps` | `Index Scan using swaps_pool_key_id_block_time_ohlc_idx`, 3,482 loops |

The `ORDER BY block_time DESC` in that subquery is dropped with it. It never meant anything to `PERCENTILE_CONT` and only invited a sort.

## 2. The tick math was quadratic in disguise

For every `(pool, depth)` pair the old definition intersected the depth band against every one of the pool's tick segments — the largest pool has 1,763 — so a pool cost `ticks × 41` range intersections.

It is now one ordered pass per pool: prefix sums of each segment's token amounts, then a band's amount is the difference of the cumulative value at its two edges. The largest pool goes from **1,689 ms to 93 ms**.

## The rewrite is exact, not approximate

`NUMERIC` `+ - *` are arbitrary-precision and lossless. The only rounding is inside `POWER()` and the `1/p` divisions, and both definitions evaluate those at exactly the same tick values, so the reassociated sums agree digit for digit.

Verified two ways:

- **On production**, both definitions in a single statement so they saw one snapshot: the same **69,150 rows**, `only_in_new = 0`, `only_in_deployed = 0`, `depth0_differs = 0`, `depth1_differs = 0`. 24.5 s for the deployed definition against **10.0 s** for this one.
- **In CI**, `tests/migrations/faster-pool-market-depth.test.ts` snapshots the old view's output, applies the migration, and asserts strict equality. The fixture covers bands falling inside the tick range, bands running off both ends, a pool whose liquidity returns to zero mid-range, a pool priced from `pool_states` because it never swapped, a pool with no ticks at all, and a pool whose fee is wider than the tightest bands. A separate test refreshes the matview `CONCURRENTLY` on the new definition, and a third proves `OFFSET 0` stayed a planner fence by checking that a swap outside the one-hour window still does not move the result.

One trap for anyone touching this again: deriving the band edge prices as `p(last) × p(offset)` via exponent laws is one extra rounding step and drifts ~1e-12 relative. Each edge price is computed directly from its own tick.

## Schedule: every 15 minutes → every 10

The `REFRESH … CONCURRENTLY` diff costs ~0.19 s on top of computing the view (the mean of its two internal `pg_temp` statements), so a run is ~10.5 s.

| schedule | cost/day | worst-case lag behind a liquidity change |
|---|---|---|
| today, every 15 min at 25.1 s | 2,410 s | 25 min |
| **this PR, every 10 min at ~10.5 s** | **1,512 s** | **20 min** |
| every 5 min at ~10.5 s | 3,024 s | 15 min |

Depth drives the APR denominators, the depth column and the pool page's depth card. Half the saving is spent on freshness and half kept as a 37% cut. **Every 5 minutes was considered and not taken** — it costs more than today (0.87% of the four vCPUs against 0.70%) for a further five minutes, and the API's own 600 s cache is the other half of the lag either way. It is a one-token change in the migration's `DO` block if that trade is wanted.

Buffer traffic falls regardless of schedule, and that is the bigger win: ~11 GB read from disk per run becomes ~0.5 GB of cache hits.

## Deploy

`CREATE OR REPLACE VIEW` takes `ACCESS EXCLUSIVE` on the view alone and only `ACCESS SHARE` on the tables it reads, which does not conflict with the workers' `ROW EXCLUSIVE`. Unlike 00120 and 00123 this holds nothing a worker can wait on, so it needs no `LOCK TABLE blocks` preamble. The one lock it can wait behind is a cron refresh already reading the view, hence the 15-minute `lock_timeout`.

The migration does not refresh the matview; the next cron run picks up the new definition. No consumer changes — same columns, same values.

https://claude.ai/code/session_01EafuJ5i85zz2wqaNQidE3F
