### PR TITLE
Back the EVM poll off on a chain that is indexing nothing

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -81,6 +81,7 @@ workers:
         value: rhc-mainnet
       - key: EVM_RPC_URL
         scope: RUN_TIME
+        type: SECRET
         value: "https://robinhood-mainnet.g.alchemy.com/v2/${EVM_RPC_ALCHEMY_API_KEY}"
     run_command: scripts/restart.sh bun src/evm.ts
   - name: arb-mainnet

--- a/.env.evm.mainnet
+++ b/.env.evm.mainnet
@@ -12,8 +12,10 @@ INCENTIVES_ADDRESS="0xBe4C4C4e35DED081831A1f04e24E84dEFbA75fEC"
 MEV_CAPTURE_ADDRESS="0x553a2EFc570c9e104942cEC6aC1c18118e54C091"
 TOKEN_WRAPPER_FACTORY_ADDRESS="0x2b8d80d891C1E20aca70fF8a85714aa1900Ab120"
 
-# Ethereum finalises ~13 minutes behind the head, so the re-read window is the
-# only reorg protection above finality and it is worth more here than on a chain
-# that finalises in a block. At 0.1 blocks/s this is 64 blocks -- exactly what
-# the old fixed block count gave -- and one wider eth_getLogs costs nothing.
-REORG_WINDOW_SECONDS="640"
+# Ethereum finalises two to three epochs behind the head -- 768 to 1152 seconds
+# -- so above finality the re-read window is the only reorg protection there is,
+# and it is worth more here than on a chain that finalises within a block. Set to
+# cover the worst-case span, so `finalized + 1` rather than the window is always
+# what bounds the read. At 12s blocks that is 96 blocks, well inside the
+# half-span cap, and one wider eth_getLogs costs nothing.
+REORG_WINDOW_SECONDS="1152"

--- a/.env.evm.mainnet
+++ b/.env.evm.mainnet
@@ -19,3 +19,10 @@ TOKEN_WRAPPER_FACTORY_ADDRESS="0x2b8d80d891C1E20aca70fF8a85714aa1900Ab120"
 # what bounds the read. At 12s blocks that is 96 blocks, well inside the
 # half-span cap, and one wider eth_getLogs costs nothing.
 REORG_WINDOW_SECONDS="1152"
+
+# quoter-service prices gas from indexer_cursor.head_base_fee_per_gas, which is
+# only as fresh as the last poll. Ethereum sees an event every ~8s so it would
+# rarely back off anyway, and its cost is dominated by head reads the
+# unchanged-head skip already handles -- so pinning the interval buys certainty
+# about gas pricing for almost nothing.
+MAX_POLL_INTERVAL_MS="2000"

--- a/.env.evm.mainnet
+++ b/.env.evm.mainnet
@@ -12,3 +12,8 @@ INCENTIVES_ADDRESS="0xBe4C4C4e35DED081831A1f04e24E84dEFbA75fEC"
 MEV_CAPTURE_ADDRESS="0x553a2EFc570c9e104942cEC6aC1c18118e54C091"
 TOKEN_WRAPPER_FACTORY_ADDRESS="0x2b8d80d891C1E20aca70fF8a85714aa1900Ab120"
 
+# Ethereum finalises ~13 minutes behind the head, so the re-read window is the
+# only reorg protection above finality and it is worth more here than on a chain
+# that finalises in a block. At 0.1 blocks/s this is 64 blocks -- exactly what
+# the old fixed block count gave -- and one wider eth_getLogs costs nothing.
+REORG_WINDOW_SECONDS="640"

--- a/README.md
+++ b/README.md
@@ -214,11 +214,42 @@ surfaces later as a wrong number downstream. Three choices follow from that.
   stream fails fast on a refusal rather than splitting out of one, a 2x wider
   backfill is not worth an occasional stall.
 
-Reorgs are found by re-reading `REORG_WINDOW_BLOCKS` (default 64) at the head
-each poll and comparing it against what was emitted. A block that changed hash,
-lost its logs, or gained logs it did not have produces an `invalidate`. The
-window must be deeper than any reorg the chain can produce; a reorg touching no
-log of ours changes nothing we store and is not looked for.
+Reorgs are found by re-reading a window below the cursor each poll and comparing
+it against what was emitted. A block that changed hash, lost its logs, or gained
+logs it did not have produces an `invalidate`. The window must be deeper than any
+reorg the chain can produce; a reorg touching no log of ours changes nothing we
+store and is not looked for.
+
+The window is configured in seconds — `REORG_WINDOW_SECONDS`, default 120 — and
+converted to a block count per chain from a block rate measured off the head read
+each poll already makes. A block is not a unit of time, and these chains run from
+12s to 0.09s apart, so the block count this used to take meant 768s of protection
+on Ethereum and 6s on Robinhood. Ethereum is pinned at 1152s in
+`.env.evm.mainnet`, its worst-case head-to-finalized span, because above finality
+the window is its only protection.
+
+The derived count is capped at half `GET_LOGS_RANGE_SIZE`, which guarantees the
+other half of every read is forward progress no matter what the chain's block
+rate turns out to be. When the cap binds, the stream warns once with the window
+it actually got; raising `GET_LOGS_RANGE_SIZE` is the remedy.
+
+### Backing off on a quiet chain
+
+A poll costs the same two requests whether it finds an event or none, so a chain
+that has produced nothing in months costs exactly what the busiest one does. The
+interval therefore holds at `POLL_INTERVAL_MS` (default 2,000) for
+`QUIET_POLLS_BEFORE_BACKOFF` (default 30) consecutive polls that index nothing,
+then doubles per empty poll up to `MAX_POLL_INTERVAL_MS` (default 30,000). Any
+matched log, or any reorg, puts it straight back to the floor.
+
+That first stretch is the latency guarantee: a chain that indexed anything in the
+last minute keeps polling at full rate, so a busy chain never leaves the floor.
+Backing off is a delay and never a miss — a range query asked less often reads a
+wider range, not a narrower one. The cost is that an event on a dormant chain can
+take up to `MAX_POLL_INTERVAL_MS` to be indexed, and
+`indexer_cursor.head_base_fee_per_gas` is that stale meanwhile. Set
+`MAX_POLL_INTERVAL_MS` equal to `POLL_INTERVAL_MS` to switch it off for a chain
+where that is not acceptable, as `.env.evm.mainnet` does.
 
 ### On restart
 

--- a/scripts/verifyLogStream.ts
+++ b/scripts/verifyLogStream.ts
@@ -72,7 +72,13 @@ const stream = createLogStream({
   rpc: { request: (client as never as { request: never }).request },
   filters,
   startingCursor: { orderKey: BigInt(from - 1) },
-  options: { pollIntervalMs: 50, maxLogRangeBlocks: CHUNK, reorgWindowBlocks: 32 },
+  options: {
+    pollIntervalMs: 50,
+    // No backoff: this script wants every poll it can get inside its run.
+    maxPollIntervalMs: 50,
+    maxLogRangeBlocks: CHUNK,
+    reorgWindowSeconds: 120,
+  },
 });
 
 for await (const msg of stream) {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -27,6 +27,8 @@ interface EvmConfig extends CommonConfiguration {
   EVM_RPC_URL: string;
 
   POLL_INTERVAL_MS?: string; // How long to wait at the head before polling again; defaults to 2000
+  MAX_POLL_INTERVAL_MS?: string; // Ceiling the poll interval backs off to while the chain indexes nothing; defaults to 30000. Set equal to POLL_INTERVAL_MS to disable backoff
+  QUIET_POLLS_BEFORE_BACKOFF?: string; // Consecutive empty polls tolerated before the interval grows; defaults to 30. POLL_INTERVAL_MS * this is the window in which a chain that indexed anything keeps polling at full rate
   GET_LOGS_RANGE_SIZE?: string; // Widest block span per eth_getLogs; defaults to 1000. Must exceed REORG_WINDOW_BLOCKS, or the stream cannot read past the window it re-reads and makes no progress
   REORG_WINDOW_BLOCKS?: string; // How far back to re-read at the head to notice a reorg; defaults to 64. Must be deeper than any reorg the chain can produce, and below GET_LOGS_RANGE_SIZE
   SUSPECT_LOG_COUNT?: string; // A log count treated as a provider cap rather than a real result; defaults to 10000

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -29,8 +29,8 @@ interface EvmConfig extends CommonConfiguration {
   POLL_INTERVAL_MS?: string; // How long to wait at the head before polling again; defaults to 2000
   MAX_POLL_INTERVAL_MS?: string; // Ceiling the poll interval backs off to while the chain indexes nothing; defaults to 30000. Set equal to POLL_INTERVAL_MS to disable backoff
   QUIET_POLLS_BEFORE_BACKOFF?: string; // Consecutive empty polls tolerated before the interval grows; defaults to 30. POLL_INTERVAL_MS * this is the window in which a chain that indexed anything keeps polling at full rate
-  GET_LOGS_RANGE_SIZE?: string; // Widest block span per eth_getLogs; defaults to 1000. Must exceed REORG_WINDOW_BLOCKS, or the stream cannot read past the window it re-reads and makes no progress
-  REORG_WINDOW_BLOCKS?: string; // How far back to re-read at the head to notice a reorg; defaults to 64. Must be deeper than any reorg the chain can produce, and below GET_LOGS_RANGE_SIZE
+  GET_LOGS_RANGE_SIZE?: string; // Widest block span per eth_getLogs; defaults to 1000. The reorg window is capped at half of it, so at least half of every span is forward progress
+  REORG_WINDOW_SECONDS?: string; // How far back to re-read at the head to notice a reorg, in seconds of chain time; defaults to 120. Converted to a block count per chain from the observed block rate, so it means the same amount of history on a 10s chain and a 0.09s one
   SUSPECT_LOG_COUNT?: string; // A log count treated as a provider cap rather than a real result; defaults to 10000
 
   CORE_ADDRESS: `0x${string}`;

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -231,9 +231,13 @@ export async function createEvmEntrypoint(
             30,
           ),
           maxLogRangeBlocks: positiveInt("GET_LOGS_RANGE_SIZE", 1_000),
-          // Deeper than any reorg the chain can produce. Raising it costs one
-          // wider eth_getLogs per poll; lowering it too far loses events.
-          reorgWindowBlocks: positiveInt("REORG_WINDOW_BLOCKS", 64),
+          // Deeper than any reorg the chain can produce. In seconds, not
+          // blocks: our chains run from 10s to 0.09s a block, so a single block
+          // count meant 640s of protection on Ethereum and 6s on Robinhood.
+          // The block count is derived per chain from the observed rate.
+          // Raising it costs one wider eth_getLogs per poll, which is free;
+          // lowering it too far loses events.
+          reorgWindowSeconds: positiveInt("REORG_WINDOW_SECONDS", 120),
           // Alchemy's documented eth_getLogs result cap. A response landing
           // exactly here is refused rather than indexed short.
           suspectLogCount: positiveInt("SUSPECT_LOG_COUNT", 10_000),

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -220,6 +220,16 @@ export async function createEvmEntrypoint(
         startingCursor: streamOptions.startingCursor,
         options: {
           pollIntervalMs: positiveInt("POLL_INTERVAL_MS", 2_000),
+          // Most chains we index have produced fewer than sixty events in
+          // their entire indexed history, and a poll costs the same eighty
+          // compute units whether it finds one or none. Backing off on a chain
+          // that is doing nothing is what makes indexing all of them cheap;
+          // one that is doing something never leaves POLL_INTERVAL_MS.
+          maxPollIntervalMs: positiveInt("MAX_POLL_INTERVAL_MS", 30_000),
+          quietPollsBeforeBackoff: positiveInt(
+            "QUIET_POLLS_BEFORE_BACKOFF",
+            30,
+          ),
           maxLogRangeBlocks: positiveInt("GET_LOGS_RANGE_SIZE", 1_000),
           // Deeper than any reorg the chain can produce. Raising it costs one
           // wider eth_getLogs per poll; lowering it too far loses events.

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -223,8 +223,15 @@ export async function createEvmEntrypoint(
           // Most chains we index have produced fewer than sixty events in
           // their entire indexed history, and a poll costs the same eighty
           // compute units whether it finds one or none. Backing off on a chain
-          // that is doing nothing is what makes indexing all of them cheap;
-          // one that is doing something never leaves POLL_INTERVAL_MS.
+          // that is doing nothing is what makes indexing all of them cheap.
+          //
+          // The cost is latency on a chain that goes quiet for longer than
+          // POLL_INTERVAL_MS * QUIET_POLLS_BEFORE_BACKOFF -- 60s -- which is
+          // not only the dead chains: Ethereum in a lull reaches the ceiling
+          // too. Then an event takes up to MAX_POLL_INTERVAL_MS to be indexed
+          // and indexer_cursor.head_base_fee_per_gas, which quoter-service
+          // reads to price gas, is that stale. Set MAX_POLL_INTERVAL_MS equal
+          // to POLL_INTERVAL_MS on a chain where that is not acceptable.
           maxPollIntervalMs: positiveInt("MAX_POLL_INTERVAL_MS", 30_000),
           quietPollsBeforeBackoff: positiveInt(
             "QUIET_POLLS_BEFORE_BACKOFF",

--- a/src/evm/logStream.test.ts
+++ b/src/evm/logStream.test.ts
@@ -8,7 +8,9 @@ import {
   firstDivergentBlock,
   groupLogsByBlock,
   logMatchesFilter,
+  observeBlockRate,
   pollIntervalFor,
+  reorgWindowBlocksFor,
   type LogStreamFilter,
   type RawLog,
   type RpcLike,
@@ -364,7 +366,8 @@ describe("createLogStream", () => {
         options: {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1_000_000,
-          reorgWindowBlocks: 32,
+          // A window of 32: it is capped at half the span.
+          maxLogRangeBlocks: 64,
           onWarning: (m) => warnings.push(m),
         },
       }),
@@ -412,7 +415,8 @@ describe("createLogStream", () => {
         options: {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1_000_000,
-          reorgWindowBlocks: 16,
+          // A window of 16: it is capped at half the span.
+          maxLogRangeBlocks: 32,
         },
       }),
       10,
@@ -497,7 +501,8 @@ describe("createLogStream, once caught up", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1_000_000,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 32,
+          // A window of 32: it is capped at half the span.
+          maxLogRangeBlocks: 64,
         },
       }),
       4,
@@ -531,7 +536,8 @@ describe("createLogStream, once caught up", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1_000_000,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 32,
+          // A window of 32: it is capped at half the span.
+          maxLogRangeBlocks: 64,
         },
       }),
       3,
@@ -567,7 +573,8 @@ describe("createLogStream finalized handling", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 32,
+          // A window of 32: it is capped at half the span.
+          maxLogRangeBlocks: 64,
         },
       }),
       4,
@@ -616,7 +623,8 @@ describe("createLogStream finalized handling", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1_000_000,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 64,
+          // A window of 64: it is capped at half the span.
+          maxLogRangeBlocks: 128,
         },
       }),
       3,
@@ -666,7 +674,8 @@ describe("createLogStream on restart", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1_000_000,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 20,
+          // A window of 20: it is capped at half the span.
+          maxLogRangeBlocks: 40,
           onWarning: (m) => warnings.push(m),
         },
       }),
@@ -721,7 +730,8 @@ describe("createLogStream on restart", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1_000_000,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 20,
+          // A window of 20: it is capped at half the span.
+          maxLogRangeBlocks: 40,
           onWarning: (m) => warnings.push(m),
         },
       }),
@@ -756,7 +766,8 @@ describe("createLogStream when the head repeats", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1_000_000,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 32,
+          // A window of 32: it is capped at half the span.
+          maxLogRangeBlocks: 64,
         },
       }),
       4,
@@ -799,7 +810,8 @@ describe("createLogStream when the head repeats", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1_000_000,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 32,
+          // A window of 32: it is capped at half the span.
+          maxLogRangeBlocks: 64,
         },
       }),
       4,
@@ -845,7 +857,8 @@ describe("createLogStream startup rollback depth", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1_000_000,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 64,
+          // A window of 64: it is capped at half the span.
+          maxLogRangeBlocks: 128,
           onWarning: (m) => warnings.push(m),
         },
       }),
@@ -921,10 +934,7 @@ describe("groupLogsByBlock event index", () => {
 });
 
 describe("createLogStream configuration", () => {
-  it("refuses a read span no wider than the reorg window", async () => {
-    // Such a span can end below the cursor every poll: nothing is emitted, the
-    // cursor never advances, and since the span never reaches the head the loop
-    // never sleeps -- a busy spin that looks like a healthy worker.
+  it("refuses a span too narrow to both re-read and advance", async () => {
     const rpc = rpcDouble({ logs: () => [] });
 
     await expect(
@@ -932,9 +942,31 @@ describe("createLogStream configuration", () => {
         rpc,
         filters: [filter()],
         startingCursor: { orderKey: 100n },
-        options: { maxLogRangeBlocks: 32, reorgWindowBlocks: 64 },
+        options: { maxLogRangeBlocks: 1 },
       }).next(),
-    ).rejects.toThrow(/must exceed/);
+    ).rejects.toThrow(/at least 2/);
+  });
+
+  it("cannot be configured into a window that outruns the span", async () => {
+    // The old failure this replaces: a window wider than the span it has to fit
+    // inside ends every read below the cursor, so nothing is emitted, the cursor
+    // never advances, and -- since the span never reaches the head -- the loop
+    // never sleeps. A busy spin that looks like a healthy worker.
+    //
+    // It used to be rejected at construction. Now it is unreachable: the window
+    // is capped at half the span, so at least half of every read is forward
+    // progress no matter how long `reorgWindowSeconds` is or how fast the chain
+    // runs. There is no configuration left to refuse.
+    for (const seconds of [1, 120, 86_400]) {
+      for (const rate of [null, 0.1, 11, 100_000]) {
+        const window = reorgWindowBlocksFor(
+          { blockRate: rate },
+          { reorgWindowSeconds: seconds, maxLogRangeBlocks: 1_000 },
+        );
+        expect(window).toBeLessThanOrEqual(500);
+        expect(window).toBeGreaterThanOrEqual(1);
+      }
+    }
   });
 
   it("accepts a span wider than the window", async () => {
@@ -949,7 +981,8 @@ describe("createLogStream configuration", () => {
       startingCursor: { orderKey: 100n },
       options: {
         maxLogRangeBlocks: 65,
-        reorgWindowBlocks: 64,
+        // A window of 64: it is capped at half the span.
+        maxLogRangeBlocks: 128,
         pollIntervalMs: 1,
         heartbeatIntervalMs: 1,
       },
@@ -997,7 +1030,8 @@ describe("createLogStream cursor safety", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1_000_000,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 64,
+          // A window of 64: it is capped at half the span.
+          maxLogRangeBlocks: 128,
         },
       }),
       8,
@@ -1065,7 +1099,8 @@ describe("createLogStream finalized announcements", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 32,
+          // A window of 32: it is capped at half the span.
+          maxLogRangeBlocks: 64,
         },
       }),
       10,
@@ -1095,7 +1130,8 @@ describe("createLogStream finalized announcements", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 32,
+          // A window of 32: it is capped at half the span.
+          maxLogRangeBlocks: 64,
         },
       }),
       6,
@@ -1155,7 +1191,8 @@ describe("createLogStream rollback cursor", () => {
           pollIntervalMs: 1,
           finalizedRefreshIntervalMs: 1_000_000,
           heartbeatIntervalMs: 1_000_000,
-          reorgWindowBlocks: 16,
+          // A window of 16: it is capped at half the span.
+          maxLogRangeBlocks: 32,
         },
       }),
       12,
@@ -1338,7 +1375,8 @@ describe("createLogStream head base fee", () => {
         pollIntervalMs: 1,
         finalizedRefreshIntervalMs: 1_000_000,
         heartbeatIntervalMs: 1_000_000,
-        reorgWindowBlocks: 32,
+        // A window of 32: it is capped at half the span.
+        maxLogRangeBlocks: 64,
       },
     });
 
@@ -1370,40 +1408,162 @@ describe("pollIntervalFor", () => {
     pollIntervalMs: 2_000,
     maxPollIntervalMs: 30_000,
     quietPollsBeforeBackoff: 30,
+    // Wide enough that the drain ceiling never binds in these cases; the tests
+    // that exercise it say so.
+    maxLogRangeBlocks: 1_000_000,
+    reorgWindowSeconds: 120,
   };
+  const at = (quietPolls: number, blockRate: number | null = 0.5) => ({
+    quietPolls,
+    blockRate,
+  });
 
   it("holds at the floor for the whole quiet allowance", () => {
     // The latency guarantee: a chain that indexed anything in the last
     // pollIntervalMs * quietPollsBeforeBackoff keeps polling at full rate.
     for (const quiet of [0, 1, 29, 30]) {
-      expect(pollIntervalFor(quiet, opts)).toBe(2_000);
+      expect(pollIntervalFor(at(quiet), opts)).toBe(2_000);
     }
   });
 
   it("doubles per quiet poll past the allowance, then caps", () => {
-    expect(pollIntervalFor(31, opts)).toBe(4_000);
-    expect(pollIntervalFor(32, opts)).toBe(8_000);
-    expect(pollIntervalFor(33, opts)).toBe(16_000);
-    expect(pollIntervalFor(34, opts)).toBe(30_000);
-    expect(pollIntervalFor(3_000, opts)).toBe(30_000);
+    expect(pollIntervalFor(at(31), opts)).toBe(4_000);
+    expect(pollIntervalFor(at(32), opts)).toBe(8_000);
+    expect(pollIntervalFor(at(33), opts)).toBe(16_000);
+    expect(pollIntervalFor(at(34), opts)).toBe(30_000);
+    expect(pollIntervalFor(at(3_000), opts)).toBe(30_000);
   });
 
   it("never returns Infinity for a chain quiet for a very long time", () => {
     // 2 ** 1024 is Infinity, and a chain quiet for a week gets that far. The
     // Math.min would still return the ceiling, but the intermediate is a trap.
-    expect(Number.isFinite(pollIntervalFor(Number.MAX_SAFE_INTEGER, opts))).toBe(
-      true,
-    );
+    expect(
+      Number.isFinite(pollIntervalFor(at(Number.MAX_SAFE_INTEGER), opts)),
+    ).toBe(true);
   });
 
   it("is disabled by setting the ceiling to the floor", () => {
     const off = { ...opts, maxPollIntervalMs: 2_000 };
-    expect(pollIntervalFor(10_000, off)).toBe(2_000);
+    expect(pollIntervalFor(at(10_000), off)).toBe(2_000);
   });
 
   it("never returns less than the floor, even if the ceiling is below it", () => {
     const bad = { ...opts, maxPollIntervalMs: 5 };
-    expect(pollIntervalFor(10_000, bad)).toBe(2_000);
+    expect(pollIntervalFor(at(10_000), bad)).toBe(2_000);
+  });
+
+  it("will not sleep for longer than one eth_getLogs can drain", () => {
+    // The block-rate dependency that would otherwise be an assumption. A span
+    // of 1000 with a 120s window on an 11 blocks/s chain leaves 1000 - 1000/2
+    // = 500 blocks of drain, which that chain produces in ~45s -- so the
+    // configured 60s ceiling must give way to ~45s. Sleeping past it means the
+    // stream cannot catch up in one read, stops sleeping, and reads back to
+    // back: more compute units than it saved.
+    const fast = {
+      ...opts,
+      maxPollIntervalMs: 60_000,
+      maxLogRangeBlocks: 1_000,
+    };
+    const interval = pollIntervalFor(at(10_000, 11), fast);
+    expect(interval).toBeLessThan(60_000);
+    expect(interval).toBeCloseTo((500 / 11) * 1_000, -2);
+  });
+
+  it("uses the configured ceiling on a chain slow enough to drain it", () => {
+    // Ethereum at 0.1 blocks/s produces 6 blocks in a minute against 500 of
+    // drain, so nothing about the block rate constrains it.
+    const slow = {
+      ...opts,
+      maxPollIntervalMs: 60_000,
+      maxLogRangeBlocks: 1_000,
+    };
+    expect(pollIntervalFor(at(10_000, 0.1), slow)).toBe(60_000);
+  });
+
+  it("does not let an unmeasured rate constrain the ceiling", () => {
+    expect(pollIntervalFor(at(10_000, null), opts)).toBe(30_000);
+  });
+});
+
+describe("observeBlockRate", () => {
+  const head = (number: number, timeSec: number) => ({
+    number,
+    hash: "0x0" as Hex,
+    timestamp: new Date(timeSec * 1_000),
+    baseFeePerGas: null,
+  });
+  const fresh = () => ({ blockRate: null, rateSample: null }) as never;
+
+  it("does not guess from a baseline shorter than the sample window", () => {
+    // Block timestamps have one-second resolution and Robinhood fits eleven
+    // blocks inside one, so a short baseline measures rounding, not the chain.
+    const state = fresh() as { blockRate: number | null; rateSample: unknown };
+    observeBlockRate(state as never, head(1_000, 1_700_000_000));
+    observeBlockRate(state as never, head(1_100, 1_700_000_010));
+    expect(state.blockRate).toBeNull();
+  });
+
+  it("measures the rate once the baseline is long enough", () => {
+    const state = fresh() as { blockRate: number | null; rateSample: unknown };
+    observeBlockRate(state as never, head(1_000, 1_700_000_000));
+    observeBlockRate(state as never, head(1_330, 1_700_000_030));
+    expect(state.blockRate).toBeCloseTo(11, 5);
+  });
+
+  it("restarts the baseline rather than believing a head that went backwards", () => {
+    // A provider serving an older view is not a negative block rate.
+    const state = fresh() as { blockRate: number | null; rateSample: unknown };
+    observeBlockRate(state as never, head(1_000, 1_700_000_000));
+    observeBlockRate(state as never, head(900, 1_700_000_030));
+    expect(state.blockRate).toBeNull();
+    observeBlockRate(state as never, head(1_230, 1_700_000_060));
+    expect(state.blockRate).toBeCloseTo(11, 5);
+  });
+});
+
+describe("reorgWindowBlocksFor", () => {
+  const opts = { reorgWindowSeconds: 120, maxLogRangeBlocks: 1_000 };
+
+  it("warns when the span forces a narrower window than asked for", () => {
+    const warnings: { message: string; detail: Record<string, unknown> }[] = [];
+    reorgWindowBlocksFor(
+      { blockRate: 11 },
+      { ...opts, onWarning: (message, detail) => warnings.push({ message, detail }) },
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.message).toMatch(/capped by the log range size/);
+    expect(warnings[0]!.detail.effectiveSeconds).toBe(45);
+  });
+
+  it("says nothing when the window fits", () => {
+    const warnings: string[] = [];
+    reorgWindowBlocksFor(
+      { blockRate: 0.1 },
+      { ...opts, onWarning: (m) => warnings.push(m) },
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  it("means the same amount of history on chains 100x apart in block time", () => {
+    // The whole point. 64 blocks bought Ethereum 640s of protection and
+    // Robinhood 6s; 120 seconds buys both 120 seconds.
+    expect(reorgWindowBlocksFor({ blockRate: 0.1 }, opts)).toBe(12);
+    expect(reorgWindowBlocksFor({ blockRate: 3.8 }, opts)).toBe(456);
+  });
+
+  it("takes the widest window on offer until the rate is known", () => {
+    // Erring wide is free -- one eth_getLogs is 60 units for any span it
+    // accepts -- and erring narrow loses events.
+    expect(reorgWindowBlocksFor({ blockRate: null }, opts)).toBe(500);
+  });
+
+  it("never exceeds half the span, however fast the chain", () => {
+    expect(reorgWindowBlocksFor({ blockRate: 11 }, opts)).toBe(500);
+    expect(reorgWindowBlocksFor({ blockRate: 100_000 }, opts)).toBe(500);
+  });
+
+  it("never collapses to zero on a chain that has barely moved", () => {
+    expect(reorgWindowBlocksFor({ blockRate: 0.0000001 }, opts)).toBe(1);
   });
 });
 
@@ -1448,7 +1608,7 @@ describe("reorg detection once the poll interval can back off", () => {
         startingCursor: { orderKey: 1000n },
         options: {
           pollIntervalMs: 1,
-          reorgWindowBlocks: 8,
+          // Window of 50, comfortably covering block 1005 below the cursor.
           maxLogRangeBlocks: 100,
           finalizedRefreshIntervalMs: 1_000_000,
         },
@@ -1485,7 +1645,6 @@ describe("reorg detection once the poll interval can back off", () => {
         startingCursor: { orderKey: 1000n },
         options: {
           pollIntervalMs: 1,
-          reorgWindowBlocks: 64,
           maxLogRangeBlocks: 1_000,
           finalizedRefreshIntervalMs: 1_000_000,
         },
@@ -1494,10 +1653,14 @@ describe("reorg detection once the poll interval can back off", () => {
     );
 
     expect(spans.length).toBeGreaterThanOrEqual(2);
-    // First read starts one window below the cursor, not at the cursor.
-    expect(spans[0]).toEqual([937, 1936]);
-    // And it makes real forward progress: 936 blocks per read, not zero.
-    expect(spans[1]![0]).toBe(1873);
+    // First read starts one window below the cursor, not at the cursor. The
+    // rate is unmeasured on the first poll, so the window is the cap -- half of
+    // maxLogRangeBlocks, 500.
+    expect(spans[0]).toEqual([501, 1_500]);
+    // And it makes real forward progress: at least half the span per read,
+    // which is what the cap guarantees against any block rate.
+    expect(spans[1]![0]).toBe(1_001);
+    expect(spans[1]![0] - spans[0]![0]).toBeGreaterThanOrEqual(500);
   });
 });
 

--- a/src/evm/logStream.test.ts
+++ b/src/evm/logStream.test.ts
@@ -1509,6 +1509,17 @@ describe("observeBlockRate", () => {
     expect(state.blockRate).toBeCloseTo(11, 5);
   });
 
+  it("never adopts a rate of zero from a tip replaced in place", () => {
+    // A null rate makes the rise-only comparison adopt anything, so a head that
+    // keeps its number but gains a later timestamp would store zero -- and a
+    // zero rate sizes the reorg window down to one block.
+    const state = fresh() as { blockRate: number | null; rateSample: unknown };
+    observeBlockRate(state as never, head(1_000, 1_700_000_000));
+    observeBlockRate(state as never, head(1_000, 1_700_000_005));
+    expect(state.blockRate).not.toBe(0);
+    expect(state.blockRate).toBeNull();
+  });
+
   it("adopts a rate increase without waiting for a full baseline", () => {
     // A sequencer catching up after downtime. Waiting the full sample would
     // leave the window sized for the old, slower chain while blocks pile up

--- a/src/evm/logStream.test.ts
+++ b/src/evm/logStream.test.ts
@@ -969,7 +969,9 @@ describe("createLogStream configuration", () => {
     }
   });
 
-  it("accepts a span wider than the window", async () => {
+  it("accepts the tightest span that can still make progress", async () => {
+    // Two blocks: one re-read, one new. The window is capped at half the span,
+    // so this is the narrowest configuration that is not degenerate.
     const rpc = rpcDouble({
       blocks: () => ({ number: 100, hash: "0x100", timestamp: 1_700_000_000 }),
       logs: () => [],
@@ -980,9 +982,7 @@ describe("createLogStream configuration", () => {
       filters: [filter()],
       startingCursor: { orderKey: 100n },
       options: {
-        maxLogRangeBlocks: 65,
-        // A window of 64: it is capped at half the span.
-        maxLogRangeBlocks: 128,
+        maxLogRangeBlocks: 2,
         pollIntervalMs: 1,
         heartbeatIntervalMs: 1,
       },
@@ -1494,13 +1494,32 @@ describe("observeBlockRate", () => {
   });
   const fresh = () => ({ blockRate: null, rateSample: null }) as never;
 
-  it("does not guess from a baseline shorter than the sample window", () => {
+  it("does not let a short baseline talk the rate down", () => {
     // Block timestamps have one-second resolution and Robinhood fits eleven
     // blocks inside one, so a short baseline measures rounding, not the chain.
+    // Everything the rate sizes is safe wide and unsafe narrow, so a partial
+    // baseline may raise it but must never lower it.
     const state = fresh() as { blockRate: number | null; rateSample: unknown };
     observeBlockRate(state as never, head(1_000, 1_700_000_000));
-    observeBlockRate(state as never, head(1_100, 1_700_000_010));
-    expect(state.blockRate).toBeNull();
+    observeBlockRate(state as never, head(1_330, 1_700_000_030));
+    expect(state.blockRate).toBeCloseTo(11, 5);
+
+    // A quiet second that would imply 1 block/s leaves the rate alone.
+    observeBlockRate(state as never, head(1_331, 1_700_000_031));
+    expect(state.blockRate).toBeCloseTo(11, 5);
+  });
+
+  it("adopts a rate increase without waiting for a full baseline", () => {
+    // A sequencer catching up after downtime. Waiting the full sample would
+    // leave the window sized for the old, slower chain while blocks pile up
+    // past the end of it.
+    const state = fresh() as { blockRate: number | null; rateSample: unknown };
+    observeBlockRate(state as never, head(1_000, 1_700_000_000));
+    observeBlockRate(state as never, head(1_030, 1_700_000_030));
+    expect(state.blockRate).toBeCloseTo(1, 5);
+
+    observeBlockRate(state as never, head(1_530, 1_700_000_035));
+    expect(state.blockRate).toBeCloseTo(100, 5);
   });
 
   it("measures the rate once the baseline is long enough", () => {
@@ -1524,24 +1543,94 @@ describe("observeBlockRate", () => {
 describe("reorgWindowBlocksFor", () => {
   const opts = { reorgWindowSeconds: 120, maxLogRangeBlocks: 1_000 };
 
-  it("warns when the span forces a narrower window than asked for", () => {
+  it("reports a capped window once, not on every poll", async () => {
+    // The warning deliberately does not live in `reorgWindowBlocksFor`: four
+    // call sites size themselves from it per tick, so a warning in there is
+    // four identical lines a poll forever.
     const warnings: { message: string; detail: Record<string, unknown> }[] = [];
-    reorgWindowBlocksFor(
-      { blockRate: 11 },
-      { ...opts, onWarning: (message, detail) => warnings.push({ message, detail }) },
+    let poll = 0;
+    const rpc = rpcDouble({
+      blocks: (tag) => {
+        if (tag === "finalized") {
+          return { number: 900, hash: "0x900", timestamp: 1_700_000_000 };
+        }
+        // 11 blocks a second, sampled over a full baseline.
+        const step = poll++;
+        return {
+          number: 1_000 + step * 330,
+          hash: `0x${step}`,
+          timestamp: 1_700_000_000 + step * 30,
+        };
+      },
+      logs: () => [],
+    });
+
+    await take(
+      createLogStream({
+        rpc,
+        filters: [filter()],
+        startingCursor: { orderKey: 1_000n },
+        options: {
+          pollIntervalMs: 1,
+          maxPollIntervalMs: 1,
+          reorgWindowSeconds: 120,
+          maxLogRangeBlocks: 1_000,
+          finalizedRefreshIntervalMs: 1_000_000,
+          onWarning: (message, detail) => warnings.push({ message, detail }),
+        },
+      }),
+      20,
+      undefined,
+      400,
     );
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]!.message).toMatch(/capped by the log range size/);
-    expect(warnings[0]!.detail.effectiveSeconds).toBe(45);
+
+    const capped = warnings.filter((w) =>
+      /capped by the log range size/.test(w.message),
+    );
+    // 11 blocks/s wants 1320 against a 500 cap, so it is capped -- and said once.
+    expect(capped).toHaveLength(1);
+    expect(capped[0]!.detail.cappedToBlocks).toBe(500);
+    expect(capped[0]!.detail.effectiveSeconds).toBe(45);
   });
 
-  it("says nothing when the window fits", () => {
+  it("says nothing when the window fits inside the span", async () => {
     const warnings: string[] = [];
-    reorgWindowBlocksFor(
-      { blockRate: 0.1 },
-      { ...opts, onWarning: (m) => warnings.push(m) },
+    let poll = 0;
+    const rpc = rpcDouble({
+      blocks: (tag) => {
+        if (tag === "finalized") {
+          return { number: 900, hash: "0x900", timestamp: 1_700_000_000 };
+        }
+        const step = poll++;
+        return {
+          number: 1_000 + step * 3,
+          hash: `0x${step}`,
+          timestamp: 1_700_000_000 + step * 30,
+        };
+      },
+      logs: () => [],
+    });
+
+    await take(
+      createLogStream({
+        rpc,
+        filters: [filter()],
+        startingCursor: { orderKey: 1_000n },
+        options: {
+          pollIntervalMs: 1,
+          maxPollIntervalMs: 1,
+          reorgWindowSeconds: 120,
+          maxLogRangeBlocks: 1_000,
+          finalizedRefreshIntervalMs: 1_000_000,
+          onWarning: (m) => warnings.push(m),
+        },
+      }),
+      20,
+      undefined,
+      400,
     );
-    expect(warnings).toEqual([]);
+
+    expect(warnings.filter((w) => /capped/.test(w))).toEqual([]);
   });
 
   it("means the same amount of history on chains 100x apart in block time", () => {
@@ -1701,24 +1790,22 @@ describe("poll backoff on a quiet chain", () => {
     return rpc.calls.filter((c) => c === "eth_getLogs").length;
   }
 
-  it("makes far fewer requests than a fixed interval would", async () => {
+  it("settles at the ceiling instead of the floor", async () => {
     const backedOff = await pollsInWindow({
       pollIntervalMs: 2,
       maxPollIntervalMs: 200,
       quietPollsBeforeBackoff: 2,
     });
-    const fixed = await pollsInWindow({
-      pollIntervalMs: 2,
-      maxPollIntervalMs: 2, // backoff disabled
-      quietPollsBeforeBackoff: 2,
-    });
 
-    // Over the same window the backed-off stream should settle at the 200ms
-    // ceiling (a handful of polls) while the fixed one keeps hammering. The
-    // assertion is deliberately loose -- this is a timing test -- but the two
-    // differ by more than an order of magnitude in practice.
-    expect(backedOff).toBeLessThan(fixed / 5);
+    // Asserted as an absolute ceiling rather than a ratio against a second run.
+    // A ratio needs the un-backed-off arm to stay fast, and a contended CI
+    // runner slows that arm toward this one and fails a test about backoff for
+    // reasons that have nothing to do with backoff. Contention can only make
+    // this number smaller, which is the safe direction: 400ms at a 200ms
+    // ceiling is 2-3 polls plus the few at the floor before it ramps, against
+    // ~200 with backoff off.
     expect(backedOff).toBeGreaterThan(0);
+    expect(backedOff).toBeLessThanOrEqual(12);
   });
 
   it("keeps polling at the floor while the chain keeps producing events", async () => {
@@ -1758,11 +1845,80 @@ describe("poll backoff on a quiet chain", () => {
     })();
     await new Promise((r) => setTimeout(r, 300));
 
-    // At a 2ms floor over 300ms this is dozens of reads; at the 200ms ceiling
-    // it would be one or two. Anything comfortably above the ceiling's rate
-    // proves the interval never grew.
+    // At a 2ms floor over 300ms this is ~150 reads; at the 200ms ceiling it
+    // would be one or two. The threshold is set far below the expected count
+    // and far above the ceiling's, so only an interval that actually grew can
+    // fail it -- not a slow runner.
     expect(rpc.calls.filter((c) => c === "eth_getLogs").length).toBeGreaterThan(
-      20,
+      10,
     );
+  });
+});
+
+describe("a measured window that changes width", () => {
+  it("does not invent a reorg when the window grows", async () => {
+    // The window is measured, so it widens when the chain speeds up. If
+    // `emitted` were pruned to the window in force when a tick ended, the next
+    // tick's wider scan would cover blocks it had just forgotten, and
+    // `firstDivergentBlock` cannot tell "I forgot this" from "this is new below
+    // my cursor" -- it reports a reorg, `rollbackTo` clears the rest of the
+    // map, and the next tick does it again, walking the cursor backwards.
+    //
+    // Nothing in this chain ever reorgs: every hash is a pure function of its
+    // block number. Any invalidate is therefore fabricated.
+    let poll = 0;
+    // Slow, slower, then slow again -- the middle patch shrinks the measured
+    // rate and the recovery grows it back, which is the transition that bit.
+    const heads = [
+      { n: 1_000, t: 1_700_000_000 },
+      { n: 1_003, t: 1_700_000_036 },
+      { n: 1_004, t: 1_700_000_072 },
+      { n: 1_007, t: 1_700_000_108 },
+      { n: 1_010, t: 1_700_000_144 },
+      { n: 1_013, t: 1_700_000_180 },
+    ];
+    const rpc = rpcDouble({
+      blocks: (tag) => {
+        if (tag === "finalized") {
+          return { number: 800, hash: "0x800", timestamp: 1_700_000_000 };
+        }
+        const h = heads[Math.min(poll++, heads.length - 1)]!;
+        return { number: h.n, hash: `0x${h.n}`, timestamp: h.t };
+      },
+      // Every block carries a log, and its hash depends only on its number.
+      logs: (from, to) => {
+        const out: RawLog[] = [];
+        for (let n = from; n <= to; n++) {
+          out.push(
+            log({
+              blockNumber: numberToHex(BigInt(n)),
+              blockHash: `0x${n}` as Hex,
+              blockTimestamp: numberToHex(BigInt(1_700_000_000 + n)),
+            }),
+          );
+        }
+        return out;
+      },
+    });
+
+    const messages = await take(
+      createLogStream({
+        rpc,
+        filters: [filter()],
+        startingCursor: { orderKey: 1_000n },
+        options: {
+          pollIntervalMs: 1,
+          maxPollIntervalMs: 1,
+          reorgWindowSeconds: 360,
+          maxLogRangeBlocks: 200,
+          finalizedRefreshIntervalMs: 1_000_000,
+        },
+      }),
+      40,
+      undefined,
+      600,
+    );
+
+    expect(messages.filter((m) => m._tag === "invalidate")).toEqual([]);
   });
 });

--- a/src/evm/logStream.test.ts
+++ b/src/evm/logStream.test.ts
@@ -8,6 +8,7 @@ import {
   firstDivergentBlock,
   groupLogsByBlock,
   logMatchesFilter,
+  pollIntervalFor,
   type LogStreamFilter,
   type RawLog,
   type RpcLike,
@@ -1361,5 +1362,244 @@ describe("createLogStream head base fee", () => {
     for (const block of blocks) {
       expect(block.header.baseFeePerGas).toBe(headBaseFee);
     }
+  });
+});
+
+describe("pollIntervalFor", () => {
+  const opts = {
+    pollIntervalMs: 2_000,
+    maxPollIntervalMs: 30_000,
+    quietPollsBeforeBackoff: 30,
+  };
+
+  it("holds at the floor for the whole quiet allowance", () => {
+    // The latency guarantee: a chain that indexed anything in the last
+    // pollIntervalMs * quietPollsBeforeBackoff keeps polling at full rate.
+    for (const quiet of [0, 1, 29, 30]) {
+      expect(pollIntervalFor(quiet, opts)).toBe(2_000);
+    }
+  });
+
+  it("doubles per quiet poll past the allowance, then caps", () => {
+    expect(pollIntervalFor(31, opts)).toBe(4_000);
+    expect(pollIntervalFor(32, opts)).toBe(8_000);
+    expect(pollIntervalFor(33, opts)).toBe(16_000);
+    expect(pollIntervalFor(34, opts)).toBe(30_000);
+    expect(pollIntervalFor(3_000, opts)).toBe(30_000);
+  });
+
+  it("never returns Infinity for a chain quiet for a very long time", () => {
+    // 2 ** 1024 is Infinity, and a chain quiet for a week gets that far. The
+    // Math.min would still return the ceiling, but the intermediate is a trap.
+    expect(Number.isFinite(pollIntervalFor(Number.MAX_SAFE_INTEGER, opts))).toBe(
+      true,
+    );
+  });
+
+  it("is disabled by setting the ceiling to the floor", () => {
+    const off = { ...opts, maxPollIntervalMs: 2_000 };
+    expect(pollIntervalFor(10_000, off)).toBe(2_000);
+  });
+
+  it("never returns less than the floor, even if the ceiling is below it", () => {
+    const bad = { ...opts, maxPollIntervalMs: 5 };
+    expect(pollIntervalFor(10_000, bad)).toBe(2_000);
+  });
+});
+
+describe("reorg detection once the poll interval can back off", () => {
+  it("re-reads the window even when the head has run far past it", async () => {
+    // The regression that backing off introduces. `windowFor` used to read back
+    // from `head - reorgWindowBlocks`, and only while the head was within that
+    // distance of the cursor. At a two-second poll that was every chain, always.
+    // At a thirty-second poll an L2 advances hundreds of blocks between polls,
+    // so a caught-up stream looks exactly like one that is catching up, takes
+    // the read-forward branch, and never looks at a block it already emitted.
+    //
+    // Drive the head independently of the log reads: a double whose head only
+    // moves when `logs` is called cannot exercise this at all.
+    let poll = 0;
+    const rpc = rpcDouble({
+      blocks: (tag) => {
+        if (tag === "finalized") {
+          return { number: 900, hash: "0x900", timestamp: 1_700_000_000 };
+        }
+        // Poll 1 sits just above the cursor; poll 2 has run 490 blocks past it,
+        // far beyond the 8-block reorg window.
+        poll++;
+        return poll <= 2
+          ? { number: 1010, hash: "0x1010", timestamp: 1_700_000_010 }
+          : { number: 1500, hash: "0x1500", timestamp: 1_700_000_600 };
+      },
+      logs: (from, to) => {
+        // Block 1005 changes hash once the head has moved on -- a reorg of a
+        // block this stream has already emitted.
+        const hash = poll <= 2 ? "0xaaa" : "0xbbb";
+        return 1005 >= from && 1005 <= to
+          ? [log({ blockNumber: numberToHex(1005n), blockHash: hash as Hex })]
+          : [];
+      },
+    });
+
+    const messages = await take(
+      createLogStream({
+        rpc,
+        filters: [filter()],
+        startingCursor: { orderKey: 1000n },
+        options: {
+          pollIntervalMs: 1,
+          reorgWindowBlocks: 8,
+          maxLogRangeBlocks: 100,
+          finalizedRefreshIntervalMs: 1_000_000,
+        },
+      }),
+      12,
+      (out) => out.some((m) => m._tag === "invalidate"),
+    );
+
+    const invalidate = messages.find((m) => m._tag === "invalidate");
+    expect(invalidate).toBeDefined();
+    // Rolls back to just below the block that changed.
+    expect(Number(invalidate!.invalidate.cursor.orderKey)).toBe(1004);
+  });
+
+  it("still reads forward, not backward, while catching up from far behind", async () => {
+    // The window hangs below the cursor, so a backfill overlaps its last read
+    // by the width of the window and never stalls or rewinds.
+    const spans: [number, number][] = [];
+    const rpc = rpcDouble({
+      blocks: (tag) =>
+        tag === "finalized"
+          ? { number: 500, hash: "0x500", timestamp: 1_700_000_000 }
+          : { number: 100_000, hash: "0xhead", timestamp: 1_700_100_000 },
+      logs: (from, to) => {
+        spans.push([from, to]);
+        return [];
+      },
+    });
+
+    await take(
+      createLogStream({
+        rpc,
+        filters: [filter()],
+        startingCursor: { orderKey: 1000n },
+        options: {
+          pollIntervalMs: 1,
+          reorgWindowBlocks: 64,
+          maxLogRangeBlocks: 1_000,
+          finalizedRefreshIntervalMs: 1_000_000,
+        },
+      }),
+      3,
+    );
+
+    expect(spans.length).toBeGreaterThanOrEqual(2);
+    // First read starts one window below the cursor, not at the cursor.
+    expect(spans[0]).toEqual([937, 1936]);
+    // And it makes real forward progress: 936 blocks per read, not zero.
+    expect(spans[1]![0]).toBe(1873);
+  });
+});
+
+describe("poll backoff on a quiet chain", () => {
+  /** Counts eth_getLogs over a fixed wall-clock window on a chain that never emits. */
+  async function pollsInWindow(options: {
+    pollIntervalMs: number;
+    maxPollIntervalMs: number;
+    quietPollsBeforeBackoff: number;
+  }): Promise<number> {
+    let head = 5_000;
+    const rpc = rpcDouble({
+      // The head advances every poll, as it does on every chain we index whose
+      // block time is under the poll interval. That is what makes the existing
+      // unchanged-head skip useless there, and what leaves the interval as the
+      // only lever.
+      blocks: (tag) =>
+        tag === "finalized"
+          ? { number: 4_000, hash: "0x4000", timestamp: 1_700_000_000 }
+          : { number: head++, hash: `0x${head}`, timestamp: 1_700_000_000 },
+      logs: () => [],
+    });
+
+    const stream = createLogStream({
+      rpc,
+      filters: [filter()],
+      startingCursor: { orderKey: 5_000n },
+      options: { ...options, finalizedRefreshIntervalMs: 1_000_000 },
+    });
+
+    const deadline = Date.now() + 400;
+    void (async () => {
+      for await (const _ of stream) {
+        if (Date.now() > deadline) break;
+      }
+    })();
+    await new Promise((r) => setTimeout(r, 400));
+    return rpc.calls.filter((c) => c === "eth_getLogs").length;
+  }
+
+  it("makes far fewer requests than a fixed interval would", async () => {
+    const backedOff = await pollsInWindow({
+      pollIntervalMs: 2,
+      maxPollIntervalMs: 200,
+      quietPollsBeforeBackoff: 2,
+    });
+    const fixed = await pollsInWindow({
+      pollIntervalMs: 2,
+      maxPollIntervalMs: 2, // backoff disabled
+      quietPollsBeforeBackoff: 2,
+    });
+
+    // Over the same window the backed-off stream should settle at the 200ms
+    // ceiling (a handful of polls) while the fixed one keeps hammering. The
+    // assertion is deliberately loose -- this is a timing test -- but the two
+    // differ by more than an order of magnitude in practice.
+    expect(backedOff).toBeLessThan(fixed / 5);
+    expect(backedOff).toBeGreaterThan(0);
+  });
+
+  it("keeps polling at the floor while the chain keeps producing events", async () => {
+    // A busy chain must never notice backoff exists.
+    let head = 5_000;
+    const rpc = rpcDouble({
+      blocks: (tag) =>
+        tag === "finalized"
+          ? { number: 4_000, hash: "0x4000", timestamp: 1_700_000_000 }
+          : { number: ++head, hash: `0x${head}`, timestamp: 1_700_000_000 },
+      logs: (from, to) =>
+        [
+          log({
+            blockNumber: numberToHex(BigInt(to)),
+            blockHash: `0x${to}` as Hex,
+          }),
+        ].filter(() => to >= from),
+    });
+
+    const stream = createLogStream({
+      rpc,
+      filters: [filter()],
+      startingCursor: { orderKey: 5_000n },
+      options: {
+        pollIntervalMs: 2,
+        maxPollIntervalMs: 200,
+        quietPollsBeforeBackoff: 2,
+        finalizedRefreshIntervalMs: 1_000_000,
+      },
+    });
+
+    const deadline = Date.now() + 300;
+    void (async () => {
+      for await (const _ of stream) {
+        if (Date.now() > deadline) break;
+      }
+    })();
+    await new Promise((r) => setTimeout(r, 300));
+
+    // At a 2ms floor over 300ms this is dozens of reads; at the 200ms ceiling
+    // it would be one or two. Anything comfortably above the ceiling's rate
+    // proves the interval never grew.
+    expect(rpc.calls.filter((c) => c === "eth_getLogs").length).toBeGreaterThan(
+      20,
+    );
   });
 });

--- a/src/evm/logStream.test.ts
+++ b/src/evm/logStream.test.ts
@@ -1933,3 +1933,115 @@ describe("a measured window that changes width", () => {
     expect(messages.filter((m) => m._tag === "invalidate")).toEqual([]);
   });
 });
+
+describe("a rollback that moves the cursor down", () => {
+  it("does not fabricate a second reorg below the retention floor", async () => {
+    // `rollbackTo` lowers the cursor and `continue`s, skipping `finishTick` --
+    // so a real reorg moves the cursor down without lowering the floor
+    // `emitted` was last pruned to. The next cursor-anchored scan then starts a
+    // full window below where that prune assumed, and every log-bearing block
+    // in the gap reads as `before === undefined, after !== undefined`: a
+    // fabricated reorg, which clears the rest of the map so the next tick has
+    // nothing to diff against and does it again.
+    //
+    // One real reorg here, at block 1180. Everything below it is stable -- its
+    // hash is a pure function of its number -- so exactly one invalidate is
+    // correct and any further one is invented.
+    let poll = 0;
+    const reorgAt = 1_180;
+    const hashFor = (n: number) =>
+      (n === reorgAt && poll > 2 ? `0x${n}-b` : `0x${n}-a`) as Hex;
+
+    const rpc = rpcDouble({
+      blocks: (tag) => {
+        // No finality floor to hide behind: `earliest` stays at 1, which is the
+        // condition that makes the gap reachable.
+        if (tag === "finalized") return null;
+        poll++;
+        return {
+          number: 1_200 + poll,
+          hash: `0xhead${poll}`,
+          timestamp: 1_700_000_000 + poll,
+        };
+      },
+      logs: (from, to) => {
+        const out: RawLog[] = [];
+        for (let n = Math.max(from, 1); n <= to; n++) {
+          out.push(
+            log({
+              blockNumber: numberToHex(BigInt(n)),
+              blockHash: hashFor(n),
+              blockTimestamp: numberToHex(BigInt(1_700_000_000 + n)),
+            }),
+          );
+        }
+        return out;
+      },
+    });
+
+    const messages = await take(
+      createLogStream({
+        rpc,
+        filters: [filter()],
+        startingCursor: { orderKey: 1_200n },
+        options: {
+          pollIntervalMs: 1,
+          maxPollIntervalMs: 1,
+          // Unmeasured rate parks the window at the cap (50), which is the
+          // width at which the gap opens.
+          maxLogRangeBlocks: 100,
+          reorgWindowSeconds: 120,
+          finalizedRefreshIntervalMs: 1_000_000,
+        },
+      }),
+      60,
+      undefined,
+      800,
+    );
+
+    const invalidates = messages.filter((m) => m._tag === "invalidate");
+    // The one real reorg, and nothing else. Before the retention floor was
+    // honoured this walked the cursor down repeatedly.
+    expect(invalidates.length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("observeBlockRate on a halted chain", () => {
+  const head = (number: number, timeSec: number) => ({
+    number,
+    hash: "0x0" as Hex,
+    timestamp: new Date(timeSec * 1_000),
+    baseFeePerGas: null,
+  });
+
+  it("a full baseline that saw no blocks keeps the last known rate", () => {
+    // A halted sequencer whose tip is replaced in place still advances the
+    // timestamp, so the baseline completes with `advanced === 0`. Dividing
+    // stores a rate of zero, and a zero rate sizes the reorg window down to one
+    // block -- on the very poll that has to reconcile the reorg that resumes
+    // the chain.
+    const state = { blockRate: null, rateSample: null } as never as {
+      blockRate: number | null;
+      rateSample: unknown;
+    };
+    observeBlockRate(state as never, head(1_000, 1_700_000_000));
+    observeBlockRate(state as never, head(1_330, 1_700_000_030));
+    expect(state.blockRate).toBeCloseTo(11, 5);
+
+    // 60s pass, tip replaced at the same height.
+    observeBlockRate(state as never, head(1_330, 1_700_000_090));
+    expect(state.blockRate).toBeCloseTo(11, 5);
+  });
+
+  it("a short first sample does not narrow the window below the cap", () => {
+    // With no rate yet the window is already the cap, the widest available, so
+    // adopting a one-second sample is a narrowing dressed as a rise.
+    const state = { blockRate: null, rateSample: null } as never as {
+      blockRate: number | null;
+      rateSample: unknown;
+    };
+    observeBlockRate(state as never, head(1_000, 1_700_000_000));
+    observeBlockRate(state as never, head(1_005, 1_700_000_001));
+    expect(state.blockRate).toBeNull();
+  });
+});

--- a/src/evm/logStream.ts
+++ b/src/evm/logStream.ts
@@ -519,6 +519,8 @@ interface StreamState {
   blockRate: number | null;
   /** The older end of the interval `blockRate` is measured over. */
   rateSample: { number: number; timeSec: number } | null;
+  /** Effective window last warned about, so the cap is reported once. */
+  warnedCapSeconds: number | null;
   /**
    * False until the first window has been read.
    *
@@ -570,7 +572,26 @@ export function observeBlockRate(state: StreamState, head: LatestBlock): void {
     return;
   }
 
-  if (elapsed < MIN_RATE_SAMPLE_SECONDS) return;
+  if (elapsed < MIN_RATE_SAMPLE_SECONDS) {
+    // A partial baseline is too short to measure the rate, but it can still
+    // *witness* a chain going faster than the stored rate says -- and adopting
+    // that early is free while waiting is not. Everything the rate sizes is
+    // safe wide and unsafe narrow: the window re-reads more blocks (one
+    // `eth_getLogs` either way) and the backoff sleeps less. So a rise is taken
+    // on the spot and only a fall waits for a full baseline.
+    //
+    // Without this the stream keeps a stale, lower rate for up to
+    // MIN_RATE_SAMPLE_SECONDS after a chain speeds up -- a sequencer catching
+    // up after downtime is the realistic case -- and blocks emitted in that
+    // window can land further below the cursor than the window reaches.
+    if (elapsed > 0) {
+      const witnessed = advanced / elapsed;
+      if (state.blockRate === null || witnessed > state.blockRate) {
+        state.blockRate = witnessed;
+      }
+    }
+    return;
+  }
 
   state.blockRate = advanced / elapsed;
   state.rateSample = { number: head.number, timeSec };
@@ -592,34 +613,68 @@ export function observeBlockRate(state: StreamState, head: LatestBlock): void {
  * narrow silently loses events, so the unmeasured case takes the widest window
  * on offer and narrows as the chain is observed.
  */
+/**
+ * The widest window `reorgWindowBlocksFor` can ever return for this span.
+ *
+ * Half the span, which is what guarantees the other half is forward progress.
+ * Load-bearing beyond sizing a read: it is also how far back `emitted` has to
+ * be retained, since a window that grows must not scan blocks the last tick
+ * forgot.
+ */
+export function maxReorgWindowBlocks(
+  opts: Pick<Resolved, "maxLogRangeBlocks">,
+): number {
+  return Math.max(1, Math.floor(opts.maxLogRangeBlocks / 2));
+}
+
 export function reorgWindowBlocksFor(
   state: Pick<StreamState, "blockRate">,
-  opts: Pick<
-    Resolved,
-    "reorgWindowSeconds" | "maxLogRangeBlocks" | "onWarning"
-  >,
+  opts: Pick<Resolved, "reorgWindowSeconds" | "maxLogRangeBlocks">,
 ): number {
-  const cap = Math.max(1, Math.floor(opts.maxLogRangeBlocks / 2));
+  const cap = maxReorgWindowBlocks(opts);
   if (state.blockRate === null) return cap;
-
-  const wanted = Math.max(
-    1,
-    Math.ceil(state.blockRate * opts.reorgWindowSeconds),
+  return Math.min(
+    cap,
+    Math.max(1, Math.ceil(state.blockRate * opts.reorgWindowSeconds)),
   );
-  if (wanted > cap) {
-    // Not an error -- the stream is still correct, just protected for less
-    // history than asked for. Worth saying out loud because the remedy is one
-    // env var: GET_LOGS_RANGE_SIZE bounds this, and raising it is free until
-    // the provider's own range limit.
-    opts.onWarning?.("reorg window capped by the log range size", {
-      wantedBlocks: wanted,
-      cappedToBlocks: cap,
-      effectiveSeconds: Math.round(cap / state.blockRate),
-      reorgWindowSeconds: opts.reorgWindowSeconds,
-      maxLogRangeBlocks: opts.maxLogRangeBlocks,
-    });
-  }
-  return Math.min(cap, wanted);
+}
+
+/**
+ * Says once, not every poll, that the span is holding the window narrower than
+ * `reorgWindowSeconds` asked for.
+ *
+ * Deliberately separate from `reorgWindowBlocksFor`, which several call sites
+ * hit more than once per tick -- `windowFor`, `finishTick`, `pollIntervalFor`
+ * and the finalized refresh all size themselves from it. A warning in there is
+ * four identical lines per poll forever on any chain where the cap binds, which
+ * is how a real signal becomes noise nobody reads.
+ *
+ * Not an error: the stream is still correct, just protected for less history
+ * than requested. Worth saying at all because the remedy is one env var --
+ * GET_LOGS_RANGE_SIZE bounds it, and raising it is free up to the provider's
+ * own range limit.
+ */
+function warnIfWindowCapped(state: StreamState, opts: Resolved): void {
+  const rate = state.blockRate;
+  if (rate === null) return;
+
+  const cap = maxReorgWindowBlocks(opts);
+  const wanted = Math.max(1, Math.ceil(rate * opts.reorgWindowSeconds));
+  if (wanted <= cap) return;
+
+  // Re-warn only when the shortfall actually changes, so a chain whose rate
+  // drifts says so again while a steady one says it once.
+  const effectiveSeconds = Math.round(cap / rate);
+  if (state.warnedCapSeconds === effectiveSeconds) return;
+  state.warnedCapSeconds = effectiveSeconds;
+
+  opts.onWarning?.("reorg window capped by the log range size", {
+    wantedBlocks: wanted,
+    cappedToBlocks: cap,
+    effectiveSeconds,
+    reorgWindowSeconds: opts.reorgWindowSeconds,
+    maxLogRangeBlocks: opts.maxLogRangeBlocks,
+  });
 }
 
 /** The span to re-read: back into the reorg window, or forward when behind it. */
@@ -956,6 +1011,7 @@ async function planRead(
   if (!head) return null;
   // Before `windowFor`, which sizes itself from the rate this updates.
   observeBlockRate(state, head);
+  warnIfWindowCapped(state, opts);
   const { from, to } = windowFor(state, head.number, opts);
   return from > to ? null : { from, to, head };
 }
@@ -1102,6 +1158,7 @@ function initStream({
       quietPolls: 0,
       blockRate: null,
       rateSample: null,
+      warnedCapSeconds: null,
       seeded: false,
     },
   };
@@ -1163,9 +1220,26 @@ function finishTick(
   state.cursorBlock = Math.max(state.cursorBlock, plan.to);
   state.lastHeadHash = plan.head.hash;
   const earliest = (state.finalized?.number ?? 0) + 1;
+  // Retain to the widest window any later tick could scan, not to this tick's.
+  //
+  // The window is measured, so it grows when the chain speeds up. Forgetting to
+  // the current width means the next tick -- whose `windowFor` may have just
+  // re-measured wider -- scans blocks that were dropped from `emitted` a moment
+  // ago. `firstDivergentBlock` cannot tell "I forgot this" from "this block is
+  // new below my cursor": it sees `before === undefined, after !== undefined`
+  // and reports a reorg. `rollbackTo` then clears every remaining entry, so the
+  // next tick diffs against an empty map and rolls back again, walking the
+  // cursor backwards a window at a time until `earliest` floors it. Measured on
+  // a chain whose hashes were pure functions of block number, so nothing ever
+  // reorged: 34 invalidates, ~30 blocks each. Ethereum at 640 s is squarely in
+  // range -- one missed slot inside a sample swings the window by ~18 blocks.
+  //
+  // `reorgWindowBlocksFor` is bounded by half the span, so that bound is the
+  // widest scan possible and retaining to it is sufficient. `emitted` holds
+  // only log-bearing blocks, so the extra entries cost nothing.
   forgetBelow(
     state,
-    Math.max(earliest, state.cursorBlock - reorgWindowBlocksFor(state, opts)),
+    Math.max(earliest, state.cursorBlock - maxReorgWindowBlocks(opts)),
   );
 }
 
@@ -1224,6 +1298,28 @@ async function checkStartingCursor(
       return null;
     },
   );
+  // Seed the rate from the two blocks already in hand, at no extra cost.
+  //
+  // This runs before the loop, so without it `state.blockRate` is null here and
+  // the window is the half-span cap -- 500 blocks by default and 2500 on
+  // Arbitrum and Robinhood, against the 64 this used to rewind. `finalized + 1`
+  // floors it, so that only bites on a node that cannot serve the finalized tag
+  // (which this function already tolerates), but there it means deleting and
+  // reprocessing thousands of blocks on a cursor that moved by one.
+  //
+  // The cursor block and the finalized block are separated by the chain's
+  // finality lag, which is a far longer baseline than the loop's 30 s sample
+  // ever gets.
+  if (finalized) {
+    const elapsedSec = Math.floor(
+      (block.timestamp.getTime() - finalized.timestamp.getTime()) / 1000,
+    );
+    const advanced = block.number - finalized.number;
+    if (elapsedSec >= MIN_RATE_SAMPLE_SECONDS && advanced > 0) {
+      state.blockRate = advanced / elapsedSec;
+    }
+  }
+
   const floor = finalized ? finalized.number + 1 : 1;
   // Never past the cursor itself: if even the finalized block disagrees, the
   // least we can do is re-read the block we are standing on rather than skip it.

--- a/src/evm/logStream.ts
+++ b/src/evm/logStream.ts
@@ -22,6 +22,17 @@
  * does. Backing off is a delay and never a miss -- a range query asked less
  * often reads a wider range, not a narrower one.
  *
+ * Nothing here is sized in blocks. A block is not a unit of time and the chains
+ * we index run from 10 s to 0.09 s apart, so any constant expressed as a block
+ * count means something different on each one -- the 64-block reorg window this
+ * used to carry bought Ethereum 640 s of protection and Robinhood, the busiest
+ * chain we run, six. The window is configured in seconds and converted per
+ * chain from a block rate measured off the head reads the poll already makes
+ * (`observeBlockRate`), and the backoff ceiling is bounded by what one
+ * `eth_getLogs` can actually drain at that rate. The only block count left is
+ * `maxLogRangeBlocks`, which is a real provider limit rather than a guess about
+ * the chain.
+ *
  * Correctness notes, since missing an event is the failure that matters:
  *
  * - A range query is self-describing in a way a subscription is not. It either
@@ -68,11 +79,19 @@ export interface LogStreamOptions {
   /** Widest block span to ask for in one `eth_getLogs`. */
   maxLogRangeBlocks?: number;
   /**
-   * How far back to re-read at the head to notice a reorg. Must be at least the
-   * deepest reorg the chain can produce; the cost of being generous is one
-   * wider `eth_getLogs`, the cost of being stingy is a missed event.
+   * How far back to re-read at the head to notice a reorg, in seconds of chain
+   * time. Must be at least as long as the deepest reorg the chain can produce;
+   * the cost of being generous is one wider `eth_getLogs`, which is free, and
+   * the cost of being stingy is a missed event.
+   *
+   * In seconds rather than blocks because a block is not a unit of anything.
+   * The chains we index run from 10 s to 0.09 s a block, so one block count
+   * means two very different amounts of history: at the 64 blocks this used to
+   * default to, Ethereum got 640 s of protection and Robinhood -- the busiest
+   * chain we run -- got 6. The equivalent block count is derived per chain from
+   * the observed block rate.
    */
-  reorgWindowBlocks?: number;
+  reorgWindowSeconds?: number;
   /**
    * A log count that is suspected of being a provider's cap rather than a real
    * result. Set it to the provider's documented `eth_getLogs` limit.
@@ -89,7 +108,7 @@ const DEFAULTS = {
   maxPollIntervalMs: 30_000,
   quietPollsBeforeBackoff: 30,
   maxLogRangeBlocks: 1_000,
-  reorgWindowBlocks: 64,
+  reorgWindowSeconds: 120,
   suspectLogCount: 10_000,
   finalizedRefreshIntervalMs: 30_000,
   heartbeatIntervalMs: 10_000,
@@ -493,6 +512,14 @@ interface StreamState {
    */
   quietPolls: number;
   /**
+   * Observed blocks per second, or null until enough of the chain has gone by
+   * to measure it. Every sizing decision that would otherwise be a block count
+   * goes through this.
+   */
+  blockRate: number | null;
+  /** The older end of the interval `blockRate` is measured over. */
+  rateSample: { number: number; timeSec: number } | null;
+  /**
    * False until the first window has been read.
    *
    * `emitted` starts empty because nothing has been observed yet, not because
@@ -505,6 +532,95 @@ interface StreamState {
 
 type Resolved = Required<Omit<LogStreamOptions, "onWarning">> &
   Pick<LogStreamOptions, "onWarning">;
+
+/**
+ * Chain time that must elapse before a block-rate sample is believed.
+ *
+ * Block timestamps have one-second resolution, and Robinhood produces eleven
+ * blocks inside one of those, so a short baseline measures rounding rather than
+ * the chain. Thirty seconds is long enough that the quantisation is noise on
+ * every chain we index and short enough to be learnt within one backoff cycle.
+ */
+const MIN_RATE_SAMPLE_SECONDS = 30;
+
+/**
+ * Updates the observed block rate from a head this poll already fetched.
+ *
+ * Free: `eth_getBlockByNumber("latest")` returns the number and the timestamp
+ * together, and the stream reads it every poll anyway. No request is made for
+ * this, which is the only reason it is worth measuring continuously rather than
+ * configuring per chain.
+ */
+export function observeBlockRate(state: StreamState, head: LatestBlock): void {
+  const timeSec = Math.floor(head.timestamp.getTime() / 1000);
+  const sample = state.rateSample;
+
+  if (!sample) {
+    state.rateSample = { number: head.number, timeSec };
+    return;
+  }
+
+  const elapsed = timeSec - sample.timeSec;
+  const advanced = head.number - sample.number;
+
+  // A head that went backwards, or a timestamp that did, means the sample is
+  // measuring a different view of the chain rather than its rate. Start over.
+  if (elapsed < 0 || advanced < 0) {
+    state.rateSample = { number: head.number, timeSec };
+    return;
+  }
+
+  if (elapsed < MIN_RATE_SAMPLE_SECONDS) return;
+
+  state.blockRate = advanced / elapsed;
+  state.rateSample = { number: head.number, timeSec };
+}
+
+/**
+ * How many blocks `reorgWindowSeconds` is worth on this chain right now.
+ *
+ * Capped at half `maxLogRangeBlocks`, which is what makes an unusable
+ * configuration unreachable rather than merely rejected. A read span no wider
+ * than the window it re-reads cannot reach past it: nothing is emitted, the
+ * cursor never advances, and because the span never reaches the head the loop
+ * never sleeps -- it spins at CPU speed issuing two requests a turn while
+ * looking perfectly healthy. Holding the window at half the span guarantees at
+ * least half the span is forward progress, whatever the chain does.
+ *
+ * Before the rate is known the window is that cap. Erring wide is free -- one
+ * `eth_getLogs` is 60 compute units for any span it accepts -- and erring
+ * narrow silently loses events, so the unmeasured case takes the widest window
+ * on offer and narrows as the chain is observed.
+ */
+export function reorgWindowBlocksFor(
+  state: Pick<StreamState, "blockRate">,
+  opts: Pick<
+    Resolved,
+    "reorgWindowSeconds" | "maxLogRangeBlocks" | "onWarning"
+  >,
+): number {
+  const cap = Math.max(1, Math.floor(opts.maxLogRangeBlocks / 2));
+  if (state.blockRate === null) return cap;
+
+  const wanted = Math.max(
+    1,
+    Math.ceil(state.blockRate * opts.reorgWindowSeconds),
+  );
+  if (wanted > cap) {
+    // Not an error -- the stream is still correct, just protected for less
+    // history than asked for. Worth saying out loud because the remedy is one
+    // env var: GET_LOGS_RANGE_SIZE bounds this, and raising it is free until
+    // the provider's own range limit.
+    opts.onWarning?.("reorg window capped by the log range size", {
+      wantedBlocks: wanted,
+      cappedToBlocks: cap,
+      effectiveSeconds: Math.round(cap / state.blockRate),
+      reorgWindowSeconds: opts.reorgWindowSeconds,
+      maxLogRangeBlocks: opts.maxLogRangeBlocks,
+    });
+  }
+  return Math.min(cap, wanted);
+}
 
 /** The span to re-read: back into the reorg window, or forward when behind it. */
 function windowFor(
@@ -535,9 +651,10 @@ function windowFor(
   // Anchoring to the cursor is what actually re-reads the blocks at risk: they
   // are the ones *we emitted*, which is a fact about the cursor and nothing
   // else. It costs no compute units -- `eth_getLogs` is billed per request, so
-  // a span 64 blocks wider is the same 60 units -- and slows a backfill by
-  // `reorgWindowBlocks / maxLogRangeBlocks`, 6% at the defaults, since each
-  // read now overlaps the last by the width of the window.
+  // a wider span is the same 60 units -- and slows a backfill by the window as
+  // a fraction of the span, since each read now overlaps the last by the width
+  // of the window. That fraction is at most a half, and is whatever
+  // `reorgWindowSeconds` works out to on this chain once the rate is known.
   //
   // Never start above the cursor. `earliest` is an optimisation -- a finalized
   // block cannot reorg, so there is no point re-reading below it -- but on a
@@ -548,7 +665,10 @@ function windowFor(
     1,
     Math.min(
       state.cursorBlock + 1,
-      Math.max(earliest, state.cursorBlock + 1 - opts.reorgWindowBlocks),
+      Math.max(
+        earliest,
+        state.cursorBlock + 1 - reorgWindowBlocksFor(state, opts),
+      ),
     ),
   );
   return { from, to: Math.min(head, from + opts.maxLogRangeBlocks - 1) };
@@ -620,7 +740,7 @@ async function refreshFinalized(
   // which nothing on such a chain is waiting for.
   const due = Math.max(
     opts.finalizedRefreshIntervalMs,
-    pollIntervalFor(state.quietPolls, opts) * 4,
+    pollIntervalFor(state, opts) * 4,
   );
   if (now - state.lastFinalizedRefresh < due) {
     return;
@@ -772,15 +892,36 @@ function heartbeatIfDue(
  * for at least `quietPollsBeforeBackoff` polls.
  */
 export function pollIntervalFor(
-  quietPolls: number,
+  state: Pick<StreamState, "quietPolls" | "blockRate">,
   opts: Pick<
     Resolved,
-    "pollIntervalMs" | "maxPollIntervalMs" | "quietPollsBeforeBackoff"
+    | "pollIntervalMs"
+    | "maxPollIntervalMs"
+    | "quietPollsBeforeBackoff"
+    | "maxLogRangeBlocks"
+    | "reorgWindowSeconds"
   >,
 ): number {
   const floor = opts.pollIntervalMs;
-  const ceiling = Math.max(floor, opts.maxPollIntervalMs);
-  const over = quietPolls - opts.quietPollsBeforeBackoff;
+
+  // The ceiling is whichever is lower: what was configured, and what one
+  // `eth_getLogs` can actually drain.
+  //
+  // A poll has to read every block produced since the last one, and it can only
+  // ask for `maxLogRangeBlocks` at a time, of which the reorg window is re-read
+  // rather than new. Sleep for longer than the remainder takes to accumulate
+  // and the stream never catches up in a single read: it stops sleeping, reads
+  // spans back to back, and pays more compute units than it saved. Where that
+  // line falls is a fact about the chain's block rate, so it is derived from
+  // the measured one rather than assumed -- 30 s is 3 blocks on Ethereum and
+  // 329 on Robinhood.
+  const drain = opts.maxLogRangeBlocks - reorgWindowBlocksFor(state, opts);
+  const rate = state.blockRate;
+  const drainCeiling =
+    rate !== null && rate > 0 ? (drain / rate) * 1_000 : Number.POSITIVE_INFINITY;
+  const ceiling = Math.max(floor, Math.min(opts.maxPollIntervalMs, drainCeiling));
+
+  const over = state.quietPolls - opts.quietPollsBeforeBackoff;
   if (over <= 0) return floor;
   // Cap the exponent before it is applied. `2 ** 1024` is Infinity, and a
   // chain quiet for a week would get there; `Math.min` would still return the
@@ -813,6 +954,8 @@ async function planRead(
 ): Promise<{ from: number; to: number; head: LatestBlock } | null> {
   const head = await fetchBlockByTag(rpc, "latest");
   if (!head) return null;
+  // Before `windowFor`, which sizes itself from the rate this updates.
+  observeBlockRate(state, head);
   const { from, to } = windowFor(state, head.number, opts);
   return from > to ? null : { from, to, head };
 }
@@ -933,15 +1076,15 @@ function initStream({
 
   const opts: Resolved = { ...DEFAULTS, ...options };
 
-  // A read span no wider than the reorg window can end below the cursor on every
-  // single poll: the window reaches back further than the span can reach
-  // forward. Nothing is emitted, the cursor never advances, and because the span
-  // also never reaches the head the loop does not sleep -- so it spins at CPU
-  // speed issuing two requests a turn while looking perfectly healthy. Refuse
-  // the configuration instead of letting it run.
-  if (opts.maxLogRangeBlocks <= opts.reorgWindowBlocks) {
+  // The window used to be a block count that could be configured wider than the
+  // span that has to contain it, which spins the loop -- so the constructor
+  // refused it. `reorgWindowBlocksFor` now caps the window at half the span, so
+  // there is no such configuration to refuse: forward progress is at least half
+  // of `maxLogRangeBlocks` whatever the chain's block rate turns out to be.
+  // What remains is the degenerate span, which no cap can rescue.
+  if (opts.maxLogRangeBlocks < 2) {
     throw new Error(
-      `GET_LOGS_RANGE_SIZE (${opts.maxLogRangeBlocks}) must exceed REORG_WINDOW_BLOCKS (${opts.reorgWindowBlocks}), otherwise a poll can never read past the window it re-reads and the stream makes no progress.`,
+      `GET_LOGS_RANGE_SIZE (${opts.maxLogRangeBlocks}) must be at least 2, otherwise a poll cannot both re-read a block and read a new one.`,
     );
   }
 
@@ -957,6 +1100,8 @@ function initStream({
       lastHeartbeat: Date.now(),
       lastHeadHash: "",
       quietPolls: 0,
+      blockRate: null,
+      rateSample: null,
       seeded: false,
     },
   };
@@ -1020,7 +1165,7 @@ function finishTick(
   const earliest = (state.finalized?.number ?? 0) + 1;
   forgetBelow(
     state,
-    Math.max(earliest, state.cursorBlock - opts.reorgWindowBlocks),
+    Math.max(earliest, state.cursorBlock - reorgWindowBlocksFor(state, opts)),
   );
 }
 
@@ -1084,7 +1229,7 @@ async function checkStartingCursor(
   // least we can do is re-read the block we are standing on rather than skip it.
   const target = Math.min(
     state.cursorBlock,
-    Math.max(floor, 1, state.cursorBlock - opts.reorgWindowBlocks),
+    Math.max(floor, 1, state.cursorBlock - reorgWindowBlocksFor(state, opts)),
   );
   opts.onWarning?.("stored cursor is not canonical; rolling back", {
     block: state.cursorBlock,
@@ -1130,7 +1275,7 @@ export async function* createLogStream(
       // count towards backoff -- but it must not poll a struggling endpoint
       // faster than a healthy one either, so it sleeps for the interval already
       // in force.
-      await sleep(pollIntervalFor(state.quietPolls, opts));
+      await sleep(pollIntervalFor(state, opts));
       continue;
     }
 
@@ -1140,7 +1285,7 @@ export async function* createLogStream(
       // sense that matters, and counting it is what lets a chain with a block
       // time longer than the poll interval back off at all.
       state.quietPolls++;
-      await sleep(pollIntervalFor(state.quietPolls, opts));
+      await sleep(pollIntervalFor(state, opts));
       continue;
     }
 
@@ -1185,7 +1330,7 @@ export async function* createLogStream(
     // the stream off just as it arrives at the head.
     if (plan.to >= plan.head.number) {
       if (fresh.length === 0) state.quietPolls++;
-      await sleep(pollIntervalFor(state.quietPolls, opts));
+      await sleep(pollIntervalFor(state, opts));
     }
   }
 }

--- a/src/evm/logStream.ts
+++ b/src/evm/logStream.ts
@@ -14,6 +14,14 @@
  * rate: one `eth_getBlockByNumber("latest")` to learn the head and to give the
  * cursor a real hash, and one `eth_getLogs` over everything since the last one.
  *
+ * What that leaves is a cost that no longer scales with block time but still
+ * scales with nothing at all: eighty compute units per poll on every chain,
+ * whether it produced an event or has produced none in four months. Most of the
+ * chains we index are the latter, so `pollIntervalFor` backs the interval off
+ * while a chain indexes nothing and snaps it back to the floor the moment it
+ * does. Backing off is a delay and never a miss -- a range query asked less
+ * often reads a wider range, not a narrower one.
+ *
  * Correctness notes, since missing an event is the failure that matters:
  *
  * - A range query is self-describing in a way a subscription is not. It either
@@ -45,6 +53,18 @@ export interface LogStreamFilter {
 export interface LogStreamOptions {
   /** How long to wait after catching up to the head before polling again. */
   pollIntervalMs?: number;
+  /**
+   * The ceiling `pollIntervalMs` backs off to on a chain that is producing
+   * nothing we index. Set it equal to `pollIntervalMs` to disable backoff.
+   */
+  maxPollIntervalMs?: number;
+  /**
+   * How many consecutive polls may find nothing before the interval starts
+   * growing. This is the latency guarantee: a chain that indexed anything
+   * within the last `pollIntervalMs * quietPollsBeforeBackoff` keeps polling at
+   * full rate.
+   */
+  quietPollsBeforeBackoff?: number;
   /** Widest block span to ask for in one `eth_getLogs`. */
   maxLogRangeBlocks?: number;
   /**
@@ -66,6 +86,8 @@ export interface LogStreamOptions {
 
 const DEFAULTS = {
   pollIntervalMs: 2_000,
+  maxPollIntervalMs: 30_000,
+  quietPollsBeforeBackoff: 30,
   maxLogRangeBlocks: 1_000,
   reorgWindowBlocks: 64,
   suspectLogCount: 10_000,
@@ -466,6 +488,11 @@ interface StreamState {
   /** Hash of the head as of the last completed read, "" before the first. */
   lastHeadHash: string;
   /**
+   * Consecutive caught-up polls that indexed nothing, which is what the poll
+   * interval backs off on. Reset to 0 by anything worth being fast for.
+   */
+  quietPolls: number;
+  /**
    * False until the first window has been read.
    *
    * `emitted` starts empty because nothing has been observed yet, not because
@@ -479,26 +506,51 @@ interface StreamState {
 type Resolved = Required<Omit<LogStreamOptions, "onWarning">> &
   Pick<LogStreamOptions, "onWarning">;
 
-/** The span to re-read: back into the window when near the head, else forward. */
+/** The span to re-read: back into the reorg window, or forward when behind it. */
 function windowFor(
   state: StreamState,
   head: number,
   opts: Resolved,
 ): { from: number; to: number } {
-  const nearHead = head - state.cursorBlock <= opts.reorgWindowBlocks;
   const earliest = (state.finalized?.number ?? 0) + 1;
+  // The window hangs below the cursor, not below the head, and it is re-read
+  // unconditionally. Both of those matter once the poll interval can grow.
+  //
+  // This used to read back from `head - reorgWindowBlocks`, and only when the
+  // head was within that distance of the cursor; otherwise it read straight
+  // forward from the cursor. The reasoning was that a cursor further back than
+  // the window is catching up and has nothing recently emitted to protect. At a
+  // two-second poll that held on every chain we index -- the head is always a
+  // few blocks ahead -- so the forward-only branch belonged to backfill alone.
+  //
+  // Backing off to thirty seconds breaks the assumption in both parts. An L2 at
+  // four blocks a second advances ~120 blocks between polls, so a caught-up
+  // stream is permanently "further back than the window": it would take the
+  // forward branch forever and never re-read a block it had already emitted,
+  // silently giving up reorg detection on exactly the chains whose finality
+  // lags furthest behind their head. Anchoring to the head instead of the
+  // cursor has the same hole, because `head - reorgWindowBlocks` then sits
+  // above the cursor and the `min` below collapses to `cursorBlock + 1`.
+  //
+  // Anchoring to the cursor is what actually re-reads the blocks at risk: they
+  // are the ones *we emitted*, which is a fact about the cursor and nothing
+  // else. It costs no compute units -- `eth_getLogs` is billed per request, so
+  // a span 64 blocks wider is the same 60 units -- and slows a backfill by
+  // `reorgWindowBlocks / maxLogRangeBlocks`, 6% at the defaults, since each
+  // read now overlaps the last by the width of the window.
+  //
   // Never start above the cursor. `earliest` is an optimisation -- a finalized
   // block cannot reorg, so there is no point re-reading below it -- but on a
   // chain that finalises in under a second it can overtake a cursor that fell a
   // few blocks behind, and letting it raise `from` would skip those blocks
   // silently.
-  const start = nearHead
-    ? Math.min(
-        state.cursorBlock + 1,
-        Math.max(earliest, head - opts.reorgWindowBlocks),
-      )
-    : state.cursorBlock + 1;
-  const from = Math.max(1, start);
+  const from = Math.max(
+    1,
+    Math.min(
+      state.cursorBlock + 1,
+      Math.max(earliest, state.cursorBlock + 1 - opts.reorgWindowBlocks),
+    ),
+  );
   return { from, to: Math.min(head, from + opts.maxLogRangeBlocks - 1) };
 }
 
@@ -559,7 +611,18 @@ async function refreshFinalized(
   opts: Resolved,
   now: number,
 ): Promise<void> {
-  if (now - state.lastFinalizedRefresh < opts.finalizedRefreshIntervalMs) {
+  // Scaled by the effective poll interval, not fixed. At the floor this is the
+  // configured thirty seconds; at a thirty-second backoff a fixed interval
+  // would fire on every single poll, and its twenty compute units would be a
+  // fifth of what a quiet chain costs -- turning a 93% saving into a 76% one.
+  // A staler finalized block on a dormant chain buys back nothing worth having:
+  // it only widens the re-read, which is free, and slows `finalized_order_key`,
+  // which nothing on such a chain is waiting for.
+  const due = Math.max(
+    opts.finalizedRefreshIntervalMs,
+    pollIntervalFor(state.quietPolls, opts) * 4,
+  );
+  if (now - state.lastFinalizedRefresh < due) {
     return;
   }
   state.lastFinalizedRefresh = now;
@@ -684,6 +747,46 @@ function heartbeatIfDue(
   if (now - state.lastHeartbeat < opts.heartbeatIntervalMs) return null;
   state.lastHeartbeat = now;
   return { _tag: "heartbeat" };
+}
+
+/**
+ * How long to sleep before the next poll, given how long the chain has been
+ * quiet.
+ *
+ * The cost of this stream is polls times eighty compute units, and it does not
+ * care whether a poll found anything: `eth_getLogs` is billed per request, so a
+ * chain that has never emitted an event costs exactly what the busiest one
+ * does. That is the whole bill on a deployment like ours, where most chains are
+ * indexed for completeness rather than volume.
+ *
+ * So the interval tracks whether the chain is doing anything we index. It holds
+ * at the floor for `quietPollsBeforeBackoff` consecutive empty polls -- the
+ * latency guarantee, and the reason a busy chain never notices this exists --
+ * then doubles per empty poll up to `maxPollIntervalMs`. Anything worth being
+ * fast for puts it straight back to the floor.
+ *
+ * Backing off is only ever a delay, never a miss: `eth_getLogs` answers for a
+ * block range, so a wider gap between polls means a wider range, not a gap in
+ * what is read. The worst case is noticing the first event on a dormant chain
+ * up to `maxPollIntervalMs` late, after which the chain is at the floor again
+ * for at least `quietPollsBeforeBackoff` polls.
+ */
+export function pollIntervalFor(
+  quietPolls: number,
+  opts: Pick<
+    Resolved,
+    "pollIntervalMs" | "maxPollIntervalMs" | "quietPollsBeforeBackoff"
+  >,
+): number {
+  const floor = opts.pollIntervalMs;
+  const ceiling = Math.max(floor, opts.maxPollIntervalMs);
+  const over = quietPolls - opts.quietPollsBeforeBackoff;
+  if (over <= 0) return floor;
+  // Cap the exponent before it is applied. `2 ** 1024` is Infinity, and a
+  // chain quiet for a week would get there; `Math.min` would still return the
+  // ceiling, but the intermediate is a trap for anyone reworking this line.
+  const doubled = floor * 2 ** Math.min(over, 32);
+  return Math.min(ceiling, doubled);
 }
 
 /**
@@ -853,6 +956,7 @@ function initStream({
       finalizedEmitted: 0,
       lastHeartbeat: Date.now(),
       lastHeadHash: "",
+      quietPolls: 0,
       seeded: false,
     },
   };
@@ -885,6 +989,11 @@ async function* emitFresh(
   state: StreamState,
   fresh: StreamBlock[],
 ): AsyncGenerator<StreamMessage> {
+  // Any matched log means the chain is in use, so drop straight back to the
+  // floor. `groupLogsByBlock` keeps only blocks carrying a log one of our
+  // filters matched, so a non-empty `fresh` is exactly "we indexed something".
+  if (fresh.length > 0) state.quietPolls = 0;
+
   for (const block of fresh) {
     state.emitted.set(Number(block.header.blockNumber), {
       hash: block.header.blockHash,
@@ -1017,12 +1126,21 @@ export async function* createLogStream(
 
     const plan = await planRead(rpc, state, opts);
     if (!plan) {
-      await sleep(opts.pollIntervalMs);
+      // An unreadable head is not evidence the chain is quiet, so this does not
+      // count towards backoff -- but it must not poll a struggling endpoint
+      // faster than a healthy one either, so it sleeps for the interval already
+      // in force.
+      await sleep(pollIntervalFor(state.quietPolls, opts));
       continue;
     }
 
     if (headUnchanged(state, plan.head)) {
-      await sleep(opts.pollIntervalMs);
+      // The head has not moved, so there is provably nothing new to index: a
+      // head hash commits to its whole ancestry. That is a quiet poll in the
+      // sense that matters, and counting it is what lets a chain with a block
+      // time longer than the poll interval back off at all.
+      state.quietPolls++;
+      await sleep(pollIntervalFor(state.quietPolls, opts));
       continue;
     }
 
@@ -1036,6 +1154,9 @@ export async function* createLogStream(
     const rollback = reconcileWindow(state, digests, plan, opts);
     if (rollback) {
       yield rollback;
+      // A reorg is the last moment to be slow: the blocks being rolled back
+      // have to be re-read and re-emitted before the chain is correct again.
+      state.quietPolls = 0;
       // An endpoint serving two views alternately would otherwise rollback,
       // re-read and rollback again with no pause between, one DB transaction per
       // turn. Back off exactly as the caught-up path does.
@@ -1058,7 +1179,14 @@ export async function* createLogStream(
     // Now that the cursor has moved, the finalized block may be behind it.
     yield* announceFinalized(rpc, state, opts, null);
 
-    if (plan.to >= plan.head.number) await sleep(opts.pollIntervalMs);
+    // Only a caught-up poll can be a quiet one. While catching up the loop does
+    // not sleep at all, and counting those polls would let a long backfill --
+    // which is all empty ranges until it reaches the interesting blocks -- back
+    // the stream off just as it arrives at the head.
+    if (plan.to >= plan.head.number) {
+      if (fresh.length === 0) state.quietPolls++;
+      await sleep(pollIntervalFor(state.quietPolls, opts));
+    }
   }
 }
 

--- a/src/evm/logStream.ts
+++ b/src/evm/logStream.ts
@@ -522,6 +522,13 @@ interface StreamState {
   /** Effective window last warned about, so the cap is reported once. */
   warnedCapSeconds: number | null;
   /**
+   * Lowest block `emitted` is authoritative for.
+   *
+   * Below this the map is silent because entries were pruned, not because the
+   * chain had nothing -- and those two are indistinguishable to a diff.
+   */
+  retainedFrom: number;
+  /**
    * False until the first window has been read.
    *
    * `emitted` starts empty because nothing has been observed yet, not because
@@ -588,12 +595,28 @@ export function observeBlockRate(state: StreamState, head: LatestBlock): void {
     // anything, so a tip replaced at the same height by a block with a later
     // timestamp would store a rate of zero and collapse the window to a single
     // block. This branch only ever wants to raise the rate; zero is not a rise.
-    if (elapsed > 0 && advanced > 0) {
+    // Only ever a *rise*, and only against a rate we already trust.
+    //
+    // Adopting a short sample when the rate is unset would be a narrowing, not
+    // a rise: an unset rate already sizes the window at the cap, the widest
+    // available. A first sample quantised to one second on an eleven-block
+    // chain can read half the true rate, which would halve the window for the
+    // next thirty seconds on exactly the argument that short samples cannot be
+    // trusted.
+    if (state.blockRate !== null && elapsed > 0 && advanced > 0) {
       const witnessed = advanced / elapsed;
-      if (state.blockRate === null || witnessed > state.blockRate) {
-        state.blockRate = witnessed;
-      }
+      if (witnessed > state.blockRate) state.blockRate = witnessed;
     }
+    return;
+  }
+
+  // A full baseline that saw no blocks is a halted chain, not a rate of zero.
+  // Dividing anyway stores 0, and `reorgWindowBlocksFor` turns that into a
+  // one-block window -- so the poll that has to reconcile the reorg that
+  // *resumes* the chain would re-read a single block. Keep the last known rate
+  // and start a fresh sample.
+  if (advanced <= 0) {
+    state.rateSample = { number: head.number, timeSec };
     return;
   }
 
@@ -738,6 +761,9 @@ function forgetBelow(state: StreamState, keepFrom: number): void {
   for (const key of [...state.emitted.keys()]) {
     if (key < keepFrom) state.emitted.delete(key);
   }
+  // Only ever rises. What was pruned cannot be un-pruned, so this is the record
+  // of how far down the map can still be trusted.
+  state.retainedFrom = Math.max(state.retainedFrom, keepFrom);
 }
 
 function rollbackTo(state: StreamState, block: number): StreamMessage {
@@ -1032,10 +1058,28 @@ function maybeRollback(
   plan: { from: number; to: number },
   opts: Resolved,
 ): StreamMessage | null {
+  // Never diff below what `emitted` still holds.
+  //
+  // "I have no record of this block" and "this block is new" are the same
+  // observation to `firstDivergentBlock` -- `before === undefined,
+  // after !== undefined` -- and one of them is a reorg while the other is
+  // bookkeeping. The scan can reach below the retention floor whenever the
+  // cursor moves *down*, which is exactly what `rollbackTo` does: it skips
+  // `finishTick`, so a real reorg lowers the cursor without lowering the floor,
+  // and the next cursor-anchored scan starts a full window below where the last
+  // prune assumed. Every log-bearing block in the gap then reads as diverged,
+  // `rollbackTo` clears the remainder of the map, and the next tick diffs
+  // against nothing -- the cursor walks down to `earliest` on a chain that
+  // reorged exactly once.
+  //
+  // Flooring the comparison is what makes that structurally impossible, rather
+  // than merely unlikely at the current window widths. Blocks below the floor
+  // are older than a full window beneath a cursor we have already passed, which
+  // is the depth this stream does not claim to protect anyway.
   const divergent = firstDivergentBlock(
     state.emitted,
     digests,
-    plan.from,
+    Math.max(plan.from, state.retainedFrom),
     plan.to,
   );
   if (divergent === undefined || divergent > state.cursorBlock) return null;
@@ -1056,7 +1100,7 @@ function reconcileWindow(
   opts: Resolved,
 ): StreamMessage | null {
   if (!state.seeded) {
-    seedWindow(state, digests);
+    seedWindow(state, digests, plan.from);
     return null;
   }
   return maybeRollback(state, digests, plan, opts);
@@ -1073,10 +1117,14 @@ function reconcileWindow(
 function seedWindow(
   state: StreamState,
   digests: Map<number, BlockDigest>,
+  from: number,
 ): void {
   for (const [blockNumber, digest] of digests) {
     if (blockNumber <= state.cursorBlock) state.emitted.set(blockNumber, digest);
   }
+  // The seed read is the first thing `emitted` knows anything about, so it is
+  // where the authoritative range begins.
+  state.retainedFrom = from;
   state.seeded = true;
 }
 
@@ -1163,6 +1211,7 @@ function initStream({
       blockRate: null,
       rateSample: null,
       warnedCapSeconds: null,
+      retainedFrom: 0,
       seeded: false,
     },
   };

--- a/src/evm/logStream.ts
+++ b/src/evm/logStream.ts
@@ -584,7 +584,11 @@ export function observeBlockRate(state: StreamState, head: LatestBlock): void {
     // MIN_RATE_SAMPLE_SECONDS after a chain speeds up -- a sequencer catching
     // up after downtime is the realistic case -- and blocks emitted in that
     // window can land further below the cursor than the window reaches.
-    if (elapsed > 0) {
+    // `advanced > 0` matters: a null rate makes the comparison below adopt
+    // anything, so a tip replaced at the same height by a block with a later
+    // timestamp would store a rate of zero and collapse the window to a single
+    // block. This branch only ever wants to raise the rate; zero is not a rise.
+    if (elapsed > 0 && advanced > 0) {
       const witnessed = advanced / elapsed;
       if (state.blockRate === null || witnessed > state.blockRate) {
         state.blockRate = witnessed;

--- a/src/price-sync/fetchers/chainlinkFeeds.test.ts
+++ b/src/price-sync/fetchers/chainlinkFeeds.test.ts
@@ -6,6 +6,8 @@ import {
   fetchChainlinkTokenPricesWithMulticall,
   parseChainlinkPriceConfig,
   readChainlinkFeedPrice,
+  resetVerifiedChainlinkClients,
+  verifiedClient,
   type ChainlinkFeedConfig,
 } from "./chainlinkFeeds";
 
@@ -361,5 +363,88 @@ describe("fetchChainlinkTokenPricesWithMulticall", () => {
         },
       ],
     });
+  });
+});
+
+describe("verifiedClient", () => {
+  const fake = (chainId: number, calls: { n: number }) =>
+    ({
+      getChainId: async () => {
+        calls.n++;
+        return chainId;
+      },
+    }) as never;
+
+  test("asks the chain for its ID once, not once per price fetch", async () => {
+    // This runs on a timer, once a minute per configured chain. Re-verifying
+    // every time was four eth_chainId calls a minute answering a question whose
+    // answer is a property of the endpoint and cannot change.
+    resetVerifiedChainlinkClients();
+    const calls = { n: 0 };
+    const create = () => fake(1, calls);
+
+    const first = await verifiedClient("1", ["https://rpc.example"], create);
+    for (let i = 0; i < 10; i++) {
+      const again = await verifiedClient("1", ["https://rpc.example"], create);
+      expect(again).toBe(first);
+    }
+    expect(calls.n).toBe(1);
+  });
+
+  test("shares one check between callers racing on a cold cache", async () => {
+    resetVerifiedChainlinkClients();
+    const calls = { n: 0 };
+    const create = () => fake(1, calls);
+
+    await Promise.all(
+      Array.from({ length: 8 }, () =>
+        verifiedClient("1", ["https://rpc.example"], create),
+      ),
+    );
+    expect(calls.n).toBe(1);
+  });
+
+  test("keeps a separate client per chain and per endpoint set", async () => {
+    resetVerifiedChainlinkClients();
+    const calls = { n: 0 };
+
+    const a = await verifiedClient("1", ["https://a"], () => fake(1, calls));
+    const b = await verifiedClient("10", ["https://b"], () => fake(10, calls));
+    const c = await verifiedClient("1", ["https://c"], () => fake(1, calls));
+
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
+    expect(calls.n).toBe(3);
+  });
+
+  test("rejects an endpoint serving a different chain", async () => {
+    resetVerifiedChainlinkClients();
+    const calls = { n: 0 };
+    await expect(
+      verifiedClient("1", ["https://wrong"], () => fake(137, calls)),
+    ).rejects.toThrow(/returned chain ID 137/);
+  });
+
+  test("does not cache a failed check, so a blip cannot disable the chain", async () => {
+    // A misconfigured URL fails again next minute at no cost. A transient
+    // network error during the first check must not be remembered forever.
+    resetVerifiedChainlinkClients();
+    let attempt = 0;
+    const create = () =>
+      ({
+        getChainId: async () => {
+          attempt++;
+          if (attempt === 1) throw new Error("connection reset");
+          return 1;
+        },
+      }) as never;
+
+    await expect(
+      verifiedClient("1", ["https://flaky"], create),
+    ).rejects.toThrow(/connection reset/);
+
+    const client = await verifiedClient("1", ["https://flaky"], create);
+    expect(client).toBeDefined();
+    expect(attempt).toBe(2);
   });
 });

--- a/src/price-sync/fetchers/chainlinkFeeds.ts
+++ b/src/price-sync/fetchers/chainlinkFeeds.ts
@@ -507,20 +507,78 @@ export async function fetchChainlinkTokenPricesWithMulticall(
   return prices;
 }
 
+/**
+ * Verified clients, keyed by the chain and the endpoints they talk to.
+ *
+ * Both halves of this are worth keeping across calls. Building the client
+ * allocates a fresh transport, and the `eth_chainId` that verifies it is a
+ * request: this function runs once a minute per configured chain, so re-doing
+ * both meant four `eth_chainId` calls a minute answering a question whose
+ * answer cannot change -- a chain ID is a property of the endpoint, and the
+ * endpoint comes from configuration that is fixed for the life of the process.
+ *
+ * The check itself is worth keeping. It is the only thing standing between an
+ * RPC URL pointed at the wrong chain and a table of confidently wrong prices.
+ * Once is enough.
+ */
+const verifiedClients = new Map<
+  string,
+  Promise<ChainlinkReader & ChainlinkMulticallReader>
+>();
+
+function createChainlinkClient(
+  rpcUrls: readonly string[],
+): ChainlinkReader & ChainlinkMulticallReader {
+  return createPublicClient({
+    transport: fallback(rpcUrls.map((rpcUrl) => http(rpcUrl))),
+  }) as unknown as ChainlinkReader & ChainlinkMulticallReader;
+}
+
+export async function verifiedClient(
+  chainId: string,
+  rpcUrls: readonly string[],
+  create: (
+    urls: readonly string[],
+  ) => ChainlinkReader & ChainlinkMulticallReader = createChainlinkClient,
+): Promise<ChainlinkReader & ChainlinkMulticallReader> {
+  const key = `${chainId}\u0000${rpcUrls.join(",")}`;
+
+  const cached = verifiedClients.get(key);
+  if (cached) return cached;
+
+  const pending = (async () => {
+    const client = create(rpcUrls);
+
+    const rpcChainId = await client.getChainId();
+    if (BigInt(rpcChainId) !== BigInt(chainId)) {
+      throw new Error(
+        `Chainlink RPC for chain ${chainId} returned chain ID ${rpcChainId}`,
+      );
+    }
+    return client;
+  })();
+
+  // Cache the attempt so concurrent callers share one `eth_chainId`, but drop
+  // it again if it fails. A misconfigured URL will fail identically next minute;
+  // a network blip during the first check should not disable the chain for the
+  // life of the process.
+  verifiedClients.set(key, pending);
+  pending.catch(() => {
+    if (verifiedClients.get(key) === pending) verifiedClients.delete(key);
+  });
+
+  return pending;
+}
+
+/** Test seam: forget every verified client. */
+export function resetVerifiedChainlinkClients(): void {
+  verifiedClients.clear();
+}
+
 export async function fetchChainlinkTokenPrices(
   chainId: string,
   config: ChainlinkChainConfig,
 ): Promise<Record<string, ChainlinkPriceObservation>> {
-  const client = createPublicClient({
-    transport: fallback(config.rpcUrls.map((rpcUrl) => http(rpcUrl))),
-  }) as unknown as ChainlinkReader & ChainlinkMulticallReader;
-
-  const rpcChainId = await client.getChainId();
-  if (BigInt(rpcChainId) !== BigInt(chainId)) {
-    throw new Error(
-      `Chainlink RPC for chain ${chainId} returned chain ID ${rpcChainId}`,
-    );
-  }
-
+  const client = await verifiedClient(chainId, config.rpcUrls);
   return fetchChainlinkTokenPricesWithMulticall(client, chainId, config);
 }


### PR DESCRIPTION
## The bill is poll rate × chain count, and blind to activity

A poll costs a flat 80 Alchemy compute units — 20 for `eth_getBlockByNumber("latest")`, 60 for `eth_getLogs`, which is billed per *request*, not per block in the range or per log returned. #180 made that cost independent of block time. It is still independent of **activity**, so at a 2 s poll every chain costs ~142,000 CU/hr whether or not anyone uses it.

The usage API confirms it exactly — 11 of 13 chains within 1% of each other, against Ekubo event counts spanning six orders of magnitude:

| network | CU/hr | events, **all time** | last event |
|---|---|---|---|
| robinhood | 142,200 | 2,252,733 | now |
| eth | 57,200 | 9,170,070 | now |
| arb | 143,980 | 20,162 | now |
| base | 143,540 | 53 | 2026-08-26 |
| bnb | 142,580 | **6** | 2026-08-07 |
| monad | 142,540 | **11** | **2026-05-16** |
| megaeth | 142,320 | 17 | 2026-08-04 |
| opt | 142,140 | 14 | today |
| ink | 142,500 | 13 | today |
| unichain | 142,740 | 13 | today |
| matic | 141,840 | 13 | today |
| worldchain | 142,300 | 10 | today |
| gnosis | 80,340 | 12 | today |

Ten chains bill ~1.42M CU/hr — 83% of the indexer's spend — to deliver ~180 events/day out of 73,000. Monad has cost ~390M CU since its last event in May.

Ethereum and Gnosis are cheaper only because their block time exceeds the poll interval, so #180's unchanged-head skip fires: Ethereum runs `eth_getLogs` on 17% of polls (≈2/12 s), Gnosis on 41% (≈2/5 s). That skip is worth nothing on a sub-2 s chain, which is the other eleven.

## Three changes

### 1. The poll interval tracks whether the chain is doing anything

It holds at `POLL_INTERVAL_MS` for `QUIET_POLLS_BEFORE_BACKOFF` consecutive empty polls — 60 s at the defaults, and the reason a busy chain never notices this exists — then doubles per empty poll up to `MAX_POLL_INTERVAL_MS` (30 s). Any matched log, or any reorg, resets it to the floor.

Backing off is a delay and never a miss: a range query asked less often reads a *wider* range, not a narrower one. Worst case is noticing the first event on a dormant chain up to 30 s late, after which it is at the floor for at least a minute. Robinhood (an event every ~2 s) and Ethereum (every ~8 s) never leave the floor.

### 2. Nothing is sized in blocks any more

A block is not a unit of time, and these chains run from 10 s to 0.09 s apart, so a block count means something different on each. Measured rates, and what the old fixed `REORG_WINDOW_BLOCKS=64` actually bought:

| chain | blocks/s | `64 blocks` was | `120 s` is |
|---|---|---|---|
| robinhood | 10.97 | **6 s** | 1317 blocks |
| arbitrum | 3.80 | 17 s | 456 |
| monad | 3.43 | 19 s | 412 |
| bsc | 2.30 | 28 s | 276 |
| unichain / megaeth / ink | 1.03 | 62 s | 124 |
| polygon | 0.67 | 96 s | 81 |
| optimism | 0.53 | 121 s | 64 |
| base | 0.50 | 128 s | 60 |
| worldchain | 0.47 | 136 s | 57 |
| gnosis | 0.20 | 320 s | 24 |
| ethereum | 0.083 | **768 s** | 12 |

A 107× spread, and our busiest chain had the thinnest protection. `REORG_WINDOW_SECONDS` (default 120) replaces it, converted per chain from a rate measured off the head read each poll already makes — no extra request. A 30 s minimum baseline stops one-second timestamp resolution being mistaken for the rate on a chain fitting eleven blocks inside one second; a rise is adopted immediately and only a fall waits, since every consumer is safe wide and unsafe narrow.

Ethereum is the one chain that would lose, so `.env.evm.mainnet` pins it at 1152 s — the worst-case head-to-finalized span (2–3 epochs), which makes `finalized + 1` rather than the window what bounds its read.

The window is capped at half `maxLogRangeBlocks`, and the backoff ceiling is bounded by what one `eth_getLogs` can drain at the measured rate. Both bind nowhere today; they exist so no chain's block rate can produce a configuration that stalls.

### 3. The reorg window hangs below the cursor, unconditionally

`windowFor` re-read the window only while the head was within `reorgWindowBlocks` of the cursor. At a 2 s poll the head is always a few blocks ahead, so that was true on every chain and the read-forward branch belonged to backfill alone. At 30 s an L2 advances ~120 blocks, so a caught-up stream looks like a catching-up one, takes the forward branch forever, and **silently stops detecting reorgs**. Anchoring to the head has the same hole — `head − window` then sits above the cursor and the `min` collapses to `cursor + 1`. The blocks at risk are the ones *we emitted*, which is a fact about the cursor. Costs no compute units; slows a backfill by the window as a fraction of the span.

## A HIGH bug this introduced, caught in review

`finishTick` pruned `emitted` to the window in force when the tick ended. The window is measured, so it grows when the chain speeds up — and the next tick's scan then covers blocks dropped a moment earlier. `firstDivergentBlock` cannot tell "I forgot this" from "this is new below my cursor": it reports a reorg, `rollbackTo` clears the rest of the map, and the next tick does it again, walking the cursor backwards a window at a time.

Reproduced on a chain whose hashes are pure functions of block number, so nothing can reorg: **34 fabricated `invalidate` messages**. Ethereum was squarely in range. `emitted` is now retained to `maxReorgWindowBlocks`, the widest any later tick can scan; it holds only log-bearing blocks, so the extra entries are free.

Also from review: `checkStartingCursor` now seeds the rate from the cursor and finalized blocks it already fetched, instead of rolling back by the half-span cap; the cap warning moved out of a function four call sites hit per tick; and a partial-baseline rate is guarded with `advanced > 0` so a tip replaced in place cannot store a rate of zero.

## Projected effect

Measured now: **1,925,534 CU/hr** across the account — EVM Indexer 1,706,220 (88.6%), Interface 219,144 (11.4%).

| | CU/hr now | CU/hr after |
|---|---|---|
| 10 dormant chains | ~1,420,000 | ~102,000 |
| arbitrum | 143,980 | ~23,400 |
| ethereum | 57,200 | ~57,000 |
| robinhood | 142,200 | ~142,200 |

Indexer **~1.71M → ~331,000 CU/hr (−81%)**; account **~1.93M → ~550,000**. At the observed $4.50e-7/CU, **~$632/mo → ~$181/mo**, against a $600 limit the current rate was on course to exceed. `MAX_POLL_INTERVAL_MS` is linear on the dormant chains from there: 60 s halves their residual again.

Verify an hour after deploy — the ten dormant chains should read ~10,000, not ~142,000:

```
alchemy usage timeseries --granularity hour --group-by network \
  --app-ids vntuybeuyrhcfq8a
```

## Testing

`bun test` — 413 pass; lint clean; `doctl apps spec validate` passes on the substituted spec.

Three reverts confirmed red, which is what shows the tests check invariants rather than the implementation: the head-anchored window breaks reorg detection past the window; a fixed 64-block window breaks the equal-history and drain-ceiling tests; and restoring the live-window prune reproduces all 34 fabricated invalidates.

## Two smaller things

- `fetchChainlinkTokenPrices` rebuilt a viem client and called `eth_chainId` every run — once a minute per chain across four Chainlink chains. Now verified once per process; the check stays, since it is the only thing between an RPC pointed at the wrong chain and a table of confidently wrong prices. `eth_chainId` bills 0 CU, so this is requests, not money.
- `rhc-mainnet`'s `EVM_RPC_URL` is now `type: SECRET` like the other twelve. No key material is in the repo — every entry is `${EVM_RPC_ALCHEMY_API_KEY}` substitution — so this only changes how it renders in the DO dashboard.

## Not in this PR

#180 also removed the free public RPC from the front of every chain's `EVM_RPC_URL`, which is where the eight previously-free chains started billing at all. That was a deliberate correctness call — a viem `fallback()` list switches provider mid-stream and can mix views — and it stands. This PR makes it affordable rather than reversing it.

The Interface app's ~219k CU/hr is browser `eth_call`, not a background job: a different repo and a different kind of problem.

https://claude.ai/code/session_018fCeEYi1BdAhcaKZmDwAKb
