### PR TITLE
Move BNB, Monad and World Chain off the Alchemy key for the live tail

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -90,10 +90,15 @@ workers:
     instance_size_slug: apps-s-1vcpu-0.5gb
     instance_count: 1
     envs:
+      # mainnet.optimism.io is load balanced across backends that disagree
+      # about the finalized block: on 130 of 180 consecutive polls it answered
+      # with one up to 39M blocks behind the previous answer, which crashes the
+      # stream ("Finalized cursor moved backwards"). Put it back in front once
+      # apibara/typescript-sdk#225 ships and the tracker ignores stale answers.
       - key: EVM_RPC_URL
         scope: RUN_TIME
         type: SECRET
-        value: "https://mainnet.optimism.io,https://opt-mainnet.g.alchemy.com/v2/${EVM_RPC_ALCHEMY_API_KEY}"
+        value: "https://opt-mainnet.g.alchemy.com/v2/${EVM_RPC_ALCHEMY_API_KEY}"
       - key: NETWORK
         scope: RUN_TIME
         value: opt-mainnet
@@ -103,10 +108,14 @@ workers:
     instance_size_slug: apps-s-1vcpu-0.5gb
     instance_count: 1
     envs:
+      # 48 Club serves both block reads and eth_getLogs; the official
+      # bsc-dataseed nodes are fast for block reads but answer every
+      # eth_getLogs with "limit exceeded", so they sit second and those calls
+      # fall through to Alchemy.
       - key: EVM_RPC_URL
         scope: RUN_TIME
         type: SECRET
-        value: "https://bnb-mainnet.g.alchemy.com/v2/${EVM_RPC_ALCHEMY_API_KEY}"
+        value: "https://rpc-bsc.48.club,https://bsc-dataseed.bnbchain.org,https://bnb-mainnet.g.alchemy.com/v2/${EVM_RPC_ALCHEMY_API_KEY}"
       - key: NETWORK
         scope: RUN_TIME
         value: bsc-mainnet
@@ -155,10 +164,14 @@ workers:
     instance_size_slug: apps-s-1vcpu-0.5gb
     instance_count: 1
     envs:
+      # rpc1 is Alchemy behind a 15 rps limit, so it rate-limited about a
+      # tenth of our requests and spilled them onto the keyed URL anyway.
+      # rpc2 (Goldsky) and rpc3 (Ankr) each answered 251 requests with no
+      # failures at our rate.
       - key: EVM_RPC_URL
         scope: RUN_TIME
         type: SECRET
-        value: "https://rpc1.monad.xyz,https://monad-mainnet.g.alchemy.com/v2/${EVM_RPC_ALCHEMY_API_KEY}"
+        value: "https://rpc2.monad.xyz,https://rpc3.monad.xyz,https://monad-mainnet.g.alchemy.com/v2/${EVM_RPC_ALCHEMY_API_KEY}"
       - key: NETWORK
         scope: RUN_TIME
         value: monad
@@ -168,10 +181,16 @@ workers:
     instance_size_slug: apps-s-1vcpu-0.5gb
     instance_count: 1
     envs:
+      # The keyless endpoint serves the head poll, the per-block reads and the
+      # 1-block live eth_getLogs range; only a catch-up wider than its 100
+      # block eth_getLogs limit falls through to the keyed URL. Tenderly's
+      # gateway has a bigger eth_getLogs limit but answered 81 of 180 polls
+      # with a finalized block behind the previous one, so it is not usable
+      # until apibara/typescript-sdk#225 ships.
       - key: EVM_RPC_URL
         scope: RUN_TIME
         type: SECRET
-        value: "https://worldchain-mainnet.g.alchemy.com/v2/${EVM_RPC_ALCHEMY_API_KEY}"
+        value: "https://worldchain-mainnet.g.alchemy.com/public,https://worldchain-mainnet.g.alchemy.com/v2/${EVM_RPC_ALCHEMY_API_KEY}"
       - key: NETWORK
         scope: RUN_TIME
         value: worldchain-mainnet

--- a/.env.evm.bsc-mainnet
+++ b/.env.evm.bsc-mainnet
@@ -1,6 +1,6 @@
 CHAIN_ID="56"
 STARTING_CURSOR_BLOCK_NUMBER="74289535"
-EVM_RPC_URL="https://bsc.drpc.org"
+EVM_RPC_URL="https://rpc-bsc.48.club,https://bsc-dataseed.bnbchain.org"
 
 # Only the managers deployed by the current script/DeployManagers.s.sol
 # exist on this chain, so both are overridden here rather than inheriting the

--- a/.env.evm.monad
+++ b/.env.evm.monad
@@ -1,3 +1,3 @@
 CHAIN_ID="143"
 STARTING_CURSOR_BLOCK_NUMBER="74350693"
-EVM_RPC_URL="https://rpc1.monad.xyz,https://rpc4.monad.xyz"
+EVM_RPC_URL="https://rpc2.monad.xyz,https://rpc3.monad.xyz"


### PR DESCRIPTION
Follows the RPC review of the EVM indexer. Two things changed: which endpoints the live tail uses, and dropping one endpoint that is actively crashing a worker.

## Why these chains cost what they do

Every EVM worker polls `eth_getBlockByNumber("latest")` every 2 s, reads **every new block by number** (the chain tracker fetches `head+1..newHead` to check the hashes link up), runs one `eth_getLogs` per poll, and one `eth_getBlockByHash` when the head carries no matching logs. That makes the bill scale with block rate rather than with activity:

| chain | block time | requests / 2 s poll | CU/day | ≈ $/mo |
|---|---|---|---|---|
| Monad | 0.30 s | 9.7 | 10.1M | ~$136 |
| BNB Smart Chain | 0.45 s | 7.4 | 8.1M | ~$110 |
| World Chain | 2 s | 3 | 4.3M | ~$58 |

Neither BNB nor World Chain had any public endpoint in front of the keyed URL, so all of that was landing on the Alchemy key.

## How the endpoints were chosen

Each candidate ran the live pattern at the chain's real request rate for 60 s with the production 14-address merged filter, plus a 50-request burst (the tracker fetches block headers in parallel) and a 180 s poll checking that `latest` and `finalized` stay consistent.

**BNB Smart Chain** → `rpc-bsc.48.club`, `bsc-dataseed.bnbchain.org`, keyed Alchemy

| endpoint | failures | p50 | getLogs range |
|---|---|---|---|
| `rpc-bsc.48.club` | 0/190 | 43 ms | 5,000 blocks |
| `bsc-dataseed.bnbchain.org` | 29/189 | 30 ms | **rejects all** |
| `bnb-mainnet.g.alchemy.com/public` | 29/190 | 48 ms | rejects all |
| `bsc.drpc.org` | dead | | |

The dataseed nodes are the fastest thing available for block reads but answer every `eth_getLogs` with `limit exceeded` — at any range, including a single block. They sit second so block reads land there if 48 Club is down, and `eth_getLogs` falls through to Alchemy.

**Monad** → `rpc2.monad.xyz`, `rpc3.monad.xyz`, keyed Alchemy

| endpoint | operator | failures | burst | getLogs range |
|---|---|---|---|---|
| `rpc2.monad.xyz` | Goldsky | 0/251 | 0/50 | 10,000 |
| `rpc3.monad.xyz` | Ankr | 0/251 | 0/50 | 500 |
| `rpc1.monad.xyz` (current) | **Alchemy** | **26/251** | 14/50 | 5,000 |
| `rpc.monad.xyz` | QuickNode | 0/251 | 0/50 | 100 |

`rpc1` is Alchemy behind a documented 15 rps limit, so a tenth of our requests were already spilling onto the keyed URL. Note `rpc2` rejects a `Python-urllib` user-agent with a 403 but answers normally for `undici`, which is what we send.

**World Chain** → keyless Alchemy, then keyed Alchemy

The chain produces exactly one block per 2 s poll, so the live `eth_getLogs` range is a single block and sits well inside the keyless endpoint's 100 block limit. Only a catch-up wider than 100 blocks (over 3 minutes of downtime) reaches the key. It was clean across every probe: 90/90 requests, 50/50 burst, 180/180 polls.

## Optimism

Not one of the three chains under review, but this fell out of the same measurements. The `opt-mainnet` worker restarts roughly every 80 seconds — 8 times in an 11 minute log window — with:

```
Error: Finalized cursor moved backwards
    at updateFinalized (@apibara/protocol/dist/shared/protocol.a291e075.mjs:59:17)
```

`mainnet.optimism.io` is load balanced across backends that disagree about the finalized block. Over 180 consecutive polls, one second apart:

| endpoint | polls answering with an older finalized block | largest step back |
|---|---|---|
| `mainnet.optimism.io` | 130 | 39,188,192 blocks |
| `worldchain-mainnet.gateway.tenderly.co` | 81 | 268 blocks |
| `optimism-rpc.publicnode.com` | 24 | 207 blocks |
| `rpc2.monad.xyz`, `rpc3.monad.xyz`, `rpc-bsc.48.club`, `worldchain-mainnet.g.alchemy.com/public`, `mainnet.base.org` | 0 | |

So Optimism goes to the keyed URL alone. This is the reason Tenderly is not used for World Chain despite having the best `eth_getLogs` limit and the lowest lag of anything on that chain.

apibara/typescript-sdk#225 makes the tracker ignore a stale finalized answer instead of throwing (it also fixes a separate crash loop on BNB and Monad, 11 and 9 restarts in 7 minutes, caused by the finalized block passing the tracked head). Once that ships, the free endpoint can go back in front on Optimism and World Chain can move to Tenderly.

## Checks

- `doctl apps spec validate` on the rendered spec: passes.
- `bun test`: 319 pass, 0 fail.
- Every endpoint added here was re-checked immediately before commit.

Endpoint choices are a judgement call on public infrastructure with no SLA, which is why the keyed Alchemy URL stays last in every list.
