### PR TITLE
Index Starknet with the same stream as every EVM chain

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -13,13 +13,6 @@ envs:
     scope: RUN_TIME
     type: SECRET
     value: ${PG_CONNECTION_STRING}
-  # No worker reads this any more: Starknet moved off the apibara DNA stream
-  # onto its own RPC. Kept for one release so reverting that is a code revert
-  # and not also a secret to put back. Delete it once the RPC stream has held.
-  - key: DNA_TOKEN
-    scope: RUN_TIME
-    type: SECRET
-    value: ${APIBARA_DNA_TOKEN}
   - key: RESTART_DELAY_SECONDS
     scope: RUN_TIME
     value: "1"

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -13,6 +13,9 @@ envs:
     scope: RUN_TIME
     type: SECRET
     value: ${PG_CONNECTION_STRING}
+  # No worker reads this any more: Starknet moved off the apibara DNA stream
+  # onto its own RPC. Kept for one release so reverting that is a code revert
+  # and not also a secret to put back. Delete it once the RPC stream has held.
   - key: DNA_TOKEN
     scope: RUN_TIME
     type: SECRET
@@ -21,6 +24,18 @@ envs:
     scope: RUN_TIME
     value: "1"
 workers:
+  # Starknet range-reads its own RPC, the same way every EVM worker does, so the
+  # one endpoint rule below applies to it too.
+  #
+  # The path carries the JSON-RPC spec version rather than the `/v2/` the EVM
+  # URLs use, and v0.10 is a floor rather than a preference: it is the first
+  # version where `EMITTED_EVENT` carries `transaction_index` and `event_index`,
+  # which are packed into `event_id`. On v0.9 the stream refuses to index rather
+  # than defaulting them, so a downgrade here stops the worker instead of
+  # silently writing wrong primary keys.
+  #
+  # NOTE: starknet-mainnet must be enabled on the Alchemy app this key belongs
+  # to before this deploys; it was an EVM-only app until this change.
   - name: starknet-mainnet
     image: &indexer-image
       registry_type: GHCR
@@ -30,6 +45,10 @@ workers:
     instance_size_slug: apps-s-1vcpu-0.5gb
     instance_count: 1
     envs:
+      - key: STARKNET_RPC_URL
+        scope: RUN_TIME
+        type: SECRET
+        value: "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_10/${EVM_RPC_ALCHEMY_API_KEY}"
       - key: NETWORK
         scope: RUN_TIME
         value: mainnet

--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 LOG_LEVEL="info"
 PG_CONNECTION_STRING="postgresql://postgres:postgres@localhost:5432/postgres"
-# this timeout is disabled by default, we should only use it for apibara
+# Disabled by default. Only the Starknet worker arms it (5 min, in
+# .env.starknet.mainnet); the EVM workers stop by erroring instead.
 NO_BLOCKS_TIMEOUT_MS="0"

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,6 @@
-DNA_TOKEN="token_from_apibara"
+# STARKNET_RPC_URL must name JSON-RPC v0.10 or later; the stream refuses to
+# index without the event positions that version added.
+STARKNET_RPC_URL="https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_10/<key>"
 PG_CONNECTION_STRING="postgresql://postgres:postgres@localhost:5432/postgres"
 # TOKEN_PRICE_SYNC_INTERVAL_MS=60000
 # MAX_QUOTER_REQUESTS_PER_MINUTE=60

--- a/.env.starknet.mainnet
+++ b/.env.starknet.mainnet
@@ -1,6 +1,12 @@
 CHAIN_ID="0x534e5f4d41494e"
 STARTING_CURSOR_BLOCK_NUMBER="165389"
-APIBARA_URL="https://mainnet.starkstream.io"
+
+# STARKNET_RPC_URL is a secret, so it is set in .do/app.yaml rather than here.
+
+# ~0.59 blocks a second on mainnet, so the 120 s reorg window is ~71 blocks and
+# the span must be at least twice that. 500 leaves room for the window to widen
+# if the chain speeds up, and bounds a catch-up read to ~8 pages of events.
+GET_LOGS_RANGE_SIZE="500"
 
 CORE_ADDRESS="0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b4b"
 POSITIONS_ADDRESS="0x02e0af29598b407c8716b17f6d2795eca1b471413fa03fb145a5e33722184067"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    groups:
-      apibara:
-        patterns:
-          - "@apibara/*"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -57,11 +57,8 @@ jobs:
 
       - name: Deploy App
         env:
-          APIBARA_DNA_TOKEN: ${{ secrets.APIBARA_DNA_TOKEN }}
           EVM_RPC_ALCHEMY_API_KEY: ${{ secrets.EVM_RPC_ALCHEMY_API_KEY }}
           COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
           PG_CONNECTION_STRING: ${{ secrets.PRIVATE_PG_CONNECTION_STRING }}
           VPC_ID: ${{ secrets.VPC_ID }}
-          STARKNET_MAINNET_APIBARA_URL: ${{ secrets.STARKNET_MAINNET_APIBARA_URL }}
-          ETH_MAINNET_APIBARA_URL: ${{ secrets.ETH_MAINNET_APIBARA_URL }}
         run: envsubst < .do/app.yaml | doctl apps create --spec - --upsert

--- a/README.md
+++ b/README.md
@@ -403,11 +403,28 @@ manual steps:
 
 1. **`starknet-mainnet` must be enabled on the Alchemy app** whose key
    `EVM_RPC_ALCHEMY_API_KEY` holds. It was an EVM-only app, so the worker will
-   fail to read the chain until it is.
-2. **`STARKNET_RPC_URL`** is a new secret in the app spec. `APIBARA_URL` is gone
-   from `.env.starknet.mainnet`; `DNA_TOKEN` is deliberately left in the app
-   spec for one release so reverting is a code revert and not also a secret to
-   put back.
+   fail to read the chain until it is. (Already done.)
+2. **`STARKNET_RPC_URL`** is a new secret in the app spec.
+
+Apibara is gone entirely: the four `@apibara/*` packages, `APIBARA_URL`,
+`DNA_TOKEN`, and the `APIBARA_DNA_TOKEN`, `STARKNET_MAINNET_APIBARA_URL` and
+`ETH_MAINNET_APIBARA_URL` secrets the deploy workflow passed to `envsubst`. The
+repository secrets themselves can be deleted in GitHub once this has shipped;
+nothing reads them.
+
+Downstream is unaffected, checked rather than assumed. `api` and
+`quoter-service` are the only things that read this database directly (`mcp`,
+`interface` and `wallet` go through the api), and both read the same five
+`indexer_cursor` columns plus `event_id`. Against a live cursor row written by
+the DNA stream, the new adapter returns an identical `head_block_hash`,
+`head_block_time` and `head_base_fee_per_gas`; `event_id` is unchanged, which is
+what quoter-service's incremental sync keys on (`last_event_id > $n`); and
+`fork_counter`, which it compares to decide a full refetch, only moves on an
+invalidate, of which a live boot from the real cursor produced none.
+
+The one behavioural difference is latency: DNA pushed a block as it was
+produced, and this polls, so Starknet events land up to `POLL_INTERVAL_MS`
+(2 s) later than they used to.
 
 `event_id` is unchanged: `transaction_index` and `event_index` come from
 `starknet_getEvents` under JSON-RPC v0.10 and match what DNA wrote, verified

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Service for indexing Ekubo events into a Postgres database.
 
 ## Overview
 
-The indexer focuses on producing an always-consistent realtime view of Ekubo events, using the Starkstream service to get a stream of relevant data.
+The indexer focuses on producing an always-consistent realtime view of Ekubo events. Every network — Starknet included — is read by polling its own RPC over block ranges; see [Block streams](#block-streams).
 
 Events are not transformed by the indexer, simply cataloged for later use such as in materialized views or complex analytical queries.
 
@@ -144,10 +144,18 @@ Catalogs are refreshed hourly by default, controlled by `CHAINLINK_FEED_CATALOG_
 
 Chainlink jobs are disabled when the interval is zero/unset or the config is empty. Valid observations are stored under the `cl1` source using the feed round's `updatedAt` timestamp, and unchanged rounds are not inserted repeatedly. One failing feed does not prevent fresh observations from other configured feeds on that chain.
 
-## EVM stream
+## Block streams
 
-The EVM entrypoint drives its own log-driven stream (`src/evm/logStream.ts`)
-rather than fetching a header per block. A poll is two requests whatever the
+Every network is indexed by one polling, range-reading stream
+(`src/_shared/blockStream.ts`). Polling, reorg detection, the poll backoff, the
+retention window and the cursor live there and are identical on every chain; the
+per-chain adapters supply only what a chain family actually does differently --
+`src/evm/logStream.ts` and `src/starknet/eventStream.ts`.
+
+### EVM
+
+The EVM adapter is log-driven rather than fetching a header per block. A poll is
+two requests whatever the
 chain's block time:
 
 1. `eth_getBlockByNumber("latest")`, which gives the head and a real block hash
@@ -175,6 +183,51 @@ by nothing, and rows for blocks with no events are removed within a day by
 
 Measured against the previous stream on Monad (0.3 s blocks), at the same two
 second cadence: 9.7 requests per poll became 2.1.
+
+### Starknet
+
+Starknet reads `starknet_getEvents` over the same window the EVM chains read
+`eth_getLogs` over, and shares everything below that. Three things differ, and
+all three are in the adapter:
+
+- **One address per request.** `starknet_getEvents` takes a single address, not
+  a list, so asking per contract would be twelve requests a poll. The range read
+  is filtered by event selector instead -- which the RPC accepts as an OR-list --
+  and narrowed to our contracts locally. On mainnet that prefilter takes a range
+  read from 15.9 to 3.3 events per block. A processor filtering on address alone
+  disables the prefilter rather than silently narrowing the read.
+- **The URL pins JSON-RPC v0.10.** That is the first version where
+  `EMITTED_EVENT` carries `transaction_index` and `event_index`; on v0.9 they
+  are absent and the `continuation_token` counts *matched* results, so it cannot
+  supply them either. The stream refuses to index an event without them rather
+  than defaulting to zero, so pointing this at an older spec stops the worker
+  instead of silently writing wrong primary keys. One block read remains, for
+  the timestamp, and only for blocks above the cursor -- the reorg window is
+  re-read every poll and paying a per-block cost for it would be ~390k requests
+  a day instead of ~6k.
+- **`event_index` is per transaction**, counting every event the transaction
+  emitted rather than only ours. That is what the apibara DNA stream stored and
+  what `compute_event_id` has packed into every Starknet `event_id` ever
+  written, so it is not ours to renumber. It counts the events in between, so it
+  is emphatically not a position within the filtered results: block 14555766
+  holds 3 and 19 for one transaction, where numbering only the matched events
+  would give 0 and 1.
+
+Those two numbers were checked three ways before this relied on them: v0.10's
+values, a reconstruction from `starknet_getBlockWithReceipts`, and the rows the
+DNA stream wrote years ago all agree, over 5,000 mainnet blocks and 44 event
+tables with no row missed.
+
+Note that this differs from EVM, where `event_index` is the block-wide
+`logIndex`. Both are inherited from the streams they replace.
+
+Finality is `l1_accepted` -- settlement on Ethereum, hours behind the head --
+rather than EVM's `finalized`. `latest` is `ACCEPTED_ON_L2` and can still be
+reorged; `pre_confirmed` has no hash at all, so nothing that cannot be rolled
+back to is indexed.
+
+`scripts/verifyStarknetStream.ts` replays a settled range and asserts the
+positions it reconstructs are exactly the ones already in the database.
 
 ### Correctness
 
@@ -328,7 +381,7 @@ Migration files live under `migrations/` and execute in order via `scripts/migra
 The DigitalOcean Apps spec in `.do/app.yaml` documents the full production stack:
 
 - Workers for each network (e.g.: `starknet-mainnet`, `eth-mainnet`, `base-mainnet`) that run the corresponding network entrypoint (`bun src/starknet.ts` or `bun src/evm.ts`) with the appropriate `NETWORK` value, pulling the published Docker image (`ghcr.io/ekuboprotocol/indexer:${IMAGE_TAG}`).
-- Managed Postgres (`indexer-db-nyc1`) wired in via the `PG_CONNECTION_STRING` env var along with secrets such as `DNA_TOKEN`.
+- Managed Postgres (`indexer-db-nyc1`) wired in via the `PG_CONNECTION_STRING` env var, alongside the per-worker RPC secrets (`EVM_RPC_URL`, `STARKNET_RPC_URL`).
 - A `run-migrations` pre-deploy job and the long-running `src/price-sync/index.ts` process. Each price source/chain job has an independent timer, with separately configured CoinGecko and Chainlink cadences. The app spec discovers Chainlink feeds for eligible tokens on Ethereum, Base, Arbitrum, and Robinhood through Chainlink's multi-network catalogs and the existing Alchemy API key secret.
 
 Use this file as a base to recreate the stack in a new DigitalOcean App Platform project or as a reference for configuring similar infrastructure elsewhere.
@@ -339,6 +392,31 @@ This log records indexer deployments that:
 
 - require **manual intervention beyond running `scripts/migrate.ts`** (e.g., backfilling data, reseeding state, or pausing workers), or
 - introduce **schema changes**, even when the standard migration workflow can apply them automatically. Schema-only updates may not mandate manual steps but can still break downstream consumers that rely on the previous structure, so they belong here as well.
+
+### 2026-09-08: Starknet moves off apibara DNA onto its own RPC
+
+**No schema change. Requires configuration before deploying.**
+
+Starknet is now indexed by the same stream as every EVM chain
+(`src/_shared/blockStream.ts`) instead of the apibara DNA gRPC stream. Two
+manual steps:
+
+1. **`starknet-mainnet` must be enabled on the Alchemy app** whose key
+   `EVM_RPC_ALCHEMY_API_KEY` holds. It was an EVM-only app, so the worker will
+   fail to read the chain until it is.
+2. **`STARKNET_RPC_URL`** is a new secret in the app spec. `APIBARA_URL` is gone
+   from `.env.starknet.mainnet`; `DNA_TOKEN` is deliberately left in the app
+   spec for one release so reverting is a code revert and not also a secret to
+   put back.
+
+`event_id` is unchanged: `transaction_index` and `event_index` come from
+`starknet_getEvents` under JSON-RPC v0.10 and match what DNA wrote, verified
+over 5,000 mainnet blocks against 44 event tables with no row missed. The URL
+must name v0.10 or later; the stream refuses to index without those fields
+rather than defaulting them.
+
+Adds ~1.9M Alchemy compute units a day (~$26/month at a 2 s poll floor), where
+DNA was billed separately.
 
 ### 2026-09-06: Market depth refresh, 25 s → 10 s, and a 10-minute schedule
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,6 @@
     "": {
       "name": "@ekubo/indexer",
       "dependencies": {
-        "@apibara/evm": "^2.1.4",
-        "@apibara/evm-rpc": "^2.1.4",
-        "@apibara/protocol": "^2.1.3",
-        "@apibara/starknet": "^2.1.4",
         "@effect/platform-bun": "4.0.0-rc.112",
         "dotenv": "^17.4.2",
         "effect": "4.0.0-rc.112",
@@ -18,7 +14,6 @@
         "winston": "^3.19.0",
       },
       "devDependencies": {
-        "@electric-sql/pglite": "^0.5.8",
         "@types/bun": "^1.4.0",
         "@typescript-eslint/parser": "8.68.0",
         "eslint": "10.9.1",
@@ -28,14 +23,6 @@
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, ""],
 
-    "@apibara/evm": ["@apibara/evm@2.1.4", "", { "dependencies": { "@apibara/protocol": "2.1.3", "long": "^5.2.1", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.1.2", "viem": "^2.40.3" } }, "sha512-A3iPlvyXJAnbu/rjmHxAm9ingaIFGK9/CMapxF5jlMvV6sDsy87zt6dwX5hnMjUmyLYuUDu0DKvOz6C2vhzLsg=="],
-
-    "@apibara/evm-rpc": ["@apibara/evm-rpc@2.1.4", "", { "dependencies": { "@apibara/evm": "2.1.4", "@apibara/protocol": "2.1.3", "@opentelemetry/api": "^1.9.0", "viem": "^2.40.3" } }, "sha512-cYsM8HF4aN9uKiv7JJRh/s7Gc/uw4VZEZO8Su/URAtiMZvbNlNhHFP4SaOMrAhNsX0AMg+xvimOJ6g7RXU17rQ=="],
-
-    "@apibara/protocol": ["@apibara/protocol@2.1.3", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "consola": "^3.4.2", "long": "^5.2.3", "nice-grpc": "^2.1.8", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.3.0", "viem": "^2.13.2" } }, "sha512-udzmoY1yd6wpbLBX6+iJmspo6x+WNfr4RasW3YcagMyYM7iYFD/zOjFTd/2z2m25bVqdkeVUsIMz6ivuRc5A9Q=="],
-
-    "@apibara/starknet": ["@apibara/starknet@2.1.4", "", { "dependencies": { "@apibara/protocol": "2.1.3", "@scure/starknet": "^1.1.0", "abi-wan-kanabi": "^2.2.4", "long": "^5.2.1", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.1.2" } }, "sha512-k9reE+blXCjI9YoAKkibDfsa5oAJNUUMZc0I5AGufJPRBLgkVDirnaVTJ/Y+47EQmz5DkT0rBHWu1T243Z18KQ=="],
-
     "@colors/colors": ["@colors/colors@1.6.0", "", {}, ""],
 
     "@dabh/diagnostics": ["@dabh/diagnostics@2.0.8", "", { "dependencies": { "@so-ric/colorspace": "^1.1.6", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="],
@@ -43,8 +30,6 @@
     "@effect/platform-bun": ["@effect/platform-bun@4.0.0-rc.112", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-rc.112" }, "peerDependencies": { "effect": "^4.0.0-rc.112" } }, "sha512-Y5n2HhV/vsbrJls9ukX42RL7zqXQxISHegWFsP9njsCyDmGTnq7QYSO82rglwrLPwtTrv5dkSRTuGw4+oXxgMg=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.112", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.3" }, "peerDependencies": { "effect": "^4.0.0-rc.112" } }, "sha512-ttjz0xKamFN7vL8pNDYVwddJLjZvqKePc05djlz2VcdaKbLsnYbtMnL1rbOfHgEnIUSHGh7FkjaN4DM1Ov81sQ=="],
-
-    "@electric-sql/pglite": ["@electric-sql/pglite@0.5.8", "", {}, "sha512-n9tsbUOhwx2epK1V0ZG9Ar4SHWUju04dhmzZXiSBXwBoleOvIfals33NAaWgagQVAL4Rbvx/Ptsu3P+pA09f6Q=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.10.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg=="],
 
@@ -60,10 +45,6 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
 
-    "@grpc/grpc-js": ["@grpc/grpc-js@1.13.3", "", { "dependencies": { "@grpc/proto-loader": "^0.7.13", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-FTXHdOoPbZrBjlVLHuKbDZnsTxXv2BlHF57xw6LuThXacXvtkahEPED0CKMk6obZDf65Hv4k3z62eyPNpvinIg=="],
-
-    "@grpc/proto-loader": ["@grpc/proto-loader@0.7.15", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.2.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ=="],
-
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
@@ -73,8 +54,6 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
-
-    "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
@@ -94,35 +73,11 @@
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
-
-    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
-
-    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
-
-    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
-
-    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
-
-    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
-
-    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
-
-    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
-
-    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
-
-    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
-
-    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
-
     "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
 
     "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
 
     "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
-
-    "@scure/starknet": ["@scure/starknet@1.1.2", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0" } }, "sha512-Qo2uNQJC/1IwfXC0f2BnDjtXnY1cVyfmK1WcGNFzfnktvlNmmmbjYeUNdYe3DBiDYyMzp1MhRUFllFW5moBaMg=="],
 
     "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
 
@@ -154,23 +109,13 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.68.0", "", { "dependencies": { "@typescript-eslint/types": "8.68.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A=="],
 
-    "abi-wan-kanabi": ["abi-wan-kanabi@2.2.4", "", { "dependencies": { "ansicolors": "^0.3.2", "cardinal": "^2.1.1", "fs-extra": "^10.0.0", "yargs": "^17.7.2" }, "bin": { "generate": "dist/generate.js" } }, "sha512-0aA81FScmJCPX+8UvkXLki3X1+yPQuWxEkqXBVKltgPAK79J+NB+Lp5DouMXa7L6f+zcRlIA/6XO7BN/q9fnvg=="],
-
     "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
-
-    "abort-controller-x": ["abort-controller-x@0.4.3", "", {}, "sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA=="],
 
     "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
-
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "ansicolors": ["ansicolors@0.3.2", "", {}, "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="],
 
     "async": ["async@3.2.5", "", {}, ""],
 
@@ -180,10 +125,6 @@
 
     "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
-    "cardinal": ["cardinal@2.1.1", "", { "dependencies": { "ansicolors": "~0.3.2", "redeyed": "~2.1.0" }, "bin": { "cdl": "bin/cdl.js" } }, "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw=="],
-
-    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
     "color": ["color@5.0.3", "", { "dependencies": { "color-convert": "^3.1.3", "color-string": "^2.1.3" } }, "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA=="],
 
     "color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
@@ -191,8 +132,6 @@
     "color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 
     "color-string": ["color-string@2.1.4", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="],
-
-    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -206,11 +145,7 @@
 
     "effect": ["effect@4.0.0-rc.112", "", { "dependencies": { "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A=="],
 
-    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
     "enabled": ["enabled@2.0.0", "", {}, ""],
-
-    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -221,8 +156,6 @@
     "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
-
-    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "bin/esparse.js", "esvalidate": "bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
@@ -256,13 +189,7 @@
 
     "fn.name": ["fn.name@1.1.0", "", {}, ""],
 
-    "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
-
-    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
-
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
-
-    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -271,8 +198,6 @@
     "inherits": ["inherits@2.0.4", "", {}, ""],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
-
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
@@ -288,8 +213,6 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
-    "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
-
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kuler": ["kuler@2.0.0", "", {}, ""],
@@ -298,11 +221,7 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
-    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
-
     "logform": ["logform@2.7.0", "", { "dependencies": { "@colors/colors": "1.6.0", "@types/triple-beam": "^1.3.2", "fecha": "^4.2.0", "ms": "^2.1.1", "safe-stable-stringify": "^2.3.1", "triple-beam": "^1.3.0" } }, ""],
-
-    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
@@ -313,10 +232,6 @@
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
-
-    "nice-grpc": ["nice-grpc@2.1.12", "", { "dependencies": { "@grpc/grpc-js": "^1.13.1", "abort-controller-x": "^0.4.0", "nice-grpc-common": "^2.0.2" } }, "sha512-J1n4Wg+D3IhRhGQb+iqh2OpiM0GzTve/kf2lnlW4S+xczmIEd0aHUDV1OsJ5a3q8GSTqJf+s4Rgg1M8uJltarw=="],
-
-    "nice-grpc-common": ["nice-grpc-common@2.0.2", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
@@ -342,17 +257,11 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "protobufjs": ["protobufjs@7.5.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw=="],
-
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, ""],
-
-    "redeyed": ["redeyed@2.1.1", "", { "dependencies": { "esprima": "~4.0.0" } }, "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ=="],
-
-    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, ""],
 
@@ -366,11 +275,7 @@
 
     "stack-trace": ["stack-trace@0.0.10", "", {}, ""],
 
-    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, ""],
-
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "text-hex": ["text-hex@1.0.0", "", {}, ""],
 
@@ -380,15 +285,11 @@
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
-    "ts-error": ["ts-error@1.0.6", "", {}, "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA=="],
-
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
-
-    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
@@ -404,46 +305,14 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
     "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
-    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
-
-    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
-
-    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
-
-    "@apibara/evm/viem": ["viem@2.48.11", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.20", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw=="],
-
-    "@apibara/evm-rpc/viem": ["viem@2.48.11", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.20", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw=="],
-
-    "@apibara/protocol/viem": ["viem@2.48.11", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.20", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw=="],
 
     "@effect/platform-node-shared/ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@scure/bip32/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
-
-    "@scure/starknet/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
-
-    "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
-
-    "@apibara/evm-rpc/viem/ox": ["ox@0.14.20", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw=="],
-
-    "@apibara/evm-rpc/viem/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
-
-    "@apibara/evm/viem/ox": ["ox@0.14.20", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw=="],
-
-    "@apibara/evm/viem/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
-
-    "@apibara/protocol/viem/ox": ["ox@0.14.20", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw=="],
-
-    "@apibara/protocol/viem/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
-
-    "ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "winston": "^3.19.0",
       },
       "devDependencies": {
+        "@electric-sql/pglite": "^0.5.8",
         "@types/bun": "^1.4.0",
         "@typescript-eslint/parser": "8.68.0",
         "eslint": "10.9.1",
@@ -30,6 +31,8 @@
     "@effect/platform-bun": ["@effect/platform-bun@4.0.0-rc.112", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-rc.112" }, "peerDependencies": { "effect": "^4.0.0-rc.112" } }, "sha512-Y5n2HhV/vsbrJls9ukX42RL7zqXQxISHegWFsP9njsCyDmGTnq7QYSO82rglwrLPwtTrv5dkSRTuGw4+oXxgMg=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.112", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.3" }, "peerDependencies": { "effect": "^4.0.0-rc.112" } }, "sha512-ttjz0xKamFN7vL8pNDYVwddJLjZvqKePc05djlz2VcdaKbLsnYbtMnL1rbOfHgEnIUSHGh7FkjaN4DM1Ov81sQ=="],
+
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.5.8", "", {}, "sha512-n9tsbUOhwx2epK1V0ZG9Ar4SHWUju04dhmzZXiSBXwBoleOvIfals33NAaWgagQVAL4Rbvx/Ptsu3P+pA09f6Q=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.10.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bun": ">=1.3"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.5.8",
     "@types/bun": "^1.4.0",
     "@typescript-eslint/parser": "8.68.0",
     "eslint": "10.9.1"

--- a/package.json
+++ b/package.json
@@ -28,16 +28,11 @@
     "bun": ">=1.3"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.5.8",
     "@types/bun": "^1.4.0",
     "@typescript-eslint/parser": "8.68.0",
     "eslint": "10.9.1"
   },
   "dependencies": {
-    "@apibara/evm": "^2.1.4",
-    "@apibara/evm-rpc": "^2.1.4",
-    "@apibara/protocol": "^2.1.3",
-    "@apibara/starknet": "^2.1.4",
     "@effect/platform-bun": "4.0.0-rc.112",
     "dotenv": "^17.4.2",
     "effect": "4.0.0-rc.112",

--- a/scripts/verifyStarknetStream.ts
+++ b/scripts/verifyStarknetStream.ts
@@ -1,0 +1,131 @@
+/**
+ * Replays a settled historical range through the Starknet adapter and asserts
+ * that the events it produces carry exactly the positions the database already
+ * holds for them.
+ *
+ * This is the check that matters for the move off the apibara DNA stream.
+ * `transaction_index` and `event_index` are packed into `event_id`, which is a
+ * primary key other tables order on, so getting them wrong would not error --
+ * it would write rows that collide with or silently duplicate years of existing
+ * history. They come from `starknet_getEvents` under JSON-RPC v0.10; under v0.9
+ * they are absent entirely, which is why the URL pins a version.
+ *
+ * The DNA stream wrote the rows already in the database. Reproducing them from
+ * the RPC, for a range indexed long before this code existed, is the only way
+ * to be sure the two agree.
+ *
+ *   bun scripts/verifyStarknetStream.ts <rpc-url> [blocks]
+ *
+ * Needs PG_CONNECTION_STRING and the Starknet contract addresses in the
+ * environment. Exits non-zero on any mismatch, so it can gate a deploy.
+ */
+import postgres from "postgres";
+import { loadHexAddresses } from "../src/_shared/loadHexAddresses";
+import { createEventProcessors } from "../src/starknet/eventProcessors";
+import {
+  createStarknetAdapter,
+  createStarknetRpc,
+  type StarknetStreamFilter,
+} from "../src/starknet/eventStream";
+
+const [url, spanRaw] = process.argv.slice(2);
+if (!url) throw new Error("usage: verifyStarknetStream.ts <rpc-url> [blocks]");
+const SPAN = Number(spanRaw ?? 2000);
+const CHUNK = 500;
+
+const addresses = loadHexAddresses({
+  nftAddress: "NFT_ADDRESS",
+  coreAddress: "CORE_ADDRESS",
+  positionsAddress: "POSITIONS_ADDRESS",
+  tokenRegistryAddress: "TOKEN_REGISTRY_ADDRESS",
+  tokenRegistryV2Address: "TOKEN_REGISTRY_V2_ADDRESS",
+  tokenRegistryV3Address: "TOKEN_REGISTRY_V3_ADDRESS",
+  twammAddress: "TWAMM_ADDRESS",
+  stakerAddress: "STAKER_ADDRESS",
+  governorAddress: "GOVERNOR_ADDRESS",
+  oracleAddress: "ORACLE_ADDRESS",
+  limitOrdersAddress: "LIMIT_ORDERS_ADDRESS",
+  splineLiquidityProviderAddress: "SPLINE_LIQUIDITY_PROVIDER_ADDRESS",
+});
+if (!addresses) throw new Error("Missing or invalid Starknet addresses");
+
+const processors = createEventProcessors(addresses);
+const filters: StarknetStreamFilter[] = processors.map((processor, ix) => ({
+  id: ix + 1,
+  fromAddress: processor.filter.fromAddress,
+  keys: processor.filter.keys,
+}));
+
+const rpc = createStarknetRpc(url);
+const adapter = createStarknetAdapter({ rpc, filters });
+
+const head = await adapter.fetchHead();
+if (!head) throw new Error("could not read the head");
+// Stay well behind the head so the range is settled and the comparison is fair.
+const to = head.number - 500;
+const from = to - SPAN + 1;
+console.log(`verifying blocks ${from}..${to} against the database`);
+
+// The Swapped event on Core, which is what the `swaps` table holds. Comparing
+// against one table keeps this an exact set equality rather than a sampling.
+const SWAPPED = BigInt(
+  "0x157717768aca88da4ac4279765f09f4d0151823d573537fbbeb950cdbd9a870",
+);
+const CORE = BigInt(addresses.coreAddress);
+
+const fromStream = new Set<string>();
+for (let start = from; start <= to; start += CHUNK) {
+  const end = Math.min(to, start + CHUNK - 1);
+  const blocks = await adapter.readRange(start, end);
+  await adapter.completeFresh(blocks, head);
+  for (const block of blocks) {
+    for (const event of block.logs) {
+      if (BigInt(event.address) !== CORE) continue;
+      if (event.keys[0] === undefined || BigInt(event.keys[0]) !== SWAPPED) {
+        continue;
+      }
+      fromStream.add(
+        `${block.header.blockNumber}:${event.transactionIndex}:${event.eventIndex}`,
+      );
+    }
+  }
+  process.stdout.write(`  read ${start}..${end}\r`);
+}
+console.log(`\nstream produced ${fromStream.size} Swapped events`);
+
+const sql = postgres(process.env.PG_CONNECTION_STRING!, {
+  types: { bigint: postgres.BigInt },
+});
+const chainId = BigInt(process.env.CHAIN_ID!);
+const rows = await sql<
+  { block_number: string; transaction_index: number; event_index: number }[]
+>`SELECT block_number, transaction_index, event_index
+    FROM swaps
+   WHERE chain_id = ${chainId}
+     AND block_number BETWEEN ${from} AND ${to}`;
+const fromDb = new Set(
+  rows.map(
+    (r) => `${r.block_number}:${r.transaction_index}:${r.event_index}`,
+  ),
+);
+console.log(`database holds  ${fromDb.size} Swapped events`);
+await sql.end();
+
+const missing = [...fromDb].filter((k) => !fromStream.has(k));
+const extra = [...fromStream].filter((k) => !fromDb.has(k));
+
+if (missing.length === 0 && extra.length === 0) {
+  console.log(`OK: ${fromDb.size} events agree exactly on block:tx:event`);
+  process.exit(0);
+}
+
+console.error(`MISMATCH`);
+if (missing.length) {
+  console.error(`  in the database but not produced (${missing.length}):`);
+  for (const k of missing.slice(0, 20)) console.error(`    ${k}`);
+}
+if (extra.length) {
+  console.error(`  produced but not in the database (${extra.length}):`);
+  for (const k of extra.slice(0, 20)) console.error(`    ${k}`);
+}
+process.exit(1);

--- a/src/_shared/blockStream.ts
+++ b/src/_shared/blockStream.ts
@@ -1,0 +1,1147 @@
+/**
+ * A polling, range-read block stream, shared by every network we index.
+ *
+ * This is the EVM log stream generalised. Nothing in it is specific to a chain
+ * family: it polls a head, re-reads a window below the cursor to notice reorgs,
+ * backs off when the chain is doing nothing we index, and emits the same
+ * messages the apibara streams did. What events *are*, how to ask a chain for a
+ * range of them, and how to fill in whatever a range read does not carry, is
+ * the `ChainAdapter`'s job.
+ *
+ * The reasoning that shaped each rule is kept with the rule, because most of it
+ * was paid for with a bug. The concrete numbers in the comments are the EVM
+ * measurements that produced them; they are illustrative here, not assumptions
+ * the core makes.
+ *
+ * Correctness notes, since missing an event is the failure that matters:
+ *
+ * - A range query is self-describing in a way a subscription is not. It either
+ *   answers for the blocks asked for or it errors; a dropped WebSocket frame
+ *   looks like silence. That is why this polls.
+ * - Reorgs are detected by re-reading a window at the head every poll and
+ *   diffing it against what was emitted, so a block whose hash changed or whose
+ *   events disappeared is caught even though no header was fetched. A reorg
+ *   that touches no event of ours changes nothing we store, so it is not
+ *   looked for.
+ * - The adapter is responsible for refusing a range read it cannot vouch for.
+ *   A provider that caps results and returns exactly the cap is
+ *   indistinguishable from one that found exactly that many, and believing it
+ *   means dropping every event past the cap with nothing to show for it.
+ */
+import type { Hex } from "viem";
+import type { IndexerCursor } from "./dao";
+
+/** Identity of a block, as far as this stream is concerned. */
+export type ChainHead = {
+  number: number;
+  hash: Hex;
+  timestamp: Date;
+  baseFeePerGas: bigint | null;
+};
+
+/** What the diff compares: a block's hash and how many events it carried. */
+export type BlockDigest = { hash: Hex; logCount: number };
+
+/**
+ * A block as the runtime consumes it.
+ *
+ * `logs` rather than `events` because that is the name the EVM runtime, the DAO
+ * and every processor already use, and renaming it would touch far more than
+ * this change is about.
+ */
+export interface StreamBlock<TEvent> {
+  header: {
+    blockNumber: bigint;
+    blockHash: Hex;
+    timestamp: Date;
+    baseFeePerGas: bigint | null;
+  };
+  logs: TEvent[];
+}
+
+export type StreamMessage<TEvent> =
+  | { _tag: "heartbeat" }
+  | { _tag: "finalize"; finalize: { cursor: IndexerCursor } }
+  | { _tag: "invalidate"; invalidate: { cursor: IndexerCursor } }
+  | {
+      _tag: "data";
+      data: { endCursor: IndexerCursor; data: StreamBlock<TEvent>[] };
+    };
+
+/**
+ * Everything chain-specific the loop needs, and nothing else.
+ *
+ * The split is drawn where cost is: `readRange` answers for a whole span in one
+ * request and is called every poll, so it must carry enough to diff a window --
+ * block number, block hash, and the events we matched. `completeFresh` is
+ * called only for blocks *above the cursor*, so anything expensive per block
+ * belongs there rather than in `readRange`. On Starknet that distinction is the
+ * difference between ~6k and ~390k requests a day: the reorg window is re-read
+ * every poll and would otherwise pay per-block costs for blocks it has already
+ * indexed and is only re-checking.
+ */
+export interface ChainAdapter<TEvent> {
+  /** Names the chain family in errors and warnings. */
+  readonly label: string;
+
+  /** The head block, or null when it cannot be read this poll. */
+  fetchHead(): Promise<ChainHead | null>;
+
+  /** One block's identity, or null when it cannot be read. */
+  fetchBlock(blockNumber: number): Promise<ChainHead | null>;
+
+  /**
+   * The deepest block that can no longer reorg, or null when the endpoint
+   * cannot answer. Never fatal: the finalized block is an optimisation here.
+   */
+  fetchFinalized(): Promise<ChainHead | null>;
+
+  /**
+   * Every event we match in `[from, to]`, grouped into blocks in ascending
+   * block order, events within a block in the order they were emitted.
+   *
+   * Must refuse rather than truncate. Blocks carrying no matched event must be
+   * omitted entirely -- a block with none has no representation in a filtered
+   * range read, so recording one would make it look like it had disappeared on
+   * the very next re-read.
+   */
+  readRange(from: number, to: number): Promise<StreamBlock<TEvent>[]>;
+
+  /**
+   * Fills in whatever `readRange` could not carry, for fresh blocks only.
+   *
+   * Must not change how many events a block holds. The diff compares the count
+   * recorded when a block was emitted against the count the next `readRange`
+   * reports, so a completion step that added or dropped one would manufacture a
+   * reorg on every single poll.
+   */
+  completeFresh(blocks: StreamBlock<TEvent>[], head: ChainHead): Promise<void>;
+}
+
+export interface BlockStreamOptions {
+  /** How long to wait after catching up to the head before polling again. */
+  pollIntervalMs?: number;
+  /** The longest this may back off to on a chain indexing nothing. */
+  maxPollIntervalMs?: number;
+  /**
+   * Consecutive caught-up polls that index nothing before the interval starts
+   * doubling. Anything indexed within the last
+   * `pollIntervalMs * quietPollsBeforeBackoff` keeps polling at the floor.
+   */
+  quietPollsBeforeBackoff?: number;
+  /** Widest block span to ask for in one range read. */
+  maxLogRangeBlocks?: number;
+  /**
+   * How far back to re-read at the head to notice a reorg. Must be at least the
+   * deepest reorg the chain can produce; the cost of being generous is one
+   * wider range read, the cost of being stingy is a missed event.
+   */
+  reorgWindowSeconds?: number;
+  /** How often to re-read the finalized block. */
+  finalizedRefreshIntervalMs?: number;
+  heartbeatIntervalMs?: number;
+  onWarning?: (message: string, detail: Record<string, unknown>) => void;
+}
+
+export const BLOCK_STREAM_DEFAULTS = {
+  pollIntervalMs: 2_000,
+  maxPollIntervalMs: 30_000,
+  quietPollsBeforeBackoff: 30,
+  maxLogRangeBlocks: 1_000,
+  reorgWindowSeconds: 120,
+  finalizedRefreshIntervalMs: 30_000,
+  heartbeatIntervalMs: 10_000,
+} as const;
+
+export type Resolved = Required<Omit<BlockStreamOptions, "onWarning">> &
+  Pick<BlockStreamOptions, "onWarning">;
+
+/** Everything the loop carries between iterations. */
+export interface StreamState {
+  cursorBlock: number;
+  /**
+   * Digests of the event-bearing blocks inside the reorg window.
+   *
+   * Only blocks that carried events belong here. A block with none has no
+   * representation in a filtered range read, so recording one would make it
+   * look like it had disappeared on the very next re-read.
+   */
+  emitted: Map<number, BlockDigest>;
+  finalized: ChainHead | null;
+  lastFinalizedRefresh: number;
+  /** Highest finalized block already announced downstream, 0 before the first. */
+  finalizedEmitted: number;
+  lastHeartbeat: number;
+  /** Hash of the head as of the last completed read, "" before the first. */
+  lastHeadHash: string;
+  /**
+   * Consecutive caught-up polls that indexed nothing, which is what the poll
+   * interval backs off on. Reset to 0 by anything worth being fast for.
+   */
+  quietPolls: number;
+  /**
+   * Observed blocks per second, or null until enough of the chain has gone by
+   * to measure it. Every sizing decision that would otherwise be a block count
+   * goes through this.
+   */
+  blockRate: number | null;
+  /** The older end of the interval `blockRate` is measured over. */
+  rateSample: { number: number; timeSec: number } | null;
+  /** Effective window last warned about, so the cap is reported once. */
+  warnedCapSeconds: number | null;
+  /**
+   * Lowest block `emitted` is authoritative for.
+   *
+   * Below this the map is silent because entries were pruned, not because the
+   * chain had nothing -- and those two are indistinguishable to a diff.
+   */
+  retainedFrom: number;
+  /**
+   * False until the first window has been read.
+   *
+   * `emitted` starts empty because nothing has been observed yet, not because
+   * the chain is empty, so the first read seeds it instead of diffing against
+   * it. Restart safety comes from the cursor hash check instead, which is both
+   * cheaper and stronger: a block hash commits to its whole ancestry.
+   */
+  seeded: boolean;
+}
+
+/** Packed into 16 bits by `compute_event_id`, so this is a hard ceiling. */
+export const MAX_EVENT_INDEX = 65_536;
+
+/**
+ * Fails loudly, and early, on an event index `compute_event_id` cannot hold.
+ *
+ * `compute_event_id` packs the index into 16 bits and raises above 65,535, so a
+ * block whose numbering reaches that cannot be indexed under this scheme at
+ * all. Which number is being packed differs by chain -- EVM uses the block-wide
+ * log index, Starknet the index within its transaction -- and that difference
+ * is inherited from the streams these replace, not introduced here. Re-basing
+ * `event_id` is a migration, not a stream change.
+ *
+ * What this does is convert a confusing failure deep in a Postgres function
+ * into one that names the cause at the point of origin.
+ */
+export function requireRepresentableIndex(
+  eventIndex: number,
+  blockNumber: number,
+  numbering: string,
+): number {
+  if (eventIndex >= MAX_EVENT_INDEX) {
+    throw new Error(
+      `Block ${blockNumber} contains an event at index ${eventIndex}, which compute_event_id cannot represent (the limit is ${MAX_EVENT_INDEX}). event_index is ${numbering}, so a block reaching that many cannot be indexed without re-basing event_id.`,
+    );
+  }
+  return eventIndex;
+}
+
+/** Which blocks in a range carry events, and under which hash. */
+export function digestBlocks<TEvent>(
+  blocks: StreamBlock<TEvent>[],
+): Map<number, BlockDigest> {
+  const digests = new Map<number, BlockDigest>();
+  for (const block of blocks) {
+    digests.set(Number(block.header.blockNumber), {
+      hash: block.header.blockHash,
+      logCount: block.logs.length,
+    });
+  }
+  return digests;
+}
+
+/**
+ * The lowest block at which `next` disagrees with `previous`, or undefined when
+ * they agree.
+ *
+ * Disagreement is a block that changed hash, a block that lost its events, or a
+ * block that gained events it did not have. Only blocks inside `[from, to]` are
+ * compared, because anything outside was not re-read.
+ */
+export function firstDivergentBlock(
+  previous: Map<number, BlockDigest>,
+  next: Map<number, BlockDigest>,
+  from: number,
+  to: number,
+): number | undefined {
+  let lowest: number | undefined;
+
+  const consider = (blockNumber: number) => {
+    if (blockNumber < from || blockNumber > to) return;
+    const before = previous.get(blockNumber);
+    const after = next.get(blockNumber);
+    const same =
+      before === undefined
+        ? after === undefined
+        : after !== undefined &&
+          before.hash.toLowerCase() === after.hash.toLowerCase() &&
+          before.logCount === after.logCount;
+    if (!same && (lowest === undefined || blockNumber < lowest)) {
+      lowest = blockNumber;
+    }
+  };
+
+  for (const blockNumber of previous.keys()) consider(blockNumber);
+  for (const blockNumber of next.keys()) consider(blockNumber);
+
+  return lowest;
+}
+
+/**
+ * Chain time that must elapse before a block-rate sample is believed.
+ *
+ * Block timestamps have one-second resolution, and Robinhood produces eleven
+ * blocks inside one of those, so a short baseline measures rounding rather than
+ * the chain. Thirty seconds is long enough that the quantisation is noise on
+ * every chain we index and short enough to be learnt within one backoff cycle.
+ */
+export const MIN_RATE_SAMPLE_SECONDS = 30;
+
+/**
+ * Updates the observed block rate from a head this poll already fetched.
+ *
+ * Free: the head read returns the number and the timestamp together, and the
+ * stream reads it every poll anyway. No request is made for this, which is the
+ * only reason it is worth measuring continuously rather than once at startup.
+ */
+export function observeBlockRate(
+  state: StreamState,
+  head: Pick<ChainHead, "number" | "timestamp">,
+): void {
+  const timeSec = Math.floor(head.timestamp.getTime() / 1000);
+  const sample = state.rateSample;
+  if (!sample) {
+    state.rateSample = { number: head.number, timeSec };
+    return;
+  }
+
+  const elapsed = timeSec - sample.timeSec;
+  const advanced = head.number - sample.number;
+  if (elapsed < 0 || advanced < 0) {
+    state.rateSample = { number: head.number, timeSec };
+    return;
+  }
+
+  if (elapsed < MIN_RATE_SAMPLE_SECONDS) {
+    // Rise-only, and only against a rate already trusted. A short baseline can
+    // prove the chain is at least this fast -- blocks did arrive -- but cannot
+    // prove it is slow, because the interval may simply have been rounded.
+    if (state.blockRate !== null && elapsed > 0 && advanced > 0) {
+      const witnessed = advanced / elapsed;
+      if (witnessed > state.blockRate) state.blockRate = witnessed;
+    }
+    return;
+  }
+
+  // A full baseline that saw no blocks is a halted chain, not a rate of zero.
+  // Treating it as zero would make every derived window infinite.
+  if (advanced <= 0) {
+    state.rateSample = { number: head.number, timeSec };
+    return;
+  }
+
+  state.blockRate = advanced / elapsed;
+  state.rateSample = { number: head.number, timeSec };
+}
+
+/**
+ * The widest window `reorgWindowBlocksFor` can ever return for this span.
+ *
+ * Half the span, which is what guarantees the other half is forward progress.
+ * Load-bearing beyond sizing a read: it is also how far back `emitted` has to
+ * be retained, since a window that grows must not scan blocks the last tick
+ * forgot.
+ */
+export function maxReorgWindowBlocks(
+  opts: Pick<Resolved, "maxLogRangeBlocks">,
+): number {
+  return Math.max(1, Math.floor(opts.maxLogRangeBlocks / 2));
+}
+
+/**
+ * How many blocks `reorgWindowSeconds` is worth on this chain right now.
+ *
+ * Capped at half `maxLogRangeBlocks`, which is what makes an unusable
+ * configuration unreachable rather than merely rejected. A read span no wider
+ * than the window it re-reads cannot reach past it: nothing is emitted, the
+ * cursor never advances, and because the span never reaches the head the loop
+ * never sleeps -- it spins at CPU speed issuing two requests a turn while
+ * looking perfectly healthy. Holding the window at half the span guarantees at
+ * least half the span is forward progress, whatever the chain does.
+ *
+ * Before the rate is known the window is that cap. Erring wide is free -- a
+ * range read is billed per request, so a wider span is the same cost -- and
+ * erring narrow silently loses events, so the unmeasured case takes the widest
+ * window on offer and narrows as the chain is observed.
+ */
+export function reorgWindowBlocksFor(
+  state: Pick<StreamState, "blockRate">,
+  opts: Pick<Resolved, "reorgWindowSeconds" | "maxLogRangeBlocks">,
+): number {
+  const cap = maxReorgWindowBlocks(opts);
+  if (state.blockRate === null) return cap;
+  return Math.min(
+    cap,
+    Math.max(1, Math.ceil(state.blockRate * opts.reorgWindowSeconds)),
+  );
+}
+
+/**
+ * Says once, not every poll, that the span is holding the window narrower than
+ * `reorgWindowSeconds` asked for.
+ *
+ * Deliberately separate from `reorgWindowBlocksFor`, which several call sites
+ * hit more than once per tick -- `windowFor`, `finishTick`, `pollIntervalFor`
+ * and the finalized refresh all size themselves from it. A warning in there is
+ * four identical lines per poll forever on any chain where the cap binds, which
+ * is how a real signal becomes noise nobody reads.
+ *
+ * Not an error: the stream is still correct, just protected for less history
+ * than requested. Worth saying at all because the remedy is one env var --
+ * the range size bounds it, and raising it is free up to the provider's own
+ * range limit.
+ */
+function warnIfWindowCapped(state: StreamState, opts: Resolved): void {
+  const rate = state.blockRate;
+  if (rate === null) return;
+
+  const cap = maxReorgWindowBlocks(opts);
+  const wanted = Math.max(1, Math.ceil(rate * opts.reorgWindowSeconds));
+  if (wanted <= cap) return;
+
+  // Re-warn only when the shortfall actually changes, so a chain whose rate
+  // drifts says so again while a steady one says it once.
+  const effectiveSeconds = Math.round(cap / rate);
+  if (state.warnedCapSeconds === effectiveSeconds) return;
+  state.warnedCapSeconds = effectiveSeconds;
+
+  opts.onWarning?.("reorg window capped by the log range size", {
+    wantedBlocks: wanted,
+    cappedToBlocks: cap,
+    effectiveSeconds,
+    reorgWindowSeconds: opts.reorgWindowSeconds,
+    maxLogRangeBlocks: opts.maxLogRangeBlocks,
+  });
+}
+
+/** The span to re-read: back into the reorg window, or forward when behind it. */
+function windowFor(
+  state: StreamState,
+  head: number,
+  opts: Resolved,
+): { from: number; to: number } {
+  const earliest = (state.finalized?.number ?? 0) + 1;
+  // The window hangs below the cursor, not below the head, and it is re-read
+  // unconditionally. Both of those matter once the poll interval can grow.
+  //
+  // This used to read back from `head - reorgWindowBlocks`, and only when the
+  // head was within that distance of the cursor; otherwise it read straight
+  // forward from the cursor. The reasoning was that a cursor further back than
+  // the window is catching up and has nothing recently emitted to protect. At a
+  // two-second poll that held on every chain we index -- the head is always a
+  // few blocks ahead -- so the forward-only branch belonged to backfill alone.
+  //
+  // Backing off to thirty seconds breaks the assumption in both parts. An L2 at
+  // four blocks a second advances ~120 blocks between polls, so a caught-up
+  // stream is permanently "further back than the window": it would take the
+  // forward branch forever and never re-read a block it had already emitted,
+  // silently giving up reorg detection on exactly the chains whose finality
+  // lags furthest behind their head. Anchoring to the head instead of the
+  // cursor has the same hole, because `head - reorgWindowBlocks` then sits
+  // above the cursor and the `min` below collapses to `cursorBlock + 1`.
+  //
+  // Anchoring to the cursor is what actually re-reads the blocks at risk: they
+  // are the ones *we emitted*, which is a fact about the cursor and nothing
+  // else. It costs no compute units -- a range read is billed per request, so
+  // a wider span is the same price -- and slows a backfill by the window as
+  // a fraction of the span, since each read now overlaps the last by the width
+  // of the window. That fraction is at most a half, and is whatever
+  // `reorgWindowSeconds` works out to on this chain once the rate is known.
+  //
+  // Never start above the cursor. `earliest` is an optimisation -- a finalized
+  // block cannot reorg, so there is no point re-reading below it -- but on a
+  // chain that finalises in under a second it can overtake a cursor that fell a
+  // few blocks behind, and letting it raise `from` would skip those blocks
+  // silently.
+  const from = Math.max(
+    1,
+    Math.min(
+      state.cursorBlock + 1,
+      Math.max(
+        earliest,
+        state.cursorBlock + 1 - reorgWindowBlocksFor(state, opts),
+      ),
+    ),
+  );
+  return { from, to: Math.min(head, from + opts.maxLogRangeBlocks - 1) };
+}
+
+/** Drops window entries the re-read no longer covers. */
+function forgetBelow(state: StreamState, keepFrom: number): void {
+  for (const key of [...state.emitted.keys()]) {
+    if (key < keepFrom) state.emitted.delete(key);
+  }
+  // Only ever rises. What was pruned cannot be un-pruned, so this is the record
+  // of how far down the map can still be trusted.
+  state.retainedFrom = Math.max(state.retainedFrom, keepFrom);
+}
+
+function rollbackTo<TEvent>(
+  state: StreamState,
+  block: number,
+): StreamMessage<TEvent> {
+  for (const key of [...state.emitted.keys()]) {
+    if (key >= block) state.emitted.delete(key);
+  }
+  state.cursorBlock = block - 1;
+
+  // Carry the hash when the block we land on is one we recorded. Without it the
+  // stored cursor has no `unique_key`, and a restart in the window between this
+  // rollback and the next data message would skip the canonicality check
+  // entirely -- right after the one event that makes it worth doing. Only
+  // event-bearing blocks are in `emitted`, so this is best-effort by nature.
+  const landing = state.emitted.get(block - 1);
+
+  return {
+    _tag: "invalidate",
+    invalidate: {
+      cursor: {
+        orderKey: BigInt(block - 1),
+        ...(landing ? { uniqueKey: landing.hash } : {}),
+      },
+    },
+  };
+}
+
+function dataMessage<TEvent>(
+  block: StreamBlock<TEvent>,
+): StreamMessage<TEvent> {
+  return {
+    _tag: "data",
+    data: {
+      endCursor: {
+        orderKey: block.header.blockNumber,
+        uniqueKey: block.header.blockHash,
+      },
+      data: [block],
+    },
+  };
+}
+
+/**
+ * Re-reads the finalized block, at most once per configured interval.
+ *
+ * A finalized block never moves backwards, so an answer that does is a stale
+ * view rather than a change to the chain. The stream this replaces threw on
+ * that and crash-looped a worker roughly every eighty seconds.
+ */
+async function refreshFinalized<TEvent>(
+  adapter: ChainAdapter<TEvent>,
+  state: StreamState,
+  opts: Resolved,
+  now: number,
+): Promise<void> {
+  // Scaled by the effective poll interval, not fixed. At the floor this is the
+  // configured thirty seconds; at a thirty-second backoff a fixed interval
+  // would fire on every single poll, and its compute units would be a
+  // fifth of what a quiet chain costs -- turning a 93% saving into a 76% one.
+  // A staler finalized block on a dormant chain buys back nothing worth having:
+  // it only widens the re-read, which is free, and slows `finalized_order_key`,
+  // which nothing on such a chain is waiting for.
+  const due = Math.max(
+    opts.finalizedRefreshIntervalMs,
+    pollIntervalFor(state, opts) * 4,
+  );
+  if (now - state.lastFinalizedRefresh < due) {
+    return;
+  }
+  state.lastFinalizedRefresh = now;
+
+  // Tolerated, not fatal. The finalized block is an optimisation here -- a floor
+  // on the re-read and a cursor to announce -- so a node that cannot answer for
+  // it should cost us that optimisation, not the worker. Without this catch the
+  // `withNullBlockRetry` wrapper turns a null answer into a throw that escapes
+  // the generator every thirty seconds and exits the process.
+  const finalized = await adapter.fetchFinalized().catch((error: unknown) => {
+    opts.onWarning?.("could not read the finalized block", {
+      error: String(error).slice(0, 200),
+    });
+    return null;
+  });
+  if (!finalized) return;
+
+  if (state.finalized && finalized.number < state.finalized.number) {
+    opts.onWarning?.("finalized block moved backwards; ignoring", {
+      seen: finalized.number,
+      held: state.finalized.number,
+    });
+    return;
+  }
+  state.finalized = finalized;
+}
+
+/**
+ * Refreshes the finalized block when due, then announces it if the cursor has
+ * reached it. `now` of null skips the refresh and only re-checks.
+ */
+async function* announceFinalized<TEvent>(
+  adapter: ChainAdapter<TEvent>,
+  state: StreamState,
+  opts: Resolved,
+  now: number | null,
+): AsyncGenerator<StreamMessage<TEvent>> {
+  if (now !== null) await refreshFinalized(adapter, state, opts, now);
+  const message = finalizeIfDue<TEvent>(state);
+  if (message) yield message;
+}
+
+/**
+ * Announces the finalized block, once the cursor has actually reached it.
+ *
+ * Never ahead of the cursor: the runtime's recovery path resets the cursor to
+ * the last finalized one, so a finalized cursor past ours would move it
+ * *forward* on the next unhandled error and skip everything between.
+ *
+ * Which is why this is a separate step rather than part of the refresh. The
+ * refresh happens at the top of a tick, when the cursor still holds last tick's
+ * value; on a chain that finalises within a block or two of the head, that stale
+ * cursor is always behind the finalized block and the message would be
+ * suppressed forever, leaving `finalized_order_key` frozen and the runtime with
+ * nothing to recover to. Checking after the cursor advances is what makes the
+ * hold-back a delay rather than a permanent mute.
+ */
+function finalizeIfDue<TEvent>(
+  state: StreamState,
+): StreamMessage<TEvent> | null {
+  const finalized = state.finalized;
+  if (
+    !finalized ||
+    finalized.number > state.cursorBlock ||
+    finalized.number <= state.finalizedEmitted
+  ) {
+    return null;
+  }
+
+  state.finalizedEmitted = finalized.number;
+  return {
+    _tag: "finalize",
+    finalize: {
+      cursor: { orderKey: BigInt(finalized.number), uniqueKey: finalized.hash },
+    },
+  };
+}
+
+function heartbeatIfDue<TEvent>(
+  state: StreamState,
+  opts: Resolved,
+  now: number,
+): StreamMessage<TEvent> | null {
+  if (now - state.lastHeartbeat < opts.heartbeatIntervalMs) return null;
+  state.lastHeartbeat = now;
+  return { _tag: "heartbeat" };
+}
+
+/**
+ * How long to sleep before the next poll, given how long the chain has been
+ * quiet.
+ *
+ * The cost of this stream is polls times the per-request price, and it does not
+ * care whether a poll found anything: a range read is billed per request, so a
+ * chain that has never emitted an event costs exactly what the busiest one
+ * does. That is the whole bill on a deployment like ours, where most chains are
+ * indexed for completeness rather than volume.
+ *
+ * So the interval tracks whether the chain is doing anything we index. It holds
+ * at the floor for `quietPollsBeforeBackoff` consecutive empty polls -- the
+ * latency guarantee, and the reason a busy chain never notices this exists --
+ * then doubles per empty poll up to `maxPollIntervalMs`. Anything worth being
+ * fast for puts it straight back to the floor.
+ *
+ * Backing off is only ever a delay, never a miss: a range read answers for a
+ * block range, so a wider gap between polls means a wider range, not a gap in
+ * what is read. The worst case is noticing the first event on a dormant chain
+ * up to `maxPollIntervalMs` late, after which the chain is at the floor again
+ * for at least `quietPollsBeforeBackoff` polls.
+ */
+export function pollIntervalFor(
+  state: Pick<StreamState, "quietPolls" | "blockRate">,
+  opts: Pick<
+    Resolved,
+    | "pollIntervalMs"
+    | "maxPollIntervalMs"
+    | "quietPollsBeforeBackoff"
+    | "maxLogRangeBlocks"
+    | "reorgWindowSeconds"
+  >,
+): number {
+  const floor = opts.pollIntervalMs;
+
+  // The ceiling is whichever is lower: what was configured, and what one
+  // range read can actually drain.
+  //
+  // A poll has to read every block produced since the last one, and it can only
+  // ask for `maxLogRangeBlocks` at a time, of which the reorg window is re-read
+  // rather than new. Sleep for longer than the remainder takes to accumulate
+  // and the stream never catches up in a single read: it stops sleeping, reads
+  // spans back to back, and pays more compute units than it saved. Where that
+  // line falls is a fact about the chain's block rate, so it is derived from
+  // the measured one rather than assumed -- 30 s is 3 blocks on Ethereum and
+  // 329 on Robinhood.
+  const drain = opts.maxLogRangeBlocks - reorgWindowBlocksFor(state, opts);
+  const rate = state.blockRate;
+  const drainCeiling =
+    rate !== null && rate > 0
+      ? (drain / rate) * 1_000
+      : Number.POSITIVE_INFINITY;
+  const ceiling = Math.max(
+    floor,
+    Math.min(opts.maxPollIntervalMs, drainCeiling),
+  );
+
+  const over = state.quietPolls - opts.quietPollsBeforeBackoff;
+  if (over <= 0) return floor;
+  // Cap the exponent before it is applied. `2 ** 1024` is Infinity, and a
+  // chain quiet for a week would get there; `Math.min` would still return the
+  // ceiling, but the intermediate is a trap for anyone reworking this line.
+  const doubled = floor * 2 ** Math.min(over, 32);
+  return Math.min(ceiling, doubled);
+}
+
+/**
+ * True when this poll's head is the one the last read already covered.
+ *
+ * An identical head means an identical chain, so the window cannot have changed
+ * and re-reading it would buy nothing. This is where the cost stops scaling with
+ * block time: on a 12 s chain polled every 2 s it skips five reads in six, and
+ * the range read is the larger part of what a poll costs.
+ */
+function headUnchanged(state: StreamState, head: ChainHead): boolean {
+  return (
+    state.seeded &&
+    head.number === state.cursorBlock &&
+    head.hash === state.lastHeadHash
+  );
+}
+
+/** The span to read this tick, or null when there is nothing to do yet. */
+async function planRead<TEvent>(
+  adapter: ChainAdapter<TEvent>,
+  state: StreamState,
+  opts: Resolved,
+): Promise<{ from: number; to: number; head: ChainHead } | null> {
+  const head = await adapter.fetchHead();
+  if (!head) return null;
+  // Before `windowFor`, which sizes itself from the rate this updates.
+  observeBlockRate(state, head);
+  warnIfWindowCapped(state, opts);
+  const { from, to } = windowFor(state, head.number, opts);
+  return from > to ? null : { from, to, head };
+}
+
+/**
+ * A rollback message when the re-read disagrees with what was already emitted.
+ *
+ * Divergence above the cursor is just a block being seen for the first time,
+ * so only a disagreement at or below it is a reorg that needs undoing.
+ */
+function maybeRollback<TEvent>(
+  state: StreamState,
+  digests: Map<number, BlockDigest>,
+  plan: { from: number; to: number },
+  opts: Resolved,
+): StreamMessage<TEvent> | null {
+  // Never diff below what `emitted` still holds.
+  //
+  // "I have no record of this block" and "this block is new" are the same
+  // observation to `firstDivergentBlock` -- `before === undefined,
+  // after !== undefined` -- and one of them is a reorg while the other is
+  // bookkeeping. The scan can reach below the retention floor whenever the
+  // cursor moves *down*, which is exactly what `rollbackTo` does: it skips
+  // `finishTick`, so a real reorg lowers the cursor without lowering the floor,
+  // and the next cursor-anchored scan starts a full window below where the last
+  // prune assumed. Every event-bearing block in the gap then reads as diverged,
+  // `rollbackTo` clears the remainder of the map, and the next tick diffs
+  // against nothing -- the cursor walks down to `earliest` on a chain that
+  // reorged exactly once.
+  //
+  // Flooring the comparison is what makes that structurally impossible, rather
+  // than merely unlikely at the current window widths. Blocks below the floor
+  // are older than a full window beneath a cursor we have already passed, which
+  // is the depth this stream does not claim to protect anyway.
+  const divergent = firstDivergentBlock(
+    state.emitted,
+    digests,
+    Math.max(plan.from, state.retainedFrom),
+    plan.to,
+  );
+  if (divergent === undefined || divergent > state.cursorBlock) return null;
+  opts.onWarning?.("reorg detected", { block: divergent });
+  return rollbackTo<TEvent>(state, divergent);
+}
+
+/**
+ * Reconciles a freshly read window against what was already emitted.
+ *
+ * The first read is adopted as the baseline; every read after it is a diff, and
+ * a disagreement at or below the cursor is a reorg to undo.
+ */
+function reconcileWindow<TEvent>(
+  state: StreamState,
+  digests: Map<number, BlockDigest>,
+  plan: { from: number; to: number },
+  opts: Resolved,
+): StreamMessage<TEvent> | null {
+  if (!state.seeded) {
+    seedWindow(state, digests, plan.from);
+    return null;
+  }
+  return maybeRollback<TEvent>(state, digests, plan, opts);
+}
+
+/**
+ * Adopts the first window read as the baseline rather than diffing against it.
+ *
+ * Only blocks at or below the cursor are taken; anything above is new and is
+ * recorded as it is emitted. Without this, a restart within the reorg window
+ * would find every event-bearing block in it "missing" from an empty map and
+ * roll the chain back on every deploy.
+ */
+function seedWindow(
+  state: StreamState,
+  digests: Map<number, BlockDigest>,
+  from: number,
+): void {
+  for (const [blockNumber, digest] of digests) {
+    if (blockNumber <= state.cursorBlock) state.emitted.set(blockNumber, digest);
+  }
+  // The seed read is the first thing `emitted` knows anything about, so it is
+  // where the authoritative range begins.
+  state.retainedFrom = from;
+  state.seeded = true;
+}
+
+/**
+ * The trailing block that moves the cursor to the end of the span.
+ *
+ * Without it a quiet chain would re-read the same blocks forever, since the
+ * runtime only advances its cursor on a data message. The head's own header is
+ * already in hand; any other endpoint costs one read.
+ */
+async function tailMessage<TEvent>(
+  adapter: ChainAdapter<TEvent>,
+  state: StreamState,
+  fresh: StreamBlock<TEvent>[],
+  plan: { to: number; head: ChainHead },
+): Promise<StreamMessage<TEvent> | null> {
+  // Once caught up, the span ends where the cursor already is. Emitting it
+  // again would cost a write transaction per poll on every chain forever,
+  // moving nothing.
+  if (plan.to <= state.cursorBlock) return null;
+
+  const last = fresh.at(-1);
+  if (last && Number(last.header.blockNumber) >= plan.to) return null;
+
+  const tail =
+    plan.to === plan.head.number
+      ? plan.head
+      : await adapter.fetchBlock(plan.to);
+  if (!tail) return null;
+
+  return dataMessage<TEvent>({
+    header: {
+      blockNumber: BigInt(tail.number),
+      blockHash: tail.hash,
+      timestamp: tail.timestamp,
+      baseFeePerGas: tail.baseFeePerGas,
+    },
+    logs: [],
+  });
+}
+
+export function initStreamState(
+  startingCursor: IndexerCursor,
+  options: BlockStreamOptions = {},
+): { opts: Resolved; state: StreamState } {
+  const opts: Resolved = { ...BLOCK_STREAM_DEFAULTS, ...options };
+
+  // The window used to be a block count that could be configured wider than the
+  // span that has to contain it, which spins the loop -- so the constructor
+  // refused it. `reorgWindowBlocksFor` now caps the window at half the span, so
+  // there is no such configuration to refuse: forward progress is at least half
+  // of `maxLogRangeBlocks` whatever the chain's block rate turns out to be.
+  // What remains is the degenerate span, which no cap can rescue.
+  if (opts.maxLogRangeBlocks < 2) {
+    throw new Error(
+      `GET_LOGS_RANGE_SIZE (${opts.maxLogRangeBlocks}) must be at least 2, otherwise a poll cannot both re-read a block and read a new one.`,
+    );
+  }
+
+  return {
+    opts,
+    state: {
+      cursorBlock: Number(startingCursor.orderKey),
+      emitted: new Map(),
+      finalized: null,
+      lastFinalizedRefresh: 0,
+      finalizedEmitted: 0,
+      lastHeartbeat: Date.now(),
+      lastHeadHash: "",
+      quietPolls: 0,
+      blockRate: null,
+      rateSample: null,
+      warnedCapSeconds: null,
+      retainedFrom: 0,
+      seeded: false,
+    },
+  };
+}
+
+/** Records each block in the reorg window and yields it downstream. */
+async function* emitFresh<TEvent>(
+  state: StreamState,
+  fresh: StreamBlock<TEvent>[],
+): AsyncGenerator<StreamMessage<TEvent>> {
+  // Any matched event means the chain is in use, so drop straight back to the
+  // floor. `readRange` keeps only blocks carrying an event one of our filters
+  // matched, so a non-empty `fresh` is exactly "we indexed something".
+  if (fresh.length > 0) state.quietPolls = 0;
+
+  for (const block of fresh) {
+    state.emitted.set(Number(block.header.blockNumber), {
+      hash: block.header.blockHash,
+      logCount: block.logs.length,
+    });
+    state.lastHeartbeat = Date.now();
+    yield dataMessage(block);
+  }
+}
+
+/** Advances the cursor and forgets what the reorg window no longer covers. */
+function finishTick(
+  state: StreamState,
+  plan: { to: number; head: ChainHead },
+  opts: Resolved,
+): void {
+  // Never backwards. An endpoint that momentarily answers with a head behind
+  // the cursor yields a valid-looking plan that ends below it, and assigning
+  // that would rewind the in-memory cursor with no `invalidate` and no warning,
+  // re-emitting blocks already indexed. A rollback is the only thing allowed to
+  // move the cursor back, and it says so.
+  state.cursorBlock = Math.max(state.cursorBlock, plan.to);
+  state.lastHeadHash = plan.head.hash;
+  const earliest = (state.finalized?.number ?? 0) + 1;
+  // Retain to the widest window any later tick could scan, not to this tick's.
+  //
+  // The window is measured, so it grows when the chain speeds up. Forgetting to
+  // the current width means the next tick -- whose `windowFor` may have just
+  // re-measured wider -- scans blocks that were dropped from `emitted` a moment
+  // ago. `firstDivergentBlock` cannot tell "I forgot this" from "this block is
+  // new below my cursor": it sees `before === undefined, after !== undefined`
+  // and reports a reorg. `rollbackTo` then clears every remaining entry, so the
+  // next tick diffs against an empty map and rolls back again, walking the
+  // cursor backwards a window at a time until `earliest` floors it. Measured on
+  // a chain whose hashes were pure functions of block number, so nothing ever
+  // reorged: 34 invalidates, ~30 blocks each. Ethereum at 640 s is squarely in
+  // range -- one missed slot inside a sample swings the window by ~18 blocks.
+  //
+  // `reorgWindowBlocksFor` is bounded by half the span, so that bound is the
+  // widest scan possible and retaining to it is sufficient. `emitted` holds
+  // only event-bearing blocks, so the extra entries cost nothing.
+  forgetBelow(
+    state,
+    Math.max(earliest, state.cursorBlock - maxReorgWindowBlocks(opts)),
+  );
+}
+
+/**
+ * Rolls back when the block the stored cursor names is no longer canonical.
+ *
+ * The stream this replaces checked this on every start, and the runtime's
+ * reorg-retry loop exists to catch its failure. An event diff cannot replace
+ * it: a reorg during downtime leaves nothing to disagree with, since the window
+ * is seeded from whatever the chain says now. One block read at startup settles
+ * it for the whole ancestry, because a block hash commits to every block
+ * beneath it.
+ */
+async function checkStartingCursor<TEvent>(
+  adapter: ChainAdapter<TEvent>,
+  state: StreamState,
+  startingCursor: IndexerCursor,
+  opts: Resolved,
+): Promise<StreamMessage<TEvent> | null> {
+  const expected = startingCursor.uniqueKey;
+  if (typeof expected !== "string" || state.cursorBlock <= 0) return null;
+
+  // An absent or unreadable block is a pruned or lagging node answering, not a
+  // reorg, and `withNullBlockRetry` surfaces the null case as a throw. Reading
+  // forward from an unverified cursor is the safe failure -- it re-reads -- and
+  // is far better than crash-looping a worker whose node cannot serve the block.
+  const block = await adapter
+    .fetchBlock(state.cursorBlock)
+    .catch((error: unknown) => {
+      opts.onWarning?.("could not verify the stored cursor", {
+        block: state.cursorBlock,
+        error: String(error).slice(0, 200),
+      });
+      return null;
+    });
+  if (!block) return null;
+
+  // The stored key round-trips through a numeric column, so leading zeroes are
+  // gone by the time it comes back -- and on Starknet a felt is routinely
+  // written unpadded by the node in the first place. Compare the values, not
+  // the strings.
+  if (BigInt(block.hash) === BigInt(expected)) return null;
+
+  // A finalized block cannot be the reorg point, so there is no reason to
+  // rewind past one -- and every reason not to, since the rows below it are
+  // settled. Costs one request, and only on the branch that already found a
+  // mismatch.
+  // Tolerated the same way `refreshFinalized` tolerates it, and for a sharper
+  // reason: this line is only reached once the cursor is already known to be
+  // non-canonical. Letting it throw would exit before the `invalidate` is
+  // emitted, and the restart would land on this same branch again -- a crash
+  // loop precisely where recovery is what is needed.
+  const finalized = await adapter.fetchFinalized().catch((error: unknown) => {
+    opts.onWarning?.("could not read the finalized block while rolling back", {
+      error: String(error).slice(0, 200),
+    });
+    return null;
+  });
+  // Seed the rate from the two blocks already in hand, at no extra cost.
+  //
+  // This runs before the loop, so without it `state.blockRate` is null here and
+  // the window is the half-span cap -- 500 blocks by default and 2500 on
+  // Arbitrum and Robinhood, against the 64 this used to rewind. `finalized + 1`
+  // floors it, so that only bites on a node that cannot serve the finalized tag
+  // (which this function already tolerates), but there it means deleting and
+  // reprocessing thousands of blocks on a cursor that moved by one.
+  //
+  // The cursor block and the finalized block are separated by the chain's
+  // finality lag, which is a far longer baseline than the loop's 30 s sample
+  // ever gets.
+  if (finalized) {
+    const elapsedSec = Math.floor(
+      (block.timestamp.getTime() - finalized.timestamp.getTime()) / 1000,
+    );
+    const advanced = block.number - finalized.number;
+    if (elapsedSec >= MIN_RATE_SAMPLE_SECONDS && advanced > 0) {
+      state.blockRate = advanced / elapsedSec;
+    }
+  }
+
+  const floor = finalized ? finalized.number + 1 : 1;
+  // Never past the cursor itself: if even the finalized block disagrees, the
+  // least we can do is re-read the block we are standing on rather than skip it.
+  const target = Math.min(
+    state.cursorBlock,
+    Math.max(floor, 1, state.cursorBlock - reorgWindowBlocksFor(state, opts)),
+  );
+  opts.onWarning?.("stored cursor is not canonical; rolling back", {
+    block: state.cursorBlock,
+    expected,
+    found: block.hash,
+    rollbackTo: target - 1,
+  });
+  return rollbackTo<TEvent>(state, target);
+}
+
+export interface CreateBlockStreamArgs<TEvent> {
+  adapter: ChainAdapter<TEvent>;
+  startingCursor: IndexerCursor;
+  options?: BlockStreamOptions;
+}
+
+/**
+ * Yields the same messages the apibara streams did, so the runtime, the DAO and
+ * every processor are untouched.
+ */
+export async function* createBlockStream<TEvent>(
+  args: CreateBlockStreamArgs<TEvent>,
+): AsyncGenerator<StreamMessage<TEvent>> {
+  const { adapter } = args;
+  const { opts, state } = initStreamState(args.startingCursor, args.options);
+
+  const sleep = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  const notCanonical = await checkStartingCursor(
+    adapter,
+    state,
+    args.startingCursor,
+    opts,
+  );
+  if (notCanonical) yield notCanonical;
+
+  while (true) {
+    const now = Date.now();
+
+    const heartbeat = heartbeatIfDue<TEvent>(state, opts, now);
+    if (heartbeat) yield heartbeat;
+
+    yield* announceFinalized(adapter, state, opts, now);
+
+    const plan = await planRead(adapter, state, opts);
+    if (!plan) {
+      // An unreadable head is not evidence the chain is quiet, so this does not
+      // count towards backoff -- but it must not poll a struggling endpoint
+      // faster than a healthy one either, so it sleeps for the interval already
+      // in force.
+      await sleep(pollIntervalFor(state, opts));
+      continue;
+    }
+
+    if (headUnchanged(state, plan.head)) {
+      // The head has not moved, so there is provably nothing new to index: a
+      // head hash commits to its whole ancestry. That is a quiet poll in the
+      // sense that matters, and counting it is what lets a chain with a block
+      // time longer than the poll interval back off at all.
+      state.quietPolls++;
+      await sleep(pollIntervalFor(state, opts));
+      continue;
+    }
+
+    const blocks = await adapter.readRange(plan.from, plan.to);
+    const digests = digestBlocks(blocks);
+
+    const rollback = reconcileWindow<TEvent>(state, digests, plan, opts);
+    if (rollback) {
+      yield rollback;
+      // A reorg is the last moment to be slow: the blocks being rolled back
+      // have to be re-read and re-emitted before the chain is correct again.
+      state.quietPolls = 0;
+      // An endpoint serving two views alternately would otherwise rollback,
+      // re-read and rollback again with no pause between, one DB transaction per
+      // turn. Back off exactly as the caught-up path does.
+      await sleep(opts.pollIntervalMs);
+      continue;
+    }
+
+    const fresh = blocks.filter(
+      (block) => Number(block.header.blockNumber) > state.cursorBlock,
+    );
+    // Fresh only. Everything below the cursor in this window has already been
+    // indexed and is being re-read solely to diff its digest, which `readRange`
+    // alone answers -- so paying a per-block completion cost for it would be
+    // the reorg window's width in wasted requests, every poll, forever.
+    await adapter.completeFresh(fresh, plan.head);
+    yield* emitFresh(state, fresh);
+
+    const tail = await tailMessage(adapter, state, fresh, plan);
+    if (tail) yield tail;
+
+    finishTick(state, plan, opts);
+
+    // Now that the cursor has moved, the finalized block may be behind it.
+    yield* announceFinalized(adapter, state, opts, null);
+
+    // Only a caught-up poll can be a quiet one. While catching up the loop does
+    // not sleep at all, and counting those polls would let a long backfill --
+    // which is all empty ranges until it reaches the interesting blocks -- back
+    // the stream off just as it arrives at the head.
+    if (plan.to >= plan.head.number) {
+      if (fresh.length === 0) state.quietPolls++;
+      await sleep(pollIntervalFor(state, opts));
+    }
+  }
+}

--- a/src/_shared/streamEndpoints.test.ts
+++ b/src/_shared/streamEndpoints.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseEvmRpcUrls, requireStarknetApibaraUrl } from "./streamEndpoints";
+import { parseEvmRpcUrls, requireStarknetRpcUrl } from "./streamEndpoints";
 
 describe("parseEvmRpcUrls", () => {
   it("splits and trims comma-separated urls", () => {
@@ -15,19 +15,19 @@ describe("parseEvmRpcUrls", () => {
   });
 });
 
-describe("requireStarknetApibaraUrl", () => {
+describe("requireStarknetRpcUrl", () => {
   it("returns a trimmed value", () => {
-    expect(requireStarknetApibaraUrl(" https://mainnet.starkstream.io ")).toBe(
-      "https://mainnet.starkstream.io",
+    expect(requireStarknetRpcUrl(" https://starknet-mainnet.example/rpc ")).toBe(
+      "https://starknet-mainnet.example/rpc",
     );
   });
 
   it("throws when missing", () => {
-    expect(() => requireStarknetApibaraUrl(undefined)).toThrow(
-      "Missing APIBARA_URL",
+    expect(() => requireStarknetRpcUrl(undefined)).toThrow(
+      "Missing STARKNET_RPC_URL",
     );
-    expect(() => requireStarknetApibaraUrl("   ")).toThrow(
-      "Missing APIBARA_URL",
+    expect(() => requireStarknetRpcUrl("   ")).toThrow(
+      "Missing STARKNET_RPC_URL",
     );
   });
 });

--- a/src/_shared/streamEndpoints.ts
+++ b/src/_shared/streamEndpoints.ts
@@ -5,13 +5,19 @@ export function parseEvmRpcUrls(evmRpcUrl: string | undefined): string[] {
     .filter(Boolean);
 }
 
-export function requireStarknetApibaraUrl(
-  apibaraUrl: string | undefined,
-): string {
-  const trimmed = apibaraUrl?.trim();
+/**
+ * One URL, not a list.
+ *
+ * The EVM side takes a comma-separated list for historical reasons and then
+ * refuses to use it as a viem `fallback()`, because two endpoints can serve two
+ * different views of the same chain and a stream that alternates between them
+ * reorgs against itself. Starknet never had the list, so it does not get one.
+ */
+export function requireStarknetRpcUrl(rpcUrl: string | undefined): string {
+  const trimmed = rpcUrl?.trim();
 
   if (!trimmed) {
-    throw new Error("Missing APIBARA_URL");
+    throw new Error("Missing STARKNET_RPC_URL");
   }
 
   return trimmed;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -62,7 +62,7 @@ interface EvmConfig extends CommonConfiguration {
 }
 
 interface StarknetConfig extends CommonConfiguration {
-  APIBARA_URL: string;
+  STARKNET_RPC_URL: string;
 
   CORE_ADDRESS: `0x${string}`;
   POSITIONS_ADDRESS: `0x${string}`;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -6,7 +6,6 @@ interface CommonConfiguration {
 
   STARTING_CURSOR_BLOCK_NUMBER: string;
 
-  DNA_TOKEN: string;
   PG_CONNECTION_STRING: string;
 
   NO_BLOCKS_TIMEOUT_MS: string; // Time in milliseconds before exiting if no blocks are received

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -1,4 +1,3 @@
-import { Block as EvmBlock } from "@apibara/evm";
 import { createPublicClient, fallback, http } from "viem";
 import type { EventKey } from "./_shared/eventKey";
 import { logger } from "./_shared/logger";
@@ -11,7 +10,11 @@ import {
 import { withNullBlockRetry } from "./_shared/nullBlockRetry";
 import { assertRpcChainIds } from "./_shared/rpcChainId";
 import { parseEvmRpcUrls } from "./_shared/streamEndpoints";
-import { createLogStream, type LogStreamFilter } from "./evm/logStream";
+import {
+  createLogStream,
+  type LogStreamFilter,
+  type StreamBlock as EvmBlock,
+} from "./evm/logStream";
 import { createLogProcessorsV2 } from "./evm/logProcessorsV2";
 import { createLogProcessorsV3 } from "./evm/logProcessorsV3";
 import { parsePositionsProtocolFeeConfigs } from "./evm/positionsProtocolFeeConfig";
@@ -51,6 +54,8 @@ export function parseEvmBlockHeader(
     block: evmBlock as EvmBlock,
     header: {
       ...common,
+      // Only the head block carries one; `stampHeadBaseFee` is what puts it
+      // there, since a log-derived block has no base fee of its own.
       baseFeePerGas: header.baseFeePerGas ?? null,
     },
   };
@@ -256,21 +261,21 @@ export async function createEvmEntrypoint(
       });
     },
     getPlannedEvents(block: EvmBlock) {
-      return block.logs.reduce(
-        (total, log) => total + (log.filterIds?.length ?? 0),
-        0,
-      );
+      return block.logs.reduce((total, log) => total + log.filterIds.length, 0);
     },
     async processBlock({ block, blockNumber, dao }) {
       let eventsProcessed = 0;
 
-      for (let i = 0; i < block.logs.length; i++) {
-        const log = block.logs[i];
-
+      for (const log of block.logs) {
         const eventKey: EventKey = {
           blockNumber,
-          transactionIndex: log.transactionIndex ?? 0,
-          eventIndex: log.logIndexInTransaction ?? log.logIndex ?? i,
+          transactionIndex: log.transactionIndex,
+          // The block-wide log index, which is what `event_id` has always been
+          // packed from on EVM. This used to read
+          // `logIndexInTransaction ?? logIndex ?? i`, but the first was a field
+          // of the apibara block type that no stream ever populated and the
+          // last could not be reached, so both fell through to this every time.
+          eventIndex: log.logIndex,
           emitter: log.address,
           transactionHash: log.transactionHash,
         };

--- a/src/evm/logStream.ts
+++ b/src/evm/logStream.ts
@@ -1,5 +1,5 @@
 /**
- * A log-driven EVM stream.
+ * The EVM adapter for the shared block stream.
  *
  * The stream this replaces asked the chain for one block header per block the
  * chain produced, so its cost scaled with block time rather than with how much
@@ -14,42 +14,40 @@
  * rate: one `eth_getBlockByNumber("latest")` to learn the head and to give the
  * cursor a real hash, and one `eth_getLogs` over everything since the last one.
  *
- * What that leaves is a cost that no longer scales with block time but still
- * scales with nothing at all: eighty compute units per poll on every chain,
- * whether it produced an event or has produced none in four months. Most of the
- * chains we index are the latter, so `pollIntervalFor` backs the interval off
- * while a chain indexes nothing and snaps it back to the floor the moment it
- * does. Backing off is a delay and never a miss -- a range query asked less
- * often reads a wider range, not a narrower one.
- *
- * Nothing here is sized in blocks. A block is not a unit of time and the chains
- * we index run from 10 s to 0.09 s apart, so any constant expressed as a block
- * count means something different on each one -- the 64-block reorg window this
- * used to carry bought Ethereum 640 s of protection and Robinhood, the busiest
- * chain we run, six. The window is configured in seconds and converted per
- * chain from a block rate measured off the head reads the poll already makes
- * (`observeBlockRate`), and the backoff ceiling is bounded by what one
- * `eth_getLogs` can actually drain at that rate. The only block count left is
- * `maxLogRangeBlocks`, which is a real provider limit rather than a guess about
- * the chain.
- *
- * Correctness notes, since missing an event is the failure that matters:
- *
- * - A range query is self-describing in a way a subscription is not. It either
- *   answers for the blocks asked for or it errors; a dropped WebSocket frame
- *   looks like silence. That is why this polls.
- * - The one way a range query lies is silent truncation: a provider that caps
- *   results and returns exactly the cap is indistinguishable from one that
- *   found exactly that many. `fetchLogsChecked` refuses to believe a response
- *   that lands on the cap and splits the range instead.
- * - Reorgs are detected by re-reading a window at the head every poll and
- *   diffing it against what was emitted, so a block whose hash changed or whose
- *   logs disappeared is caught even though no header was fetched. A reorg that
- *   touches no log of ours changes nothing we store, so it is not looked for.
+ * Polling, reorg detection, backoff, retention and the cursor live in
+ * `_shared/blockStream`, which Starknet uses too. What stays here is what only
+ * EVM knows: topic matching, `eth_getLogs` and its truncation guard, and the
+ * header reads.
  */
 import type { Address, Hex, PublicClient } from "viem";
 import { hexToBigInt, hexToNumber, numberToHex } from "viem";
 import type { IndexerCursor } from "../_shared/dao";
+import {
+  createBlockStream,
+  digestBlocks,
+  firstDivergentBlock,
+  maxReorgWindowBlocks,
+  observeBlockRate,
+  pollIntervalFor,
+  reorgWindowBlocksFor,
+  requireRepresentableIndex,
+  type BlockStreamOptions,
+  type ChainAdapter,
+  type ChainHead,
+  type StreamBlock as SharedStreamBlock,
+  type StreamMessage as SharedStreamMessage,
+} from "../_shared/blockStream";
+
+// Re-exported so this module stays the one place EVM code imports the stream
+// from, whether the piece it needs is EVM-specific or shared.
+export {
+  digestBlocks,
+  firstDivergentBlock,
+  maxReorgWindowBlocks,
+  observeBlockRate,
+  pollIntervalFor,
+  reorgWindowBlocksFor,
+};
 
 /** A single processor's log filter, mirroring the shape the entrypoint builds. */
 export interface LogStreamFilter {
@@ -61,57 +59,16 @@ export interface LogStreamFilter {
   strict: boolean;
 }
 
-export interface LogStreamOptions {
-  /** How long to wait after catching up to the head before polling again. */
-  pollIntervalMs?: number;
-  /**
-   * The ceiling `pollIntervalMs` backs off to on a chain that is producing
-   * nothing we index. Set it equal to `pollIntervalMs` to disable backoff.
-   */
-  maxPollIntervalMs?: number;
-  /**
-   * How many consecutive polls may find nothing before the interval starts
-   * growing. This is the latency guarantee: a chain that indexed anything
-   * within the last `pollIntervalMs * quietPollsBeforeBackoff` keeps polling at
-   * full rate.
-   */
-  quietPollsBeforeBackoff?: number;
-  /** Widest block span to ask for in one `eth_getLogs`. */
-  maxLogRangeBlocks?: number;
-  /**
-   * How far back to re-read at the head to notice a reorg, in seconds of chain
-   * time. Must be at least as long as the deepest reorg the chain can produce;
-   * the cost of being generous is one wider `eth_getLogs`, which is free, and
-   * the cost of being stingy is a missed event.
-   *
-   * In seconds rather than blocks because a block is not a unit of anything.
-   * The chains we index run from 10 s to 0.09 s a block, so one block count
-   * means two very different amounts of history: at the 64 blocks this used to
-   * default to, Ethereum got 640 s of protection and Robinhood -- the busiest
-   * chain we run -- got 6. The equivalent block count is derived per chain from
-   * the observed block rate.
-   */
-  reorgWindowSeconds?: number;
+export interface LogStreamOptions extends BlockStreamOptions {
   /**
    * A log count that is suspected of being a provider's cap rather than a real
    * result. Set it to the provider's documented `eth_getLogs` limit.
    */
   suspectLogCount?: number;
-  /** How often to re-read the `finalized` tag. */
-  finalizedRefreshIntervalMs?: number;
-  heartbeatIntervalMs?: number;
-  onWarning?: (message: string, detail: Record<string, unknown>) => void;
 }
 
-const DEFAULTS = {
-  pollIntervalMs: 2_000,
-  maxPollIntervalMs: 30_000,
-  quietPollsBeforeBackoff: 30,
-  maxLogRangeBlocks: 1_000,
-  reorgWindowSeconds: 120,
+const EVM_DEFAULTS = {
   suspectLogCount: 10_000,
-  finalizedRefreshIntervalMs: 30_000,
-  heartbeatIntervalMs: 10_000,
 } as const;
 
 export interface RawLog {
@@ -127,33 +84,20 @@ export interface RawLog {
   removed?: boolean;
 }
 
-/** The block shape the runtime's `parseEvmBlockHeader` expects. */
-export interface StreamBlock {
-  header: {
-    blockNumber: bigint;
-    blockHash: Hex;
-    timestamp: Date;
-    baseFeePerGas: bigint | null;
-  };
-  logs: {
-    address: Address;
-    topics: Hex[];
-    data: Hex;
-    transactionHash: Hex;
-    transactionIndex: number;
-    logIndex: number;
-    filterIds: number[];
-  }[];
+/** One log, as the runtime's processors consume it. */
+export interface StreamLog {
+  address: Address;
+  topics: Hex[];
+  data: Hex;
+  transactionHash: Hex;
+  transactionIndex: number;
+  logIndex: number;
+  filterIds: number[];
 }
 
-export type StreamMessage =
-  | { _tag: "heartbeat" }
-  | { _tag: "finalize"; finalize: { cursor: IndexerCursor } }
-  | { _tag: "invalidate"; invalidate: { cursor: IndexerCursor } }
-  | {
-      _tag: "data";
-      data: { endCursor: IndexerCursor; data: StreamBlock[] };
-    };
+/** The block shape the runtime's `parseEvmBlockHeader` expects. */
+export type StreamBlock = SharedStreamBlock<StreamLog>;
+export type StreamMessage = SharedStreamMessage<StreamLog>;
 
 /**
  * True when `log` satisfies `filter`.
@@ -193,9 +137,6 @@ export function matchingFilterIds(
   }
   return ids;
 }
-
-/** Identity of a block as far as this stream is concerned. */
-type BlockDigest = { hash: Hex; logCount: number };
 
 /**
  * Groups logs into blocks, in ascending block order, with logs inside a block
@@ -242,9 +183,13 @@ export function groupLogsByBlock(
       data: log.data,
       transactionHash: log.transactionHash,
       transactionIndex: hexToNumber(log.transactionIndex),
+      // `evm.ts` uses a log's block-wide `logIndex` as its `event_index`,
+      // because the apibara RPC stream this replaces never populated
+      // `logIndexInTransaction` either.
       logIndex: requireRepresentableIndex(
         hexToNumber(log.logIndex),
         blockNumber,
+        "the block-wide log index",
       ),
       filterIds,
     });
@@ -256,82 +201,6 @@ export function groupLogsByBlock(
       entry.block.logs.sort((a, b) => a.logIndex - b.logIndex);
       return entry.block;
     });
-}
-
-/** Packed into 16 bits by `compute_event_id`, so this is a hard ceiling. */
-const MAX_EVENT_INDEX = 65_536;
-
-/**
- * Fails loudly, and early, on a log index `compute_event_id` cannot represent.
- *
- * `evm.ts` uses a log's block-wide `logIndex` as its `event_index`, because the
- * apibara RPC stream this replaces never populated `logIndexInTransaction`
- * either. `compute_event_id` packs that index into 16 bits and raises above
- * 65,535, so a block carrying more logs than that -- counting every contract's,
- * not only ours -- cannot be indexed under this scheme at all.
- *
- * That limitation is inherited, not introduced here, and this deliberately does
- * not change the numbering: `event_id` is a primary key that other tables order
- * on, so re-basing it belongs in its own change rather than riding along with a
- * stream rewrite. What this does is convert a confusing failure deep in a
- * Postgres function into one that names the cause at the point of origin.
- */
-function requireRepresentableIndex(logIndex: number, blockNumber: number) {
-  if (logIndex >= MAX_EVENT_INDEX) {
-    throw new Error(
-      `Block ${blockNumber} contains a log at index ${logIndex}, which compute_event_id cannot represent (the limit is ${MAX_EVENT_INDEX}). event_index is the block-wide log index, so a block with more than that many logs in total cannot be indexed without re-basing event_id onto a per-transaction index.`,
-    );
-  }
-  return logIndex;
-}
-
-/** Which blocks in a range carry logs, and under which hash. */
-export function digestBlocks(blocks: StreamBlock[]): Map<number, BlockDigest> {
-  const digests = new Map<number, BlockDigest>();
-  for (const block of blocks) {
-    digests.set(Number(block.header.blockNumber), {
-      hash: block.header.blockHash,
-      logCount: block.logs.length,
-    });
-  }
-  return digests;
-}
-
-/**
- * The lowest block at which `next` disagrees with `previous`, or undefined when
- * they agree.
- *
- * Disagreement is a block that changed hash, a block that lost its logs, or a
- * block that gained logs it did not have. Only blocks inside `[from, to]` are
- * compared, because anything outside was not re-read.
- */
-export function firstDivergentBlock(
-  previous: Map<number, BlockDigest>,
-  next: Map<number, BlockDigest>,
-  from: number,
-  to: number,
-): number | undefined {
-  let lowest: number | undefined;
-
-  const consider = (blockNumber: number) => {
-    if (blockNumber < from || blockNumber > to) return;
-    const before = previous.get(blockNumber);
-    const after = next.get(blockNumber);
-    const same =
-      before === undefined
-        ? after === undefined
-        : after !== undefined &&
-          before.hash.toLowerCase() === after.hash.toLowerCase() &&
-          before.logCount === after.logCount;
-    if (!same && (lowest === undefined || blockNumber < lowest)) {
-      lowest = blockNumber;
-    }
-  };
-
-  for (const blockNumber of previous.keys()) consider(blockNumber);
-  for (const blockNumber of next.keys()) consider(blockNumber);
-
-  return lowest;
 }
 
 export interface RpcLike {
@@ -448,17 +317,10 @@ async function splitRange(
   return [...left, ...right];
 }
 
-type LatestBlock = {
-  number: number;
-  hash: Hex;
-  timestamp: Date;
-  baseFeePerGas: bigint | null;
-};
-
 async function fetchBlockByTag(
   rpc: RpcLike,
   tag: "latest" | "finalized",
-): Promise<LatestBlock | null> {
+): Promise<ChainHead | null> {
   const block = (await rpc.request({
     method: "eth_getBlockByNumber",
     params: [tag, false],
@@ -481,428 +343,29 @@ async function fetchBlockByTag(
   };
 }
 
-export interface CreateLogStreamArgs {
-  rpc: RpcLike;
-  filters: LogStreamFilter[];
-  startingCursor: IndexerCursor;
-  options?: LogStreamOptions;
-}
-
-/** Everything the loop carries between iterations. */
-interface StreamState {
-  cursorBlock: number;
-  /**
-   * Digests of the log-bearing blocks inside the reorg window.
-   *
-   * Only blocks that carried logs belong here. A block with none has no
-   * representation in an `eth_getLogs` response, so recording one would make it
-   * look like it had disappeared on the very next re-read.
-   */
-  emitted: Map<number, BlockDigest>;
-  finalized: LatestBlock | null;
-  lastFinalizedRefresh: number;
-  /** Highest finalized block already announced downstream, 0 before the first. */
-  finalizedEmitted: number;
-  lastHeartbeat: number;
-  /** Hash of the head as of the last completed read, "" before the first. */
-  lastHeadHash: string;
-  /**
-   * Consecutive caught-up polls that indexed nothing, which is what the poll
-   * interval backs off on. Reset to 0 by anything worth being fast for.
-   */
-  quietPolls: number;
-  /**
-   * Observed blocks per second, or null until enough of the chain has gone by
-   * to measure it. Every sizing decision that would otherwise be a block count
-   * goes through this.
-   */
-  blockRate: number | null;
-  /** The older end of the interval `blockRate` is measured over. */
-  rateSample: { number: number; timeSec: number } | null;
-  /** Effective window last warned about, so the cap is reported once. */
-  warnedCapSeconds: number | null;
-  /**
-   * Lowest block `emitted` is authoritative for.
-   *
-   * Below this the map is silent because entries were pruned, not because the
-   * chain had nothing -- and those two are indistinguishable to a diff.
-   */
-  retainedFrom: number;
-  /**
-   * False until the first window has been read.
-   *
-   * `emitted` starts empty because nothing has been observed yet, not because
-   * the chain is empty, so the first read seeds it instead of diffing against
-   * it. Restart safety comes from the cursor hash check instead, which is both
-   * cheaper and stronger: a block hash commits to its whole ancestry.
-   */
-  seeded: boolean;
-}
-
-type Resolved = Required<Omit<LogStreamOptions, "onWarning">> &
-  Pick<LogStreamOptions, "onWarning">;
-
-/**
- * Chain time that must elapse before a block-rate sample is believed.
- *
- * Block timestamps have one-second resolution, and Robinhood produces eleven
- * blocks inside one of those, so a short baseline measures rounding rather than
- * the chain. Thirty seconds is long enough that the quantisation is noise on
- * every chain we index and short enough to be learnt within one backoff cycle.
- */
-const MIN_RATE_SAMPLE_SECONDS = 30;
-
-/**
- * Updates the observed block rate from a head this poll already fetched.
- *
- * Free: `eth_getBlockByNumber("latest")` returns the number and the timestamp
- * together, and the stream reads it every poll anyway. No request is made for
- * this, which is the only reason it is worth measuring continuously rather than
- * configuring per chain.
- */
-export function observeBlockRate(state: StreamState, head: LatestBlock): void {
-  const timeSec = Math.floor(head.timestamp.getTime() / 1000);
-  const sample = state.rateSample;
-
-  if (!sample) {
-    state.rateSample = { number: head.number, timeSec };
-    return;
-  }
-
-  const elapsed = timeSec - sample.timeSec;
-  const advanced = head.number - sample.number;
-
-  // A head that went backwards, or a timestamp that did, means the sample is
-  // measuring a different view of the chain rather than its rate. Start over.
-  if (elapsed < 0 || advanced < 0) {
-    state.rateSample = { number: head.number, timeSec };
-    return;
-  }
-
-  if (elapsed < MIN_RATE_SAMPLE_SECONDS) {
-    // A partial baseline is too short to measure the rate, but it can still
-    // *witness* a chain going faster than the stored rate says -- and adopting
-    // that early is free while waiting is not. Everything the rate sizes is
-    // safe wide and unsafe narrow: the window re-reads more blocks (one
-    // `eth_getLogs` either way) and the backoff sleeps less. So a rise is taken
-    // on the spot and only a fall waits for a full baseline.
-    //
-    // Without this the stream keeps a stale, lower rate for up to
-    // MIN_RATE_SAMPLE_SECONDS after a chain speeds up -- a sequencer catching
-    // up after downtime is the realistic case -- and blocks emitted in that
-    // window can land further below the cursor than the window reaches.
-    // `advanced > 0` matters: a null rate makes the comparison below adopt
-    // anything, so a tip replaced at the same height by a block with a later
-    // timestamp would store a rate of zero and collapse the window to a single
-    // block. This branch only ever wants to raise the rate; zero is not a rise.
-    // Only ever a *rise*, and only against a rate we already trust.
-    //
-    // Adopting a short sample when the rate is unset would be a narrowing, not
-    // a rise: an unset rate already sizes the window at the cap, the widest
-    // available. A first sample quantised to one second on an eleven-block
-    // chain can read half the true rate, which would halve the window for the
-    // next thirty seconds on exactly the argument that short samples cannot be
-    // trusted.
-    if (state.blockRate !== null && elapsed > 0 && advanced > 0) {
-      const witnessed = advanced / elapsed;
-      if (witnessed > state.blockRate) state.blockRate = witnessed;
-    }
-    return;
-  }
-
-  // A full baseline that saw no blocks is a halted chain, not a rate of zero.
-  // Dividing anyway stores 0, and `reorgWindowBlocksFor` turns that into a
-  // one-block window -- so the poll that has to reconcile the reorg that
-  // *resumes* the chain would re-read a single block. Keep the last known rate
-  // and start a fresh sample.
-  if (advanced <= 0) {
-    state.rateSample = { number: head.number, timeSec };
-    return;
-  }
-
-  state.blockRate = advanced / elapsed;
-  state.rateSample = { number: head.number, timeSec };
-}
-
-/**
- * How many blocks `reorgWindowSeconds` is worth on this chain right now.
- *
- * Capped at half `maxLogRangeBlocks`, which is what makes an unusable
- * configuration unreachable rather than merely rejected. A read span no wider
- * than the window it re-reads cannot reach past it: nothing is emitted, the
- * cursor never advances, and because the span never reaches the head the loop
- * never sleeps -- it spins at CPU speed issuing two requests a turn while
- * looking perfectly healthy. Holding the window at half the span guarantees at
- * least half the span is forward progress, whatever the chain does.
- *
- * Before the rate is known the window is that cap. Erring wide is free -- one
- * `eth_getLogs` is 60 compute units for any span it accepts -- and erring
- * narrow silently loses events, so the unmeasured case takes the widest window
- * on offer and narrows as the chain is observed.
- */
-/**
- * The widest window `reorgWindowBlocksFor` can ever return for this span.
- *
- * Half the span, which is what guarantees the other half is forward progress.
- * Load-bearing beyond sizing a read: it is also how far back `emitted` has to
- * be retained, since a window that grows must not scan blocks the last tick
- * forgot.
- */
-export function maxReorgWindowBlocks(
-  opts: Pick<Resolved, "maxLogRangeBlocks">,
-): number {
-  return Math.max(1, Math.floor(opts.maxLogRangeBlocks / 2));
-}
-
-export function reorgWindowBlocksFor(
-  state: Pick<StreamState, "blockRate">,
-  opts: Pick<Resolved, "reorgWindowSeconds" | "maxLogRangeBlocks">,
-): number {
-  const cap = maxReorgWindowBlocks(opts);
-  if (state.blockRate === null) return cap;
-  return Math.min(
-    cap,
-    Math.max(1, Math.ceil(state.blockRate * opts.reorgWindowSeconds)),
-  );
-}
-
-/**
- * Says once, not every poll, that the span is holding the window narrower than
- * `reorgWindowSeconds` asked for.
- *
- * Deliberately separate from `reorgWindowBlocksFor`, which several call sites
- * hit more than once per tick -- `windowFor`, `finishTick`, `pollIntervalFor`
- * and the finalized refresh all size themselves from it. A warning in there is
- * four identical lines per poll forever on any chain where the cap binds, which
- * is how a real signal becomes noise nobody reads.
- *
- * Not an error: the stream is still correct, just protected for less history
- * than requested. Worth saying at all because the remedy is one env var --
- * GET_LOGS_RANGE_SIZE bounds it, and raising it is free up to the provider's
- * own range limit.
- */
-function warnIfWindowCapped(state: StreamState, opts: Resolved): void {
-  const rate = state.blockRate;
-  if (rate === null) return;
-
-  const cap = maxReorgWindowBlocks(opts);
-  const wanted = Math.max(1, Math.ceil(rate * opts.reorgWindowSeconds));
-  if (wanted <= cap) return;
-
-  // Re-warn only when the shortfall actually changes, so a chain whose rate
-  // drifts says so again while a steady one says it once.
-  const effectiveSeconds = Math.round(cap / rate);
-  if (state.warnedCapSeconds === effectiveSeconds) return;
-  state.warnedCapSeconds = effectiveSeconds;
-
-  opts.onWarning?.("reorg window capped by the log range size", {
-    wantedBlocks: wanted,
-    cappedToBlocks: cap,
-    effectiveSeconds,
-    reorgWindowSeconds: opts.reorgWindowSeconds,
-    maxLogRangeBlocks: opts.maxLogRangeBlocks,
-  });
-}
-
-/** The span to re-read: back into the reorg window, or forward when behind it. */
-function windowFor(
-  state: StreamState,
-  head: number,
-  opts: Resolved,
-): { from: number; to: number } {
-  const earliest = (state.finalized?.number ?? 0) + 1;
-  // The window hangs below the cursor, not below the head, and it is re-read
-  // unconditionally. Both of those matter once the poll interval can grow.
-  //
-  // This used to read back from `head - reorgWindowBlocks`, and only when the
-  // head was within that distance of the cursor; otherwise it read straight
-  // forward from the cursor. The reasoning was that a cursor further back than
-  // the window is catching up and has nothing recently emitted to protect. At a
-  // two-second poll that held on every chain we index -- the head is always a
-  // few blocks ahead -- so the forward-only branch belonged to backfill alone.
-  //
-  // Backing off to thirty seconds breaks the assumption in both parts. An L2 at
-  // four blocks a second advances ~120 blocks between polls, so a caught-up
-  // stream is permanently "further back than the window": it would take the
-  // forward branch forever and never re-read a block it had already emitted,
-  // silently giving up reorg detection on exactly the chains whose finality
-  // lags furthest behind their head. Anchoring to the head instead of the
-  // cursor has the same hole, because `head - reorgWindowBlocks` then sits
-  // above the cursor and the `min` below collapses to `cursorBlock + 1`.
-  //
-  // Anchoring to the cursor is what actually re-reads the blocks at risk: they
-  // are the ones *we emitted*, which is a fact about the cursor and nothing
-  // else. It costs no compute units -- `eth_getLogs` is billed per request, so
-  // a wider span is the same 60 units -- and slows a backfill by the window as
-  // a fraction of the span, since each read now overlaps the last by the width
-  // of the window. That fraction is at most a half, and is whatever
-  // `reorgWindowSeconds` works out to on this chain once the rate is known.
-  //
-  // Never start above the cursor. `earliest` is an optimisation -- a finalized
-  // block cannot reorg, so there is no point re-reading below it -- but on a
-  // chain that finalises in under a second it can overtake a cursor that fell a
-  // few blocks behind, and letting it raise `from` would skip those blocks
-  // silently.
-  const from = Math.max(
-    1,
-    Math.min(
-      state.cursorBlock + 1,
-      Math.max(
-        earliest,
-        state.cursorBlock + 1 - reorgWindowBlocksFor(state, opts),
-      ),
-    ),
-  );
-  return { from, to: Math.min(head, from + opts.maxLogRangeBlocks - 1) };
-}
-
-/** Drops window entries the re-read no longer covers. */
-function forgetBelow(state: StreamState, keepFrom: number): void {
-  for (const key of [...state.emitted.keys()]) {
-    if (key < keepFrom) state.emitted.delete(key);
-  }
-  // Only ever rises. What was pruned cannot be un-pruned, so this is the record
-  // of how far down the map can still be trusted.
-  state.retainedFrom = Math.max(state.retainedFrom, keepFrom);
-}
-
-function rollbackTo(state: StreamState, block: number): StreamMessage {
-  for (const key of [...state.emitted.keys()]) {
-    if (key >= block) state.emitted.delete(key);
-  }
-  state.cursorBlock = block - 1;
-
-  // Carry the hash when the block we land on is one we recorded. Without it the
-  // stored cursor has no `unique_key`, and a restart in the window between this
-  // rollback and the next data message would skip the canonicality check
-  // entirely -- right after the one event that makes it worth doing. Only
-  // log-bearing blocks are in `emitted`, so this is best-effort by nature.
-  const landing = state.emitted.get(block - 1);
-
-  return {
-    _tag: "invalidate",
-    invalidate: {
-      cursor: {
-        orderKey: BigInt(block - 1),
-        ...(landing ? { uniqueKey: landing.hash } : {}),
-      },
-    },
-  };
-}
-
-function dataMessage(block: StreamBlock): StreamMessage {
-  return {
-    _tag: "data",
-    data: {
-      endCursor: {
-        orderKey: block.header.blockNumber,
-        uniqueKey: block.header.blockHash,
-      },
-      data: [block],
-    },
-  };
-}
-
-/**
- * Re-reads the `finalized` tag, at most once per configured interval.
- *
- * A finalized block never moves backwards, so an answer that does is a stale
- * view rather than a change to the chain. The stream this replaces threw on
- * that and crash-looped a worker roughly every eighty seconds.
- */
-async function refreshFinalized(
+async function fetchBlockByNumber(
   rpc: RpcLike,
-  state: StreamState,
-  opts: Resolved,
-  now: number,
-): Promise<void> {
-  // Scaled by the effective poll interval, not fixed. At the floor this is the
-  // configured thirty seconds; at a thirty-second backoff a fixed interval
-  // would fire on every single poll, and its twenty compute units would be a
-  // fifth of what a quiet chain costs -- turning a 93% saving into a 76% one.
-  // A staler finalized block on a dormant chain buys back nothing worth having:
-  // it only widens the re-read, which is free, and slows `finalized_order_key`,
-  // which nothing on such a chain is waiting for.
-  const due = Math.max(
-    opts.finalizedRefreshIntervalMs,
-    pollIntervalFor(state, opts) * 4,
-  );
-  if (now - state.lastFinalizedRefresh < due) {
-    return;
-  }
-  state.lastFinalizedRefresh = now;
+  blockNumber: number,
+): Promise<ChainHead | null> {
+  const block = (await rpc.request({
+    method: "eth_getBlockByNumber",
+    params: [numberToHex(BigInt(blockNumber)), false],
+  } as never)) as unknown as {
+    number: Hex | null;
+    hash: Hex | null;
+    timestamp: Hex;
+    baseFeePerGas?: Hex;
+  } | null;
 
-  // Tolerated, not fatal. The finalized block is an optimisation here -- a floor
-  // on the re-read and a cursor to announce -- so a node that cannot answer for
-  // it should cost us that optimisation, not the worker. Without this catch the
-  // `withNullBlockRetry` wrapper turns a null answer into a throw that escapes
-  // the generator every thirty seconds and exits the process.
-  const finalized = await fetchBlockByTag(rpc, "finalized").catch(
-    (error: unknown) => {
-      opts.onWarning?.("could not read the finalized block", {
-        error: String(error).slice(0, 200),
-      });
-      return null;
-    },
-  );
-  if (!finalized) return;
+  if (!block || block.number === null || block.hash === null) return null;
 
-  if (state.finalized && finalized.number < state.finalized.number) {
-    opts.onWarning?.("finalized block moved backwards; ignoring", {
-      seen: finalized.number,
-      held: state.finalized.number,
-    });
-    return;
-  }
-  state.finalized = finalized;
-}
-
-/**
- * Refreshes the finalized block when due, then announces it if the cursor has
- * reached it. `now` of null skips the refresh and only re-checks.
- */
-async function* announceFinalized(
-  rpc: RpcLike,
-  state: StreamState,
-  opts: Resolved,
-  now: number | null,
-): AsyncGenerator<StreamMessage> {
-  if (now !== null) await refreshFinalized(rpc, state, opts, now);
-  const message = finalizeIfDue(state);
-  if (message) yield message;
-}
-
-/**
- * Announces the finalized block, once the cursor has actually reached it.
- *
- * Never ahead of the cursor: the runtime's recovery path resets the cursor to
- * the last finalized one, so a finalized cursor past ours would move it
- * *forward* on the next unhandled error and skip everything between.
- *
- * Which is why this is a separate step rather than part of the refresh. The
- * refresh happens at the top of a tick, when the cursor still holds last tick's
- * value; on a chain that finalises within a block or two of the head, that stale
- * cursor is always behind the finalized block and the message would be
- * suppressed forever, leaving `finalized_order_key` frozen and the runtime with
- * nothing to recover to. Checking after the cursor advances is what makes the
- * hold-back a delay rather than a permanent mute.
- */
-function finalizeIfDue(state: StreamState): StreamMessage | null {
-  const finalized = state.finalized;
-  if (
-    !finalized ||
-    finalized.number > state.cursorBlock ||
-    finalized.number <= state.finalizedEmitted
-  ) {
-    return null;
-  }
-
-  state.finalizedEmitted = finalized.number;
   return {
-    _tag: "finalize",
-    finalize: {
-      cursor: { orderKey: BigInt(finalized.number), uniqueKey: finalized.hash },
-    },
+    number: hexToNumber(block.number),
+    hash: block.hash,
+    timestamp: new Date(hexToNumber(block.timestamp) * 1000),
+    baseFeePerGas: block.baseFeePerGas
+      ? hexToBigInt(block.baseFeePerGas)
+      : null,
   };
 }
 
@@ -927,296 +390,6 @@ async function requireTimestamps(
   }
 }
 
-/** Reads a span of logs and summarises which blocks in it carry them. */
-async function readWindow(
-  rpc: RpcLike,
-  args: { from: number; to: number; addresses: Address[] },
-  filters: LogStreamFilter[],
-  opts: Resolved,
-): Promise<{ blocks: StreamBlock[]; digests: Map<number, BlockDigest> }> {
-  const logs = await fetchLogsChecked(rpc, {
-    fromBlock: args.from,
-    toBlock: args.to,
-    addresses: args.addresses,
-    suspectLogCount: opts.suspectLogCount,
-  });
-  const blocks = groupLogsByBlock(logs, filters);
-  return { blocks, digests: digestBlocks(blocks) };
-}
-
-function heartbeatIfDue(
-  state: StreamState,
-  opts: Resolved,
-  now: number,
-): StreamMessage | null {
-  if (now - state.lastHeartbeat < opts.heartbeatIntervalMs) return null;
-  state.lastHeartbeat = now;
-  return { _tag: "heartbeat" };
-}
-
-/**
- * How long to sleep before the next poll, given how long the chain has been
- * quiet.
- *
- * The cost of this stream is polls times eighty compute units, and it does not
- * care whether a poll found anything: `eth_getLogs` is billed per request, so a
- * chain that has never emitted an event costs exactly what the busiest one
- * does. That is the whole bill on a deployment like ours, where most chains are
- * indexed for completeness rather than volume.
- *
- * So the interval tracks whether the chain is doing anything we index. It holds
- * at the floor for `quietPollsBeforeBackoff` consecutive empty polls -- the
- * latency guarantee, and the reason a busy chain never notices this exists --
- * then doubles per empty poll up to `maxPollIntervalMs`. Anything worth being
- * fast for puts it straight back to the floor.
- *
- * Backing off is only ever a delay, never a miss: `eth_getLogs` answers for a
- * block range, so a wider gap between polls means a wider range, not a gap in
- * what is read. The worst case is noticing the first event on a dormant chain
- * up to `maxPollIntervalMs` late, after which the chain is at the floor again
- * for at least `quietPollsBeforeBackoff` polls.
- */
-export function pollIntervalFor(
-  state: Pick<StreamState, "quietPolls" | "blockRate">,
-  opts: Pick<
-    Resolved,
-    | "pollIntervalMs"
-    | "maxPollIntervalMs"
-    | "quietPollsBeforeBackoff"
-    | "maxLogRangeBlocks"
-    | "reorgWindowSeconds"
-  >,
-): number {
-  const floor = opts.pollIntervalMs;
-
-  // The ceiling is whichever is lower: what was configured, and what one
-  // `eth_getLogs` can actually drain.
-  //
-  // A poll has to read every block produced since the last one, and it can only
-  // ask for `maxLogRangeBlocks` at a time, of which the reorg window is re-read
-  // rather than new. Sleep for longer than the remainder takes to accumulate
-  // and the stream never catches up in a single read: it stops sleeping, reads
-  // spans back to back, and pays more compute units than it saved. Where that
-  // line falls is a fact about the chain's block rate, so it is derived from
-  // the measured one rather than assumed -- 30 s is 3 blocks on Ethereum and
-  // 329 on Robinhood.
-  const drain = opts.maxLogRangeBlocks - reorgWindowBlocksFor(state, opts);
-  const rate = state.blockRate;
-  const drainCeiling =
-    rate !== null && rate > 0 ? (drain / rate) * 1_000 : Number.POSITIVE_INFINITY;
-  const ceiling = Math.max(floor, Math.min(opts.maxPollIntervalMs, drainCeiling));
-
-  const over = state.quietPolls - opts.quietPollsBeforeBackoff;
-  if (over <= 0) return floor;
-  // Cap the exponent before it is applied. `2 ** 1024` is Infinity, and a
-  // chain quiet for a week would get there; `Math.min` would still return the
-  // ceiling, but the intermediate is a trap for anyone reworking this line.
-  const doubled = floor * 2 ** Math.min(over, 32);
-  return Math.min(ceiling, doubled);
-}
-
-/**
- * True when this poll's head is the one the last read already covered.
- *
- * An identical head means an identical chain, so the window cannot have changed
- * and re-reading it would buy nothing. This is where the cost stops scaling with
- * block time: on a 12 s chain polled every 2 s it skips five reads in six, and
- * `eth_getLogs` is 60 of the 80 compute units a poll costs.
- */
-function headUnchanged(state: StreamState, head: LatestBlock): boolean {
-  return (
-    state.seeded &&
-    head.number === state.cursorBlock &&
-    head.hash === state.lastHeadHash
-  );
-}
-
-/** The span to read this tick, or null when there is nothing to do yet. */
-async function planRead(
-  rpc: RpcLike,
-  state: StreamState,
-  opts: Resolved,
-): Promise<{ from: number; to: number; head: LatestBlock } | null> {
-  const head = await fetchBlockByTag(rpc, "latest");
-  if (!head) return null;
-  // Before `windowFor`, which sizes itself from the rate this updates.
-  observeBlockRate(state, head);
-  warnIfWindowCapped(state, opts);
-  const { from, to } = windowFor(state, head.number, opts);
-  return from > to ? null : { from, to, head };
-}
-
-/**
- * A rollback message when the re-read disagrees with what was already emitted.
- *
- * Divergence above the cursor is just a block being seen for the first time,
- * so only a disagreement at or below it is a reorg that needs undoing.
- */
-function maybeRollback(
-  state: StreamState,
-  digests: Map<number, BlockDigest>,
-  plan: { from: number; to: number },
-  opts: Resolved,
-): StreamMessage | null {
-  // Never diff below what `emitted` still holds.
-  //
-  // "I have no record of this block" and "this block is new" are the same
-  // observation to `firstDivergentBlock` -- `before === undefined,
-  // after !== undefined` -- and one of them is a reorg while the other is
-  // bookkeeping. The scan can reach below the retention floor whenever the
-  // cursor moves *down*, which is exactly what `rollbackTo` does: it skips
-  // `finishTick`, so a real reorg lowers the cursor without lowering the floor,
-  // and the next cursor-anchored scan starts a full window below where the last
-  // prune assumed. Every log-bearing block in the gap then reads as diverged,
-  // `rollbackTo` clears the remainder of the map, and the next tick diffs
-  // against nothing -- the cursor walks down to `earliest` on a chain that
-  // reorged exactly once.
-  //
-  // Flooring the comparison is what makes that structurally impossible, rather
-  // than merely unlikely at the current window widths. Blocks below the floor
-  // are older than a full window beneath a cursor we have already passed, which
-  // is the depth this stream does not claim to protect anyway.
-  const divergent = firstDivergentBlock(
-    state.emitted,
-    digests,
-    Math.max(plan.from, state.retainedFrom),
-    plan.to,
-  );
-  if (divergent === undefined || divergent > state.cursorBlock) return null;
-  opts.onWarning?.("reorg detected", { block: divergent });
-  return rollbackTo(state, divergent);
-}
-
-/**
- * Reconciles a freshly read window against what was already emitted.
- *
- * The first read is adopted as the baseline; every read after it is a diff, and
- * a disagreement at or below the cursor is a reorg to undo.
- */
-function reconcileWindow(
-  state: StreamState,
-  digests: Map<number, BlockDigest>,
-  plan: { from: number; to: number },
-  opts: Resolved,
-): StreamMessage | null {
-  if (!state.seeded) {
-    seedWindow(state, digests, plan.from);
-    return null;
-  }
-  return maybeRollback(state, digests, plan, opts);
-}
-
-/**
- * Adopts the first window read as the baseline rather than diffing against it.
- *
- * Only blocks at or below the cursor are taken; anything above is new and is
- * recorded as it is emitted. Without this, a restart within the reorg window
- * would find every log-bearing block in it "missing" from an empty map and roll
- * the chain back on every deploy.
- */
-function seedWindow(
-  state: StreamState,
-  digests: Map<number, BlockDigest>,
-  from: number,
-): void {
-  for (const [blockNumber, digest] of digests) {
-    if (blockNumber <= state.cursorBlock) state.emitted.set(blockNumber, digest);
-  }
-  // The seed read is the first thing `emitted` knows anything about, so it is
-  // where the authoritative range begins.
-  state.retainedFrom = from;
-  state.seeded = true;
-}
-
-/**
- * The trailing block that moves the cursor to the end of the span.
- *
- * Without it a quiet chain would re-read the same blocks forever, since the
- * runtime only advances its cursor on a data message. The head's own header is
- * already in hand; any other endpoint costs one read.
- */
-async function tailMessage(
-  rpc: RpcLike,
-  state: StreamState,
-  fresh: StreamBlock[],
-  plan: { to: number; head: LatestBlock },
-): Promise<StreamMessage | null> {
-  // Once caught up, the span ends where the cursor already is. Emitting it
-  // again would cost a write transaction per poll on every chain forever,
-  // moving nothing.
-  if (plan.to <= state.cursorBlock) return null;
-
-  const last = fresh.at(-1);
-  if (last && Number(last.header.blockNumber) >= plan.to) return null;
-
-  const tail =
-    plan.to === plan.head.number
-      ? plan.head
-      : await fetchBlockByNumber(rpc, plan.to);
-  if (!tail) return null;
-
-  return dataMessage({
-    header: {
-      blockNumber: BigInt(tail.number),
-      blockHash: tail.hash,
-      timestamp: tail.timestamp,
-      baseFeePerGas: tail.baseFeePerGas,
-    },
-    logs: [],
-  });
-}
-
-function initStream({
-  filters,
-  startingCursor,
-  options = {},
-}: Omit<CreateLogStreamArgs, "rpc">): {
-  opts: Resolved;
-  addresses: Address[];
-  state: StreamState;
-} {
-  const addresses = [
-    ...new Set(filters.map((f) => f.address.toLowerCase() as Address)),
-  ];
-  if (addresses.length === 0) {
-    throw new Error("createLogStream requires at least one filter");
-  }
-
-  const opts: Resolved = { ...DEFAULTS, ...options };
-
-  // The window used to be a block count that could be configured wider than the
-  // span that has to contain it, which spins the loop -- so the constructor
-  // refused it. `reorgWindowBlocksFor` now caps the window at half the span, so
-  // there is no such configuration to refuse: forward progress is at least half
-  // of `maxLogRangeBlocks` whatever the chain's block rate turns out to be.
-  // What remains is the degenerate span, which no cap can rescue.
-  if (opts.maxLogRangeBlocks < 2) {
-    throw new Error(
-      `GET_LOGS_RANGE_SIZE (${opts.maxLogRangeBlocks}) must be at least 2, otherwise a poll cannot both re-read a block and read a new one.`,
-    );
-  }
-
-  return {
-    opts,
-    addresses,
-    state: {
-      cursorBlock: Number(startingCursor.orderKey),
-      emitted: new Map(),
-      finalized: null,
-      lastFinalizedRefresh: 0,
-      finalizedEmitted: 0,
-      lastHeartbeat: Date.now(),
-      lastHeadHash: "",
-      quietPolls: 0,
-      blockRate: null,
-      rateSample: null,
-      warnedCapSeconds: null,
-      retainedFrom: 0,
-      seeded: false,
-    },
-  };
-}
-
 /**
  * Gives the head block its own base fee, which this poll already fetched.
  *
@@ -1231,7 +404,7 @@ function initStream({
  * `indexer_cursor.head_base_fee_per_gas` -- which quoter-service reads to price
  * gas -- both fresh and never null.
  */
-function stampHeadBaseFee(blocks: StreamBlock[], head: LatestBlock): void {
+function stampHeadBaseFee(blocks: StreamBlock[], head: ChainHead): void {
   for (const block of blocks) {
     if (Number(block.header.blockNumber) === head.number) {
       block.header.baseFeePerGas = head.baseFeePerGas;
@@ -1239,273 +412,59 @@ function stampHeadBaseFee(blocks: StreamBlock[], head: LatestBlock): void {
   }
 }
 
-/** Records each block in the reorg window and yields it downstream. */
-async function* emitFresh(
-  state: StreamState,
-  fresh: StreamBlock[],
-): AsyncGenerator<StreamMessage> {
-  // Any matched log means the chain is in use, so drop straight back to the
-  // floor. `groupLogsByBlock` keeps only blocks carrying a log one of our
-  // filters matched, so a non-empty `fresh` is exactly "we indexed something".
-  if (fresh.length > 0) state.quietPolls = 0;
-
-  for (const block of fresh) {
-    state.emitted.set(Number(block.header.blockNumber), {
-      hash: block.header.blockHash,
-      logCount: block.logs.length,
-    });
-    state.lastHeartbeat = Date.now();
-    yield dataMessage(block);
-  }
+export interface CreateLogStreamArgs {
+  rpc: RpcLike;
+  filters: LogStreamFilter[];
+  startingCursor: IndexerCursor;
+  options?: LogStreamOptions;
 }
 
-/** Advances the cursor and forgets what the reorg window no longer covers. */
-function finishTick(
-  state: StreamState,
-  plan: { to: number; head: LatestBlock },
-  opts: Resolved,
-): void {
-  // Never backwards. An endpoint that momentarily answers `latest` with a block
-  // behind the cursor yields a valid-looking plan that ends below it, and
-  // assigning that would rewind the in-memory cursor with no `invalidate` and no
-  // warning, re-emitting blocks already indexed. A rollback is the only thing
-  // allowed to move the cursor back, and it says so.
-  state.cursorBlock = Math.max(state.cursorBlock, plan.to);
-  state.lastHeadHash = plan.head.hash;
-  const earliest = (state.finalized?.number ?? 0) + 1;
-  // Retain to the widest window any later tick could scan, not to this tick's.
-  //
-  // The window is measured, so it grows when the chain speeds up. Forgetting to
-  // the current width means the next tick -- whose `windowFor` may have just
-  // re-measured wider -- scans blocks that were dropped from `emitted` a moment
-  // ago. `firstDivergentBlock` cannot tell "I forgot this" from "this block is
-  // new below my cursor": it sees `before === undefined, after !== undefined`
-  // and reports a reorg. `rollbackTo` then clears every remaining entry, so the
-  // next tick diffs against an empty map and rolls back again, walking the
-  // cursor backwards a window at a time until `earliest` floors it. Measured on
-  // a chain whose hashes were pure functions of block number, so nothing ever
-  // reorged: 34 invalidates, ~30 blocks each. Ethereum at 640 s is squarely in
-  // range -- one missed slot inside a sample swings the window by ~18 blocks.
-  //
-  // `reorgWindowBlocksFor` is bounded by half the span, so that bound is the
-  // widest scan possible and retaining to it is sufficient. `emitted` holds
-  // only log-bearing blocks, so the extra entries cost nothing.
-  forgetBelow(
-    state,
-    Math.max(earliest, state.cursorBlock - maxReorgWindowBlocks(opts)),
-  );
-}
-
-/**
- * Rolls back when the block the stored cursor names is no longer canonical.
- *
- * The stream this replaces checked this on every start, and the runtime's
- * reorg-retry loop exists to catch its failure. A log diff cannot replace it: a
- * reorg during downtime leaves nothing to disagree with, since the window is
- * seeded from whatever the chain says now. One `eth_getBlockByNumber` at
- * startup settles it for the whole ancestry, because a block hash commits to
- * every block beneath it.
- */
-async function checkStartingCursor(
+export function createEvmAdapter(
   rpc: RpcLike,
-  state: StreamState,
-  startingCursor: IndexerCursor,
-  opts: Resolved,
-): Promise<StreamMessage | null> {
-  const expected = startingCursor.uniqueKey;
-  if (typeof expected !== "string" || state.cursorBlock <= 0) return null;
-
-  // An absent or unreadable block is a pruned or lagging node answering, not a
-  // reorg, and `withNullBlockRetry` surfaces the null case as a throw. Reading
-  // forward from an unverified cursor is the safe failure -- it re-reads -- and
-  // is far better than crash-looping a worker whose node cannot serve the block.
-  const block = await fetchBlockByNumber(rpc, state.cursorBlock).catch(
-    (error: unknown) => {
-      opts.onWarning?.("could not verify the stored cursor", {
-        block: state.cursorBlock,
-        error: String(error).slice(0, 200),
-      });
-      return null;
-    },
-  );
-  if (!block) return null;
-
-  // The stored key round-trips through a numeric column, so leading zeroes are
-  // gone by the time it comes back. Compare the values, not the strings.
-  if (BigInt(block.hash) === BigInt(expected)) return null;
-
-  // A finalized block cannot be the reorg point, so there is no reason to
-  // rewind past one -- and every reason not to, since the rows below it are
-  // settled. Costs one request, and only on the branch that already found a
-  // mismatch.
-  // Tolerated the same way `refreshFinalized` tolerates it, and for a sharper
-  // reason: this line is only reached once the cursor is already known to be
-  // non-canonical. Letting it throw would exit before the `invalidate` is
-  // emitted, and the restart would land on this same branch again -- a crash
-  // loop precisely where recovery is what is needed.
-  const finalized = await fetchBlockByTag(rpc, "finalized").catch(
-    (error: unknown) => {
-      opts.onWarning?.("could not read the finalized block while rolling back", {
-        error: String(error).slice(0, 200),
-      });
-      return null;
-    },
-  );
-  // Seed the rate from the two blocks already in hand, at no extra cost.
-  //
-  // This runs before the loop, so without it `state.blockRate` is null here and
-  // the window is the half-span cap -- 500 blocks by default and 2500 on
-  // Arbitrum and Robinhood, against the 64 this used to rewind. `finalized + 1`
-  // floors it, so that only bites on a node that cannot serve the finalized tag
-  // (which this function already tolerates), but there it means deleting and
-  // reprocessing thousands of blocks on a cursor that moved by one.
-  //
-  // The cursor block and the finalized block are separated by the chain's
-  // finality lag, which is a far longer baseline than the loop's 30 s sample
-  // ever gets.
-  if (finalized) {
-    const elapsedSec = Math.floor(
-      (block.timestamp.getTime() - finalized.timestamp.getTime()) / 1000,
-    );
-    const advanced = block.number - finalized.number;
-    if (elapsedSec >= MIN_RATE_SAMPLE_SECONDS && advanced > 0) {
-      state.blockRate = advanced / elapsedSec;
-    }
+  filters: LogStreamFilter[],
+  suspectLogCount: number,
+): ChainAdapter<StreamLog> {
+  const addresses = [
+    ...new Set(filters.map((f) => f.address.toLowerCase() as Address)),
+  ];
+  if (addresses.length === 0) {
+    throw new Error("createLogStream requires at least one filter");
   }
 
-  const floor = finalized ? finalized.number + 1 : 1;
-  // Never past the cursor itself: if even the finalized block disagrees, the
-  // least we can do is re-read the block we are standing on rather than skip it.
-  const target = Math.min(
-    state.cursorBlock,
-    Math.max(floor, 1, state.cursorBlock - reorgWindowBlocksFor(state, opts)),
-  );
-  opts.onWarning?.("stored cursor is not canonical; rolling back", {
-    block: state.cursorBlock,
-    expected,
-    found: block.hash,
-    rollbackTo: target - 1,
-  });
-  return rollbackTo(state, target);
+  return {
+    label: "evm",
+    fetchHead: () => fetchBlockByTag(rpc, "latest"),
+    fetchFinalized: () => fetchBlockByTag(rpc, "finalized"),
+    fetchBlock: (blockNumber) => fetchBlockByNumber(rpc, blockNumber),
+    async readRange(from, to) {
+      const logs = await fetchLogsChecked(rpc, {
+        fromBlock: from,
+        toBlock: to,
+        addresses,
+        suspectLogCount,
+      });
+      return groupLogsByBlock(logs, filters);
+    },
+    async completeFresh(blocks, head) {
+      await requireTimestamps(rpc, blocks);
+      stampHeadBaseFee(blocks, head);
+    },
+  };
 }
 
 /**
  * Yields the same messages the previous stream did, so the runtime, the DAO and
  * every processor are untouched.
  */
-export async function* createLogStream(
+export function createLogStream(
   args: CreateLogStreamArgs,
 ): AsyncGenerator<StreamMessage> {
-  const { rpc, filters } = args;
-  const { opts, addresses, state } = initStream(args);
+  const { suspectLogCount = EVM_DEFAULTS.suspectLogCount, ...options } =
+    args.options ?? {};
 
-  const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-
-  const notCanonical = await checkStartingCursor(
-    rpc,
-    state,
-    args.startingCursor,
-    opts,
-  );
-  if (notCanonical) yield notCanonical;
-
-  while (true) {
-    const now = Date.now();
-
-    const heartbeat = heartbeatIfDue(state, opts, now);
-    if (heartbeat) yield heartbeat;
-
-    yield* announceFinalized(rpc, state, opts, now);
-
-    const plan = await planRead(rpc, state, opts);
-    if (!plan) {
-      // An unreadable head is not evidence the chain is quiet, so this does not
-      // count towards backoff -- but it must not poll a struggling endpoint
-      // faster than a healthy one either, so it sleeps for the interval already
-      // in force.
-      await sleep(pollIntervalFor(state, opts));
-      continue;
-    }
-
-    if (headUnchanged(state, plan.head)) {
-      // The head has not moved, so there is provably nothing new to index: a
-      // head hash commits to its whole ancestry. That is a quiet poll in the
-      // sense that matters, and counting it is what lets a chain with a block
-      // time longer than the poll interval back off at all.
-      state.quietPolls++;
-      await sleep(pollIntervalFor(state, opts));
-      continue;
-    }
-
-    const { blocks, digests } = await readWindow(
-      rpc,
-      { from: plan.from, to: plan.to, addresses },
-      filters,
-      opts,
-    );
-
-    const rollback = reconcileWindow(state, digests, plan, opts);
-    if (rollback) {
-      yield rollback;
-      // A reorg is the last moment to be slow: the blocks being rolled back
-      // have to be re-read and re-emitted before the chain is correct again.
-      state.quietPolls = 0;
-      // An endpoint serving two views alternately would otherwise rollback,
-      // re-read and rollback again with no pause between, one DB transaction per
-      // turn. Back off exactly as the caught-up path does.
-      await sleep(opts.pollIntervalMs);
-      continue;
-    }
-
-    const fresh = blocks.filter(
-      (block) => Number(block.header.blockNumber) > state.cursorBlock,
-    );
-    await requireTimestamps(rpc, fresh);
-    stampHeadBaseFee(fresh, plan.head);
-    yield* emitFresh(state, fresh);
-
-    const tail = await tailMessage(rpc, state, fresh, plan);
-    if (tail) yield tail;
-
-    finishTick(state, plan, opts);
-
-    // Now that the cursor has moved, the finalized block may be behind it.
-    yield* announceFinalized(rpc, state, opts, null);
-
-    // Only a caught-up poll can be a quiet one. While catching up the loop does
-    // not sleep at all, and counting those polls would let a long backfill --
-    // which is all empty ranges until it reaches the interesting blocks -- back
-    // the stream off just as it arrives at the head.
-    if (plan.to >= plan.head.number) {
-      if (fresh.length === 0) state.quietPolls++;
-      await sleep(pollIntervalFor(state, opts));
-    }
-  }
-}
-
-async function fetchBlockByNumber(
-  rpc: RpcLike,
-  blockNumber: number,
-): Promise<LatestBlock | null> {
-  const block = (await rpc.request({
-    method: "eth_getBlockByNumber",
-    params: [numberToHex(BigInt(blockNumber)), false],
-  } as never)) as unknown as {
-    number: Hex | null;
-    hash: Hex | null;
-    timestamp: Hex;
-    baseFeePerGas?: Hex;
-  } | null;
-
-  if (!block || block.number === null || block.hash === null) return null;
-
-  return {
-    number: hexToNumber(block.number),
-    hash: block.hash,
-    timestamp: new Date(hexToNumber(block.timestamp) * 1000),
-    baseFeePerGas: block.baseFeePerGas
-      ? hexToBigInt(block.baseFeePerGas)
-      : null,
-  };
+  return createBlockStream<StreamLog>({
+    adapter: createEvmAdapter(args.rpc, args.filters, suspectLogCount),
+    startingCursor: args.startingCursor,
+    options,
+  });
 }

--- a/src/starknet.ts
+++ b/src/starknet.ts
@@ -1,46 +1,44 @@
-import { Metadata, createClient } from "@apibara/protocol";
-import { Block as StarknetBlock, StarknetStream } from "@apibara/starknet";
 import type { EventKey } from "./_shared/eventKey";
 import { logger } from "./_shared/logger";
 import { parseCommonBlockHeader } from "./_shared/parseBlockHeader";
 import { loadHexAddresses } from "./_shared/loadHexAddresses";
-import { requireStarknetApibaraUrl } from "./_shared/streamEndpoints";
+import { requireStarknetRpcUrl } from "./_shared/streamEndpoints";
 import { runIndexer, type ParsedRuntimeBlock } from "./runtime";
 import { createEventProcessors } from "./starknet/eventProcessors";
+import {
+  createStarknetEventStream,
+  createStarknetRpc,
+  type StarknetStreamBlock,
+  type StarknetStreamFilter,
+} from "./starknet/eventStream";
 import type { NetworkEntrypoint, StreamOptions } from "./types";
 
 export function parseStarknetBlockHeader(
   block: unknown,
-): ParsedRuntimeBlock<StarknetBlock> | null {
+): ParsedRuntimeBlock<StarknetStreamBlock> | null {
   if (!block || typeof block !== "object") return null;
 
-  const starknetBlock = block as Partial<StarknetBlock>;
-  if (!starknetBlock.header || !Array.isArray(starknetBlock.events)) {
+  const starknetBlock = block as Partial<StarknetStreamBlock>;
+  if (!starknetBlock.header || !Array.isArray(starknetBlock.logs)) {
     return null;
   }
 
-  const { header } = starknetBlock;
-  const common = parseCommonBlockHeader(header);
+  const common = parseCommonBlockHeader(starknetBlock.header);
   if (!common) return null;
 
-  // A malformed L2 gas price is treated the same as a malformed hash: the block
-  // is unusable rather than indexed with a missing fee.
-  let baseFeePerGas: bigint | null = null;
-  try {
-    if (header.l2GasPrice?.priceInFri) {
-      baseFeePerGas = BigInt(header.l2GasPrice.priceInFri);
-    }
-  } catch {
-    return null;
-  }
-
   return {
-    block: starknetBlock as StarknetBlock,
-    header: { ...common, baseFeePerGas },
+    block: starknetBlock as StarknetStreamBlock,
+    header: {
+      ...common,
+      // The L2 gas price, which the stream reads from the head block. Only the
+      // head's is stored -- `indexer_cursor.head_base_fee_per_gas`, which
+      // quoter-service reads to price gas.
+      baseFeePerGas: starknetBlock.header.baseFeePerGas ?? null,
+    },
   };
 }
 
-export function createStarknetEntrypoint(): NetworkEntrypoint<StarknetBlock> {
+export function createStarknetEntrypoint(): NetworkEntrypoint<StarknetStreamBlock> {
   const starknetAddressConfig = loadHexAddresses({
     nftAddress: "NFT_ADDRESS",
     coreAddress: "CORE_ADDRESS",
@@ -63,33 +61,55 @@ export function createStarknetEntrypoint(): NetworkEntrypoint<StarknetBlock> {
   logger.info(`Indexing Starknet contracts`, { starknetAddressConfig });
 
   const processors = createEventProcessors(starknetAddressConfig);
-  const starknetApibaraUrl = requireStarknetApibaraUrl(process.env.APIBARA_URL);
+  const rpc = createStarknetRpc(
+    requireStarknetRpcUrl(process.env.STARKNET_RPC_URL),
+  );
+
+  const filters: StarknetStreamFilter[] = processors.map((processor, ix) => ({
+    id: ix + 1,
+    fromAddress: processor.filter.fromAddress,
+    keys: processor.filter.keys,
+  }));
+
+  const positiveInt = (name: string, fallbackValue: number): number => {
+    const raw = process.env[name];
+    if (raw === undefined || raw === "") return fallbackValue;
+    const parsed = Number(raw);
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+      throw new Error(`${name} must be a positive integer, got ${raw}`);
+    }
+    return parsed;
+  };
 
   return {
     createStream(streamOptions: StreamOptions) {
-      return createClient(StarknetStream, starknetApibaraUrl, {
-        defaultCallOptions: {
-          "*": {
-            metadata: Metadata({
-              Authorization: `Bearer ${process.env.DNA_TOKEN}`,
-            }),
-          },
+      return createStarknetEventStream({
+        rpc,
+        filters,
+        startingCursor: streamOptions.startingCursor,
+        options: {
+          pollIntervalMs: positiveInt("POLL_INTERVAL_MS", 2_000),
+          // Starknet is never quiet for long -- it lands an event we index
+          // roughly every thirteen seconds -- so the backoff this shares with
+          // the EVM chains will rarely leave the floor. It is left armed
+          // because "rarely" is not "never": the ceiling costs at most one
+          // interval of latency, and NO_BLOCKS_TIMEOUT_MS is five minutes, far
+          // above it.
+          maxPollIntervalMs: positiveInt("MAX_POLL_INTERVAL_MS", 30_000),
+          quietPollsBeforeBackoff: positiveInt("QUIET_POLLS_BEFORE_BACKOFF", 30),
+          // ~0.59 blocks a second on mainnet, so the default 120 s window is
+          // ~71 blocks and the span has to be at least twice that.
+          maxLogRangeBlocks: positiveInt("GET_LOGS_RANGE_SIZE", 500),
+          reorgWindowSeconds: positiveInt("REORG_WINDOW_SECONDS", 120),
+          heartbeatIntervalMs: Number(
+            streamOptions.heartbeatInterval.seconds * 1000n,
+          ),
+          onWarning: (message, detail) => logger.warn({ message, ...detail }),
         },
-      }).streamData({
-        ...streamOptions,
-        filter: [
-          {
-            events: processors.map((processor, ix) => ({
-              id: ix + 1,
-              address: processor.filter.fromAddress,
-              keys: processor.filter.keys,
-            })),
-          },
-        ],
       });
     },
-    getPlannedEvents(block: StarknetBlock) {
-      return block.events.reduce(
+    getPlannedEvents(block: StarknetStreamBlock) {
+      return block.logs.reduce(
         (total, event) => total + (event.filterIds?.length ?? 0),
         0,
       );
@@ -97,11 +117,11 @@ export function createStarknetEntrypoint(): NetworkEntrypoint<StarknetBlock> {
     async processBlock({ block, blockNumber, dao }) {
       let eventsProcessed = 0;
 
-      for (const event of block.events) {
+      for (const event of block.logs) {
         const eventKey: EventKey = {
           blockNumber,
           transactionIndex: event.transactionIndex,
-          eventIndex: event.eventIndexInTransaction ?? event.eventIndex,
+          eventIndex: event.eventIndex,
           emitter: event.address,
           transactionHash: event.transactionHash,
         };

--- a/src/starknet/eventStream.test.ts
+++ b/src/starknet/eventStream.test.ts
@@ -1,0 +1,437 @@
+import { describe, expect, it } from "bun:test";
+import type { Hex } from "viem";
+import {
+  createStarknetAdapter,
+  eventMatchesFilter,
+  groupEventsByBlock,
+  matchingFilterIds,
+  selectorPrefilter,
+  type StarknetRpc,
+  type StarknetStreamFilter,
+} from "./eventStream";
+
+/**
+ * Block 14555766 of Starknet mainnet, reduced to the shape this reads.
+ *
+ * Not invented. The chain really answers with 28 events for its first
+ * transaction and 8 for its second, with ours at indices 3 and 19 of the first
+ * and 1 of the second -- and the production database really holds
+ * (tx 0, event 3), (tx 0, event 19) and (tx 1, event 1) for it, written years
+ * ago by the DNA stream this replaces. Reproducing those three pairs from the
+ * RPC is the whole reason the receipts read exists.
+ */
+const BLOCK_NUMBER = 14_555_766;
+const BLOCK_TIMESTAMP = 1_788_870_514;
+// Unpadded, exactly as the node returns it. The config below is padded.
+const BLOCK_HASH =
+  "0xe2e6b27298293e43981bc78a466ed6c4435cda64fceb1b849a151581e942a7" as Hex;
+const TX0 =
+  "0x14e1987a79e7343af32021e4644ffe7e6229a6c3a852761344a9fb331750544" as Hex;
+const TX1 =
+  "0x21ffe2bf674418f0804f98316027146bfc6378aff0dffce43dc06d0a6cc7032" as Hex;
+/** As `.env.starknet.mainnet` writes it: zero-padded, and mixed case. */
+const CORE_PADDED =
+  "0x00000005dd3D2F4429AF886cD1a3b08289DBcEa99A294197E9eB43b0e0325b4b" as Hex;
+/** As the node returns it. */
+const CORE_UNPADDED =
+  "0x5dd3d2f4429af886cd1a3b08289dbcea99a294197e9eb43b0e0325b4b" as Hex;
+const SWAPPED =
+  "0x157717768aca88da4ac4279765f09f4d0151823d573537fbbeb950cdbd9a870" as Hex;
+const OTHER_CONTRACT = "0x1234" as Hex;
+
+const coreFilter: StarknetStreamFilter = {
+  id: 1,
+  fromAddress: CORE_PADDED,
+  keys: [SWAPPED],
+};
+
+function emitted(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    from_address: CORE_UNPADDED,
+    keys: [SWAPPED],
+    data: ["0x1"] as Hex[],
+    block_hash: BLOCK_HASH,
+    block_number: BLOCK_NUMBER,
+    transaction_hash: TX0,
+    transaction_index: 0,
+    event_index: 3,
+    ...over,
+  } as Parameters<typeof groupEventsByBlock>[0][number];
+}
+
+/** A block header, as `starknet_getBlockWithTxHashes` answers. */
+function header(over: Record<string, unknown> = {}) {
+  return {
+    block_hash: BLOCK_HASH,
+    block_number: BLOCK_NUMBER,
+    timestamp: BLOCK_TIMESTAMP,
+    ...over,
+  };
+}
+
+function rpcReturning(handlers: Record<string, unknown[]>): {
+  rpc: StarknetRpc;
+  calls: { method: string; params: unknown }[];
+} {
+  const calls: { method: string; params: unknown }[] = [];
+  const remaining = Object.fromEntries(
+    Object.entries(handlers).map(([method, responses]) => [
+      method,
+      [...responses],
+    ]),
+  );
+  return {
+    calls,
+    rpc: {
+      async request<T>(method: string, params: unknown): Promise<T> {
+        calls.push({ method, params });
+        const queue = remaining[method];
+        if (!queue || queue.length === 0) {
+          throw new Error(`unexpected call to ${method}`);
+        }
+        return (queue.length === 1 ? queue[0] : queue.shift()) as T;
+      },
+    },
+  };
+}
+
+describe("eventMatchesFilter", () => {
+  it("compares felts by value, not by string", () => {
+    // The single most likely way to break Starknet indexing: the node writes a
+    // felt unpadded, the env writes it padded, and a string compare silently
+    // matches nothing at all while looking perfectly healthy.
+    expect(
+      eventMatchesFilter(
+        { address: CORE_UNPADDED, keys: [SWAPPED] },
+        coreFilter,
+      ),
+    ).toBe(true);
+  });
+
+  it("matches a key written with and without leading zeroes", () => {
+    expect(
+      eventMatchesFilter(
+        { address: CORE_UNPADDED, keys: [`0x0${SWAPPED.slice(2)}` as Hex] },
+        coreFilter,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects another contract emitting the same selector", () => {
+    expect(
+      eventMatchesFilter(
+        { address: OTHER_CONTRACT, keys: [SWAPPED] },
+        coreFilter,
+      ),
+    ).toBe(false);
+  });
+
+  it("matches on a prefix, so extra keys do not disqualify an event", () => {
+    expect(
+      eventMatchesFilter(
+        { address: CORE_UNPADDED, keys: [SWAPPED, "0x9" as Hex] },
+        coreFilter,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects an event carrying fewer keys than the filter names", () => {
+    expect(
+      eventMatchesFilter({ address: CORE_UNPADDED, keys: [] }, coreFilter),
+    ).toBe(false);
+  });
+});
+
+describe("selectorPrefilter", () => {
+  it("dedupes selectors that differ only in padding", () => {
+    const selectors = selectorPrefilter([
+      coreFilter,
+      { id: 2, fromAddress: OTHER_CONTRACT, keys: [`0x0${SWAPPED.slice(2)}`] },
+    ]);
+    expect(selectors).toHaveLength(1);
+  });
+
+  it("is disabled entirely by a filter that matches on address alone", () => {
+    // A prefilter has to be a superset of what the local matcher accepts. A
+    // filter with no selector cannot be represented as one, so narrowing the
+    // read would silently drop that processor's events.
+    expect(
+      selectorPrefilter([coreFilter, { id: 2, fromAddress: CORE_PADDED, keys: [] }]),
+    ).toBeNull();
+  });
+});
+
+describe("groupEventsByBlock", () => {
+  it("keeps only matched events and sorts blocks ascending", () => {
+    const blocks = groupEventsByBlock(
+      [
+        emitted({ block_number: BLOCK_NUMBER + 1 }),
+        emitted({ from_address: OTHER_CONTRACT }),
+        emitted(),
+      ],
+      [coreFilter],
+    );
+    expect(blocks.map((b) => Number(b.header.blockNumber))).toEqual([
+      BLOCK_NUMBER,
+      BLOCK_NUMBER + 1,
+    ]);
+    expect(blocks[0]!.logs).toHaveLength(1);
+  });
+
+  it("omits a block carrying nothing we match", () => {
+    // Load-bearing for the shared diff: a block with no matched event has no
+    // representation in a range read, so recording one would make it look like
+    // it had vanished on the next re-read.
+    expect(
+      groupEventsByBlock([emitted({ from_address: OTHER_CONTRACT })], [
+        coreFilter,
+      ]),
+    ).toEqual([]);
+  });
+
+  it("skips a pre-confirmed event, which has no hash to anchor a cursor to", () => {
+    expect(
+      groupEventsByBlock(
+        [emitted({ block_hash: undefined, block_number: undefined })],
+        [coreFilter],
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("groupEventsByBlock positions", () => {
+  it("carries through the transaction and event indices the database holds", () => {
+    // Block 14555766's three Core events. The production database holds
+    // (0, 3), (0, 19) and (1, 1) for them, written by the DNA stream; v0.10
+    // reports the same, and so did a reconstruction from the block's receipts.
+    const blocks = groupEventsByBlock(
+      [
+        emitted({ transaction_hash: TX0, transaction_index: 0, event_index: 3 }),
+        emitted({ transaction_hash: TX0, transaction_index: 0, event_index: 19 }),
+        emitted({ transaction_hash: TX1, transaction_index: 1, event_index: 1 }),
+      ],
+      [coreFilter],
+    );
+
+    expect(
+      blocks[0]!.logs.map((e) => [e.transactionIndex, e.eventIndex]),
+    ).toEqual([
+      [0, 3],
+      [0, 19],
+      [1, 1],
+    ]);
+  });
+
+  it("refuses an event with no position rather than defaulting it to zero", () => {
+    // A zero here is not a near miss: it is a wrong `event_id`, which is a
+    // primary key other tables order on, written with no error anywhere. An
+    // endpoint answering without these is serving a spec older than v0.10.
+    expect(() =>
+      groupEventsByBlock(
+        [emitted({ transaction_index: undefined, event_index: undefined })],
+        [coreFilter],
+      ),
+    ).toThrow(/v0\.10/);
+  });
+
+  it("refuses an event index compute_event_id cannot represent", () => {
+    expect(() =>
+      groupEventsByBlock([emitted({ event_index: 65_536 })], [coreFilter]),
+    ).toThrow(/compute_event_id/);
+  });
+});
+
+describe("completeFresh", () => {
+  it("takes the block timestamp from the header read", async () => {
+    const { rpc } = rpcReturning({ starknet_getBlockWithTxHashes: [header()] });
+    const adapter = createStarknetAdapter({ rpc, filters: [coreFilter] });
+    const blocks = groupEventsByBlock([emitted()], [coreFilter]);
+
+    expect(blocks[0]!.header.timestamp.getTime()).toBe(0);
+    await adapter.completeFresh(blocks, {
+      number: BLOCK_NUMBER + 5,
+      hash: "0xff",
+      timestamp: new Date(),
+      baseFeePerGas: null,
+    });
+    expect(blocks[0]!.header.timestamp.getTime()).toBe(BLOCK_TIMESTAMP * 1000);
+  });
+
+  it("never changes how many events a block holds", async () => {
+    // The shared diff compares the count recorded when a block was emitted
+    // against the count the next range read reports. A completion step that
+    // added or dropped one would manufacture a reorg on every single poll.
+    const { rpc } = rpcReturning({ starknet_getBlockWithTxHashes: [header()] });
+    const adapter = createStarknetAdapter({ rpc, filters: [coreFilter] });
+    const blocks = groupEventsByBlock(
+      [emitted(), emitted({ event_index: 19 })],
+      [coreFilter],
+    );
+
+    await adapter.completeFresh(blocks, {
+      number: BLOCK_NUMBER,
+      hash: BLOCK_HASH,
+      timestamp: new Date(),
+      baseFeePerGas: null,
+    });
+    expect(blocks[0]!.logs).toHaveLength(2);
+  });
+
+  it("refuses a block that changed hash between the two reads", async () => {
+    // Two requests, so the chain can move between them. A timestamp from a
+    // different block would reach `blocks.block_time` with nothing to flag it.
+    const { rpc } = rpcReturning({
+      starknet_getBlockWithTxHashes: [header({ block_hash: "0xdead" })],
+    });
+    const adapter = createStarknetAdapter({ rpc, filters: [coreFilter] });
+    const blocks = groupEventsByBlock([emitted()], [coreFilter]);
+
+    await expect(
+      adapter.completeFresh(blocks, {
+        number: BLOCK_NUMBER,
+        hash: BLOCK_HASH,
+        timestamp: new Date(),
+        baseFeePerGas: null,
+      }),
+    ).rejects.toThrow(/changed hash/);
+  });
+
+  it("stamps the head's gas price onto the head block only", async () => {
+    const { rpc } = rpcReturning({ starknet_getBlockWithTxHashes: [header()] });
+    const adapter = createStarknetAdapter({ rpc, filters: [coreFilter] });
+    const blocks = groupEventsByBlock([emitted()], [coreFilter]);
+
+    await adapter.completeFresh(blocks, {
+      number: BLOCK_NUMBER,
+      hash: BLOCK_HASH,
+      timestamp: new Date(),
+      baseFeePerGas: 28_776_978_417n,
+    });
+    expect(blocks[0]!.header.baseFeePerGas).toBe(28_776_978_417n);
+  });
+
+  it("reads once per block, not once per event", async () => {
+    const { rpc, calls } = rpcReturning({
+      starknet_getBlockWithTxHashes: [header()],
+    });
+    const adapter = createStarknetAdapter({ rpc, filters: [coreFilter] });
+    const blocks = groupEventsByBlock(
+      [emitted(), emitted({ event_index: 19 }), emitted({ event_index: 21 })],
+      [coreFilter],
+    );
+
+    await adapter.completeFresh(blocks, {
+      number: BLOCK_NUMBER,
+      hash: BLOCK_HASH,
+      timestamp: new Date(),
+      baseFeePerGas: null,
+    });
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("readRange", () => {
+  it("follows the continuation token to the end", async () => {
+    const { rpc, calls } = rpcReturning({
+      starknet_getEvents: [
+        { events: [emitted()], continuation_token: "14555766-1" },
+        { events: [emitted({ transaction_hash: TX1 })] },
+      ],
+    });
+    const adapter = createStarknetAdapter({ rpc, filters: [coreFilter] });
+
+    const blocks = await adapter.readRange(BLOCK_NUMBER, BLOCK_NUMBER);
+    expect(blocks[0]!.logs).toHaveLength(2);
+    expect(calls).toHaveLength(2);
+    expect(
+      (calls[1]!.params as [{ continuation_token: string }])[0]
+        .continuation_token,
+    ).toBe("14555766-1");
+  });
+
+  it("sends the selector prefilter rather than asking per address", async () => {
+    // One address per request would be twelve requests a poll where EVM makes
+    // one, which is the whole cost argument for this shape.
+    const { rpc, calls } = rpcReturning({
+      starknet_getEvents: [{ events: [] }],
+    });
+    const adapter = createStarknetAdapter({ rpc, filters: [coreFilter] });
+
+    await adapter.readRange(1, 10);
+    const params = (calls[0]!.params as [Record<string, unknown>])[0];
+    expect(params.keys).toEqual([[SWAPPED]]);
+    expect(params.address).toBeUndefined();
+  });
+
+  it("refuses a range that will not finish paginating", async () => {
+    const { rpc } = rpcReturning({
+      starknet_getEvents: [{ events: [], continuation_token: "forever" }],
+    });
+    const adapter = createStarknetAdapter({
+      rpc,
+      filters: [coreFilter],
+      maxPages: 3,
+    });
+
+    await expect(adapter.readRange(1, 1_000)).rejects.toThrow(
+      /did not finish paginating/,
+    );
+  });
+});
+
+describe("fetchHead", () => {
+  it("reads the L2 gas price the cursor stores as its base fee", async () => {
+    const { rpc } = rpcReturning({
+      starknet_getBlockWithTxHashes: [
+        {
+          block_hash: BLOCK_HASH,
+          block_number: BLOCK_NUMBER,
+          timestamp: BLOCK_TIMESTAMP,
+          l2_gas_price: { price_in_fri: "0x6b33dd7f1" },
+        },
+      ],
+    });
+    const adapter = createStarknetAdapter({ rpc, filters: [coreFilter] });
+
+    expect(await adapter.fetchHead()).toEqual({
+      number: BLOCK_NUMBER,
+      hash: BLOCK_HASH,
+      timestamp: new Date(BLOCK_TIMESTAMP * 1000),
+      baseFeePerGas: 28_776_978_417n,
+    });
+  });
+
+  it("asks for l1_accepted as the finalized block", async () => {
+    // Starknet finality is settlement on Ethereum. `latest` is ACCEPTED_ON_L2,
+    // which can still be reorged.
+    const { rpc, calls } = rpcReturning({
+      starknet_getBlockWithTxHashes: [
+        { block_hash: BLOCK_HASH, block_number: 1, timestamp: 1 },
+      ],
+    });
+    const adapter = createStarknetAdapter({ rpc, filters: [coreFilter] });
+
+    await adapter.fetchFinalized();
+    expect(calls[0]!.params).toEqual(["l1_accepted"]);
+  });
+
+  it("treats a block with no hash as unreadable rather than as a cursor", async () => {
+    const { rpc } = rpcReturning({
+      starknet_getBlockWithTxHashes: [{ timestamp: 1 }],
+    });
+    const adapter = createStarknetAdapter({ rpc, filters: [coreFilter] });
+    expect(await adapter.fetchHead()).toBeNull();
+  });
+});
+
+describe("matchingFilterIds", () => {
+  it("returns every filter an event satisfies", () => {
+    expect(
+      matchingFilterIds({ address: CORE_UNPADDED, keys: [SWAPPED] }, [
+        coreFilter,
+        { id: 2, fromAddress: CORE_PADDED, keys: [] },
+        { id: 3, fromAddress: OTHER_CONTRACT, keys: [SWAPPED] },
+      ]),
+    ).toEqual([1, 2]);
+  });
+});

--- a/src/starknet/eventStream.test.ts
+++ b/src/starknet/eventStream.test.ts
@@ -364,6 +364,22 @@ describe("readRange", () => {
     expect(params.address).toBeUndefined();
   });
 
+  it("stops on a token the node ends the listing with as null", async () => {
+    // `continuation_token` is optional in the spec, so implementations differ
+    // on whether the last page omits it or sends an explicit null. Testing for
+    // `undefined` alone would keep the loop alive while the falsy token was
+    // dropped from the request -- page one re-fetched until `maxPages`, then an
+    // error blaming the range size, which is not the problem.
+    const { rpc, calls } = rpcReturning({
+      starknet_getEvents: [{ events: [emitted()], continuation_token: null }],
+    });
+    const adapter = createStarknetAdapter({ rpc, filters: [coreFilter] });
+
+    const blocks = await adapter.readRange(BLOCK_NUMBER, BLOCK_NUMBER);
+    expect(blocks[0]!.logs).toHaveLength(1);
+    expect(calls).toHaveLength(1);
+  });
+
   it("refuses a range that will not finish paginating", async () => {
     const { rpc } = rpcReturning({
       starknet_getEvents: [{ events: [], continuation_token: "forever" }],
@@ -528,5 +544,90 @@ describe("createStarknetRpc", () => {
     );
     expect(result).toBe(1);
     expect(calls).toBe(2);
+  });
+});
+
+describe("createStarknetRpc retry envelope", () => {
+  const withFetch = async <T>(
+    responses: (() => Response | Promise<Response>)[],
+    run: (rpc: ReturnType<typeof createStarknetRpc>) => Promise<T>,
+  ): Promise<{ result: T | Error; calls: number }> => {
+    const original = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = (async () =>
+      responses[Math.min(calls++, responses.length - 1)]!()) as unknown as typeof fetch;
+    try {
+      return {
+        result: await run(createStarknetRpc("https://x", { retryDelayMs: 1 })),
+        calls,
+      };
+    } catch (error) {
+      return { result: error as Error, calls };
+    } finally {
+      globalThis.fetch = original;
+    }
+  };
+  const json = (body: unknown, status = 200) => () =>
+    new Response(JSON.stringify(body), { status });
+
+  it("retries a 403, which an edge can return transiently", async () => {
+    // viem retries 403 and 413 for the EVM streams. Throwing here instead would
+    // exit the generator, and runtime.ts exits the process on that -- a worker
+    // restart where an EVM worker retries in place.
+    const { result, calls } = await withFetch(
+      [json({}, 403), json({ result: 5 })],
+      (rpc) => rpc.request("starknet_blockNumber", []),
+    );
+    expect(result).toBe(5);
+    expect(calls).toBe(2);
+  });
+
+  it("retries a 413", async () => {
+    const { result } = await withFetch(
+      [json({}, 413), json({ result: 6 })],
+      (rpc) => rpc.request("starknet_blockNumber", []),
+    );
+    expect(result).toBe(6);
+  });
+
+  it("retries a 200 whose body is not JSON", async () => {
+    // A proxy or CDN error page served with a 200. That is a failure to answer
+    // rather than an answer, so it is retried like one.
+    const { result, calls } = await withFetch(
+      [() => new Response("<html>502</html>", { status: 200 }), json({ result: 7 })],
+      (rpc) => rpc.request("starknet_blockNumber", []),
+    );
+    expect(result).toBe(7);
+    expect(calls).toBe(2);
+  });
+
+  it("gives up with the cause attached once retries are spent", async () => {
+    const { result, calls } = await withFetch([json({}, 503)], (rpc) =>
+      rpc.request("starknet_blockNumber", []),
+    );
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toMatch(/after 4 attempts.*503/s);
+    expect(calls).toBe(4);
+  });
+
+  it("bounds a request that never answers", async () => {
+    // Without a deadline a half-open socket parks the generator forever: the
+    // retry loop never runs, and the only backstop left is the five-minute
+    // NO_BLOCKS_TIMEOUT_MS.
+    const rpc = createStarknetRpc("https://x", { retries: 0, timeoutMs: 20 });
+    const original = globalThis.fetch;
+    globalThis.fetch = ((_u: string, init: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        );
+      })) as unknown as typeof fetch;
+    try {
+      await expect(rpc.request("starknet_blockNumber", [])).rejects.toThrow(
+        /after 1 attempts/,
+      );
+    } finally {
+      globalThis.fetch = original;
+    }
   });
 });

--- a/src/starknet/eventStream.test.ts
+++ b/src/starknet/eventStream.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { Hex } from "viem";
 import {
   createStarknetAdapter,
+  createStarknetRpc,
   eventMatchesFilter,
   groupEventsByBlock,
   matchingFilterIds,
@@ -395,7 +396,8 @@ describe("fetchHead", () => {
 
     expect(await adapter.fetchHead()).toEqual({
       number: BLOCK_NUMBER,
-      hash: BLOCK_HASH,
+      // Padded to 32 bytes on the way out; the node sends 62 hex characters.
+      hash: `0x00${BLOCK_HASH.slice(2)}`,
       timestamp: new Date(BLOCK_TIMESTAMP * 1000),
       baseFeePerGas: 28_776_978_417n,
     });
@@ -433,5 +435,98 @@ describe("matchingFilterIds", () => {
         { id: 3, fromAddress: OTHER_CONTRACT, keys: [SWAPPED] },
       ]),
     ).toEqual([1, 2]);
+  });
+});
+
+describe("canonical block hashes", () => {
+  // The adapter compares felts by value, but the shared core cannot:
+  // `firstDivergentBlock` diffs hash strings and `headUnchanged` compares them
+  // outright. A node that strips leading zeroes on one request and not the next
+  // would read as a block that changed hash -- a reorg that never happened,
+  // with rows deleted and re-indexed for it.
+  const PADDED = `0x${"0".repeat(2)}${BLOCK_HASH.slice(2)}` as Hex;
+
+  it("pads a block hash carried on an event", () => {
+    const [short] = groupEventsByBlock([emitted()], [coreFilter]);
+    const [long] = groupEventsByBlock(
+      [emitted({ block_hash: PADDED })],
+      [coreFilter],
+    );
+    expect(short!.header.blockHash).toBe(long!.header.blockHash);
+    expect(short!.header.blockHash).toHaveLength(66);
+  });
+
+  it("pads a block hash carried on a header", async () => {
+    const { rpc } = rpcReturning({
+      starknet_getBlockWithTxHashes: [header(), header({ block_hash: PADDED })],
+    });
+    const adapter = createStarknetAdapter({ rpc, filters: [coreFilter] });
+    const first = await adapter.fetchHead();
+    const second = await adapter.fetchHead();
+    expect(first!.hash).toBe(second!.hash);
+    expect(first!.hash).toHaveLength(66);
+  });
+
+  it("still matches the cursor it is compared against numerically", () => {
+    const [block] = groupEventsByBlock([emitted()], [coreFilter]);
+    expect(BigInt(block!.header.blockHash)).toBe(BigInt(BLOCK_HASH));
+  });
+});
+
+describe("createStarknetRpc", () => {
+  const withFetch = async <T>(
+    responses: (() => Response)[],
+    run: (rpc: ReturnType<typeof createStarknetRpc>) => Promise<T>,
+  ): Promise<{ result: T | Error; calls: number }> => {
+    const original = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      const next = responses[Math.min(calls++, responses.length - 1)]!;
+      return next();
+    }) as unknown as typeof fetch;
+    try {
+      return { result: await run(createStarknetRpc("https://x", { retryDelayMs: 1 })), calls };
+    } catch (error) {
+      return { result: error as Error, calls };
+    } finally {
+      globalThis.fetch = original;
+    }
+  };
+
+  const json = (body: unknown, status = 200) =>
+    () => new Response(JSON.stringify(body), { status });
+
+  it("retries a compute-unit overage, which arrives as HTTP 200 code 429", async () => {
+    // The trap: Alchemy reports an overage as a *successful* HTTP response
+    // carrying a JSON-RPC error. Throwing here would exit the generator and
+    // restart.sh would poll the throttling endpoint a second later, forever.
+    const { result, calls } = await withFetch(
+      [
+        json({ error: { code: 429, message: "capacity" } }),
+        json({ result: { block_number: 7 } }),
+      ],
+      (rpc) => rpc.request("starknet_blockNumber", []),
+    );
+    expect(result).toEqual({ block_number: 7 });
+    expect(calls).toBe(2);
+  });
+
+  it("does not retry an error that is an answer", async () => {
+    const { result, calls } = await withFetch(
+      [json({ error: { code: -32602, message: "Invalid params" } })],
+      (rpc) => rpc.request("starknet_getEvents", []),
+    );
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toMatch(/Invalid params/);
+    expect(calls).toBe(1);
+  });
+
+  it("retries a transient HTTP status", async () => {
+    const { result, calls } = await withFetch(
+      [json({}, 503), json({ result: 1 })],
+      (rpc) => rpc.request("starknet_blockNumber", []),
+    );
+    expect(result).toBe(1);
+    expect(calls).toBe(2);
   });
 });

--- a/src/starknet/eventStream.ts
+++ b/src/starknet/eventStream.ts
@@ -318,7 +318,7 @@ export function createStarknetAdapter({
 
     async readRange(from, to) {
       const events: EmittedEvent[] = [];
-      let continuationToken: string | undefined;
+      let continuationToken: string | null | undefined;
       let pages = 0;
 
       do {
@@ -330,7 +330,9 @@ export function createStarknetAdapter({
 
         const page = await rpc.request<{
           events: EmittedEvent[];
-          continuation_token?: string;
+          // Nullable, not merely optional: the field is optional in the spec, so
+          // a node may end a listing either by omitting it or by sending null.
+          continuation_token?: string | null;
         }>("starknet_getEvents", [
           {
             from_block: { block_number: from },
@@ -345,7 +347,12 @@ export function createStarknetAdapter({
 
         events.push(...page.events);
         continuationToken = page.continuation_token;
-      } while (continuationToken !== undefined);
+        // `!= null` deliberately: the field is optional in the spec, so a node
+        // may end a listing with an explicit JSON `null` rather than by omitting
+        // it. Testing only for `undefined` would keep this loop alive while the
+        // falsy token was dropped from the request below -- page one re-fetched
+        // until `maxPages`, then an error blaming the range size.
+      } while (continuationToken != null);
 
       // Unlike `eth_getLogs` there is no truncation to guard against. A capped
       // response says so by handing back a continuation token, and the loop
@@ -415,72 +422,118 @@ export function createStarknetAdapter({
 const RETRYABLE_RPC_CODES = new Set([-1, -32005, -32603, 429]);
 
 /**
+ * HTTP statuses viem retries for the EVM streams, enumerated so this client
+ * matches them rather than approximating them.
+ *
+ * 403 and 413 are the two a `status >= 500 || 408 || 429` test misses. A
+ * transient 403 from a provider edge would otherwise throw straight out of
+ * `fetchHead`, and `runtime.ts` exits the process on a generator throw -- a
+ * worker restart where an EVM worker would have retried in place.
+ */
+const RETRYABLE_HTTP_STATUSES = new Set([403, 408, 413, 429]);
+
+function isRetryableStatus(status: number): boolean {
+  return RETRYABLE_HTTP_STATUSES.has(status) || status >= 500;
+}
+
+/** One attempt, classified into a value, a retry, or a throw. */
+type Attempt<T> =
+  | { outcome: "ok"; value: T }
+  | { outcome: "retry"; error: Error }
+  | { outcome: "fail"; error: Error };
+
+/**
  * A JSON-RPC client with the retry behaviour viem gives the EVM streams.
  *
- * Retries a transport failure, a status the server says is transient, and the
- * JSON-RPC codes above. Anything else is an answer, and is returned or thrown
- * as one.
+ * Retries a transport failure, a timeout, a status the server says is
+ * transient, a body that is not the JSON it claimed, and the JSON-RPC codes
+ * above. Anything else is an answer, and is returned or thrown as one.
  */
 export function createStarknetRpc(
   url: string,
-  { retries = 3, retryDelayMs = 250 }: { retries?: number; retryDelayMs?: number } = {},
+  {
+    retries = 3,
+    retryDelayMs = 250,
+    timeoutMs = 20_000,
+  }: { retries?: number; retryDelayMs?: number; timeoutMs?: number } = {},
 ): StarknetRpc {
+  // Split out of `request` so each half stays under the lint's complexity cap,
+  // and so the classification can be read without the retry loop around it.
+  const attempt = async <T>(
+    method: string,
+    params: unknown,
+  ): Promise<Attempt<T>> => {
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+        // Nothing else bounds how long this may hang. Without it a half-open
+        // socket blocks the poll indefinitely: the generator is parked on this
+        // await, so the retry loop below never runs, and because `runtime.ts`
+        // does not reset the no-blocks timer on heartbeats the only backstop
+        // left is NO_BLOCKS_TIMEOUT_MS -- five minutes of not indexing. viem
+        // gives the EVM streams this for free; this is the equivalent.
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      return { outcome: "retry", error: error as Error };
+    }
+
+    if (isRetryableStatus(response.status)) {
+      return {
+        outcome: "retry",
+        error: new Error(`${method} failed with HTTP ${response.status}`),
+      };
+    }
+    if (!response.ok) {
+      return {
+        outcome: "fail",
+        error: new Error(`${method} failed with HTTP ${response.status}`),
+      };
+    }
+
+    let body: { result?: T; error?: { code: number; message: string } };
+    try {
+      body = (await response.json()) as typeof body;
+    } catch (error) {
+      // A 200 carrying a proxy or CDN error page rather than JSON. That is a
+      // failure to answer, not an answer, so it is retried like one.
+      return {
+        outcome: "retry",
+        error: new Error(
+          `${method} returned a body that is not JSON: ${String(error).slice(0, 120)}`,
+        ),
+      };
+    }
+
+    if (body.error) {
+      const failure = new Error(
+        `${method} failed: ${body.error.message} (code ${body.error.code})`,
+      );
+      return RETRYABLE_RPC_CODES.has(body.error.code)
+        ? { outcome: "retry", error: failure }
+        : { outcome: "fail", error: failure };
+    }
+    return { outcome: "ok", value: body.result as T };
+  };
+
   return {
     async request<T>(method: string, params: unknown): Promise<T> {
       let lastError: unknown;
 
-      for (let attempt = 0; attempt <= retries; attempt++) {
-        if (attempt > 0) {
+      for (let i = 0; i <= retries; i++) {
+        if (i > 0) {
           await new Promise((resolve) =>
-            setTimeout(resolve, retryDelayMs * 2 ** (attempt - 1)),
+            setTimeout(resolve, retryDelayMs * 2 ** (i - 1)),
           );
         }
 
-        let response: Response;
-        try {
-          response = await fetch(url, {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({
-              jsonrpc: "2.0",
-              id: 1,
-              method,
-              params,
-            }),
-          });
-        } catch (error) {
-          lastError = error;
-          continue;
-        }
-
-        if (
-          response.status === 429 ||
-          response.status === 408 ||
-          response.status >= 500
-        ) {
-          lastError = new Error(`${method} failed with HTTP ${response.status}`);
-          continue;
-        }
-
-        if (!response.ok) {
-          throw new Error(`${method} failed with HTTP ${response.status}`);
-        }
-
-        const body = (await response.json()) as {
-          result?: T;
-          error?: { code: number; message: string };
-        };
-        if (body.error) {
-          const failure = new Error(
-            `${method} failed: ${body.error.message} (code ${body.error.code})`,
-          );
-          if (RETRYABLE_RPC_CODES.has(body.error.code)) {
-            lastError = failure;
-            continue;
-          }
-          throw failure;
-        }
-        return body.result as T;
+        const result = await attempt<T>(method, params);
+        if (result.outcome === "ok") return result.value;
+        if (result.outcome === "fail") throw result.error;
+        lastError = result.error;
       }
 
       throw new Error(

--- a/src/starknet/eventStream.ts
+++ b/src/starknet/eventStream.ts
@@ -1,0 +1,476 @@
+/**
+ * The Starknet adapter for the shared block stream.
+ *
+ * Starknet used to be indexed from an apibara DNA gRPC stream while every EVM
+ * chain moved to range-reading its own RPC. That left two ways of handling the
+ * same three problems -- reorgs, backoff and the cursor -- and only one of them
+ * had the bugs beaten out of it. This puts Starknet on the same core, so a fix
+ * to the reorg window or the poll backoff lands on every chain at once.
+ *
+ * Three things genuinely differ from EVM, and they are all here rather than in
+ * the shared core:
+ *
+ * 1. `starknet_getEvents` takes one address, not a list. Asking per contract
+ *    would be twelve requests a poll where EVM makes one, so the range read is
+ *    filtered by event selector instead -- which the RPC does accept as an
+ *    OR-list -- and narrowed to our contracts locally. Measured on mainnet the
+ *    selector prefilter cuts a range read from 15.9 to 3.3 events per block.
+ *
+ * 2. `EMITTED_EVENT` carries a transaction index and an event index only from
+ *    JSON-RPC v0.10, which is why the URL pins that version. Under v0.9 they
+ *    are absent and the `continuation_token` counts *matched* results, so it
+ *    cannot supply them either -- they had to be rebuilt from the block's
+ *    receipts, pairing our events back onto their true positions. That is a
+ *    lot of machinery to get exactly right for two integers, and both were
+ *    checked three ways before this was allowed to rely on them: v0.10's
+ *    values, a receipts reconstruction, and the rows the DNA stream wrote
+ *    years ago all agree, over 5,000 mainnet blocks.
+ *
+ *    A block read remains, but only for the timestamp: `EMITTED_EVENT` has
+ *    none and `blocks.block_time` needs one. It costs the same 20 compute
+ *    units the receipts read did, so this is a simplification rather than a
+ *    saving -- one request per block above the cursor either way.
+ *
+ * 3. A felt is not an EVM word. Nodes return them unpadded, the processor
+ *    filters are written unpadded, and the database stores them as numerics, so
+ *    every comparison here is on the value and never on the string.
+ */
+import type { Hex } from "viem";
+import type { IndexerCursor } from "../_shared/dao";
+import {
+  createBlockStream,
+  requireRepresentableIndex,
+  type BlockStreamOptions,
+  type ChainAdapter,
+  type ChainHead,
+  type StreamBlock as SharedStreamBlock,
+  type StreamMessage as SharedStreamMessage,
+} from "../_shared/blockStream";
+
+/** A single processor's event filter, as `eventProcessors` already writes it. */
+export interface StarknetStreamFilter {
+  /** 1-based, matching the `filterIds` the block processors index into. */
+  id: number;
+  fromAddress: Hex;
+  /** Matched positionally against the event's keys, as a prefix. */
+  keys: Hex[];
+}
+
+/** One event, as the runtime's processors consume it. */
+export interface StarknetStreamEvent {
+  address: Hex;
+  keys: Hex[];
+  data: Hex[];
+  transactionHash: Hex;
+  /** Position of the emitting transaction in its block. */
+  transactionIndex: number;
+  /**
+   * Position of the event within its transaction, counting *every* event the
+   * transaction emitted rather than only ours.
+   *
+   * This is what the apibara stream stored as `event_index` and what
+   * `compute_event_id` has packed into every Starknet `event_id` ever written,
+   * so it is not ours to renumber: re-basing it is a migration, not a stream
+   * change. Note it counts the events in between, which is why it cannot be a
+   * position within the filtered results -- block 14555766 holds 3 and 19 for
+   * one transaction, where numbering only the matched events would give 0 and 1.
+   */
+  eventIndex: number;
+  filterIds: number[];
+}
+
+export type StarknetStreamBlock = SharedStreamBlock<StarknetStreamEvent>;
+export type StarknetStreamMessage = SharedStreamMessage<StarknetStreamEvent>;
+
+/** Felts compare by value: nodes pad them inconsistently and we do not. */
+function feltEquals(a: string, b: string): boolean {
+  return BigInt(a) === BigInt(b);
+}
+
+/**
+ * True when `event` satisfies `filter`.
+ *
+ * Prefix match on keys, mirroring what the DNA filter did: an event carrying
+ * more keys than the filter names still matches, which is what lets a filter on
+ * the selector alone match every event of that name.
+ */
+export function eventMatchesFilter(
+  event: Pick<StarknetStreamEvent, "address" | "keys">,
+  filter: StarknetStreamFilter,
+): boolean {
+  if (!feltEquals(event.address, filter.fromAddress)) return false;
+  if (event.keys.length < filter.keys.length) return false;
+  for (let i = 0; i < filter.keys.length; i++) {
+    const expected = filter.keys[i];
+    if (expected === undefined) continue;
+    const actual = event.keys[i];
+    if (actual === undefined || !feltEquals(actual, expected)) return false;
+  }
+  return true;
+}
+
+export function matchingFilterIds(
+  event: Pick<StarknetStreamEvent, "address" | "keys">,
+  filters: StarknetStreamFilter[],
+): number[] {
+  const ids: number[] = [];
+  for (const filter of filters) {
+    if (eventMatchesFilter(event, filter)) ids.push(filter.id);
+  }
+  return ids;
+}
+
+/**
+ * The selectors to ask the node for, or null when the filters do not all pin
+ * one.
+ *
+ * A prefilter is only ever an optimisation, so it has to be a superset of what
+ * `matchingFilterIds` accepts. A filter with no keys matches on address alone,
+ * and no selector list can stand in for that -- so one such filter disables the
+ * prefilter entirely rather than silently narrowing the read.
+ */
+export function selectorPrefilter(
+  filters: StarknetStreamFilter[],
+): Hex[] | null {
+  const selectors = new Map<string, Hex>();
+  for (const filter of filters) {
+    const selector = filter.keys[0];
+    if (selector === undefined) return null;
+    selectors.set(BigInt(selector).toString(), selector);
+  }
+  return selectors.size > 0 ? [...selectors.values()] : null;
+}
+
+interface EmittedEvent {
+  from_address: Hex;
+  keys: Hex[];
+  data: Hex[];
+  block_hash?: Hex;
+  block_number?: number;
+  transaction_hash: Hex;
+  /** v0.10 and above. Absent is a misconfigured endpoint, not an old block. */
+  transaction_index?: number;
+  event_index?: number;
+}
+
+/**
+ * Groups matched events into blocks, in ascending block order, preserving the
+ * order the node returned them in within a block.
+ *
+ * Blocks carrying nothing we match are omitted, which the shared diff depends
+ * on: a block with no matched event has no representation in a range read, so
+ * recording one would make it look like it had disappeared on the next re-read.
+ */
+export function groupEventsByBlock(
+  events: EmittedEvent[],
+  filters: StarknetStreamFilter[],
+): StarknetStreamBlock[] {
+  const byBlock = new Map<number, StarknetStreamBlock>();
+
+  for (const event of events) {
+    if (event.block_number === undefined || event.block_hash === undefined) {
+      // A pre-confirmed block has neither, and it has no hash to anchor a
+      // cursor to either. Nothing that cannot be rolled back to is indexed.
+      continue;
+    }
+    const filterIds = matchingFilterIds(
+      { address: event.from_address, keys: event.keys },
+      filters,
+    );
+    if (filterIds.length === 0) continue;
+
+    let block = byBlock.get(event.block_number);
+    if (!block) {
+      block = {
+        header: {
+          blockNumber: BigInt(event.block_number),
+          blockHash: event.block_hash,
+          // Filled by `completeFresh`, which reads the block anyway.
+          timestamp: new Date(0),
+          baseFeePerGas: null,
+        },
+        logs: [],
+      };
+      byBlock.set(event.block_number, block);
+    }
+
+    // Refused rather than defaulted. A zero here is not a near miss: it is a
+    // wrong `event_id`, which is a primary key other tables order on, and it
+    // would be written with no error anywhere. An endpoint that does not send
+    // these is serving a spec older than the URL asks for.
+    if (event.transaction_index === undefined || event.event_index === undefined) {
+      throw new Error(
+        `starknet_getEvents returned an event in block ${event.block_number} with no transaction_index or event_index. The RPC URL must name JSON-RPC v0.10 or later, which is where EMITTED_EVENT carries them.`,
+      );
+    }
+
+    block.logs.push({
+      address: event.from_address,
+      keys: event.keys,
+      data: event.data,
+      transactionHash: event.transaction_hash,
+      transactionIndex: event.transaction_index,
+      eventIndex: requireRepresentableIndex(
+        event.event_index,
+        event.block_number,
+        "the index within its transaction",
+      ),
+      filterIds,
+    });
+  }
+
+  return [...byBlock.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([, block]) => block);
+}
+
+export interface StarknetRpc {
+  request<T>(method: string, params: unknown): Promise<T>;
+}
+
+type BlockId = "latest" | "l1_accepted" | { block_number: number };
+
+interface BlockHeaderResponse {
+  block_hash?: Hex;
+  block_number?: number;
+  timestamp: number;
+  l2_gas_price?: { price_in_fri?: Hex };
+}
+
+function toChainHead(block: BlockHeaderResponse | null): ChainHead | null {
+  if (!block || block.block_hash === undefined || block.block_number === undefined) {
+    return null;
+  }
+  const priceInFri = block.l2_gas_price?.price_in_fri;
+  return {
+    number: block.block_number,
+    hash: block.block_hash,
+    timestamp: new Date(block.timestamp * 1000),
+    // What the DNA stream reported as the header's base fee, and what
+    // `indexer_cursor.head_base_fee_per_gas` has held for Starknet all along.
+    baseFeePerGas: priceInFri === undefined ? null : BigInt(priceInFri),
+  };
+}
+
+export interface StarknetAdapterOptions {
+  rpc: StarknetRpc;
+  filters: StarknetStreamFilter[];
+  /** Events per `starknet_getEvents` page. */
+  chunkSize?: number;
+  /** Refuses a range read that will not terminate rather than looping forever. */
+  maxPages?: number;
+}
+
+export function createStarknetAdapter({
+  rpc,
+  filters,
+  chunkSize = 1_000,
+  maxPages = 200,
+}: StarknetAdapterOptions): ChainAdapter<StarknetStreamEvent> {
+  if (filters.length === 0) {
+    throw new Error("createStarknetEventStream requires at least one filter");
+  }
+  const keysPrefilter = selectorPrefilter(filters);
+
+  const fetchHeader = async (blockId: BlockId): Promise<ChainHead | null> =>
+    toChainHead(
+      await rpc.request<BlockHeaderResponse | null>(
+        "starknet_getBlockWithTxHashes",
+        [blockId],
+      ),
+    );
+
+  return {
+    label: "starknet",
+
+    fetchHead: () => fetchHeader("latest"),
+
+    // Starknet's finality is settlement on Ethereum, and `l1_accepted` names
+    // the deepest block that has it. It trails the head by hours rather than
+    // seconds, which costs nothing here: the finalized block is only a floor on
+    // the re-read and a cursor to announce.
+    fetchFinalized: () => fetchHeader("l1_accepted"),
+
+    fetchBlock: (blockNumber) => fetchHeader({ block_number: blockNumber }),
+
+    async readRange(from, to) {
+      const events: EmittedEvent[] = [];
+      let continuationToken: string | undefined;
+      let pages = 0;
+
+      do {
+        if (++pages > maxPages) {
+          throw new Error(
+            `starknet_getEvents did not finish paginating blocks ${from}..${to} within ${maxPages} pages of ${chunkSize}. Lower GET_LOGS_RANGE_SIZE.`,
+          );
+        }
+
+        const page = await rpc.request<{
+          events: EmittedEvent[];
+          continuation_token?: string;
+        }>("starknet_getEvents", [
+          {
+            from_block: { block_number: from },
+            to_block: { block_number: to },
+            ...(keysPrefilter ? { keys: [keysPrefilter] } : {}),
+            chunk_size: chunkSize,
+            ...(continuationToken
+              ? { continuation_token: continuationToken }
+              : {}),
+          },
+        ]);
+
+        events.push(...page.events);
+        continuationToken = page.continuation_token;
+      } while (continuationToken !== undefined);
+
+      // Unlike `eth_getLogs` there is no truncation to guard against. A capped
+      // response says so by handing back a continuation token, and the loop
+      // above only stops when the node reports there is no more -- so a short
+      // read is a protocol violation rather than something indistinguishable
+      // from a complete answer.
+      return groupEventsByBlock(events, filters);
+    },
+
+    async completeFresh(blocks, head) {
+      // Only the timestamp, and only for blocks above the cursor. Everything
+      // below is being re-read to diff its digest, which the range read already
+      // answers, so paying a request per block for it would be the reorg
+      // window's width in waste on every poll -- ~390k requests a day against
+      // ~6k.
+      for (const block of blocks) {
+        const blockNumber = Number(block.header.blockNumber);
+        const header = await fetchHeader({ block_number: blockNumber });
+        if (!header) {
+          throw new Error(
+            `Could not read block ${blockNumber}, whose events are already in hand`,
+          );
+        }
+
+        // The range read and this read are two requests, so the chain can move
+        // between them. A timestamp from a different block would be written to
+        // `blocks.block_time` with nothing to flag it, so a block that changed
+        // identity is refused instead. The cursor is durable and the runtime
+        // restarts, so the next pass re-reads a consistent block.
+        if (!feltEquals(header.hash, block.header.blockHash)) {
+          throw new Error(
+            `Block ${blockNumber} changed hash between the event read (${block.header.blockHash}) and the header read (${header.hash}); refusing to timestamp its events from a different block`,
+          );
+        }
+
+        block.header.timestamp = header.timestamp;
+      }
+
+      // The head's own gas price is already in hand from this poll's head read,
+      // and it is the only block whose base fee is stored -- the DAO keeps it on
+      // `indexer_cursor`, which quoter-service reads to price gas.
+      for (const block of blocks) {
+        if (Number(block.header.blockNumber) === head.number) {
+          block.header.baseFeePerGas = head.baseFeePerGas;
+        }
+      }
+    },
+  };
+}
+
+/**
+ * A JSON-RPC client with the retry behaviour viem gives the EVM streams.
+ *
+ * Retries only what is worth retrying -- a transport failure or a status the
+ * server itself says is transient -- and never a JSON-RPC error, which is an
+ * answer rather than a failure to answer.
+ */
+export function createStarknetRpc(
+  url: string,
+  { retries = 3, retryDelayMs = 250 }: { retries?: number; retryDelayMs?: number } = {},
+): StarknetRpc {
+  return {
+    async request<T>(method: string, params: unknown): Promise<T> {
+      let lastError: unknown;
+
+      for (let attempt = 0; attempt <= retries; attempt++) {
+        if (attempt > 0) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, retryDelayMs * 2 ** (attempt - 1)),
+          );
+        }
+
+        let response: Response;
+        try {
+          response = await fetch(url, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method,
+              params,
+            }),
+          });
+        } catch (error) {
+          lastError = error;
+          continue;
+        }
+
+        if (
+          response.status === 429 ||
+          response.status === 408 ||
+          response.status >= 500
+        ) {
+          lastError = new Error(`${method} failed with HTTP ${response.status}`);
+          continue;
+        }
+
+        if (!response.ok) {
+          throw new Error(`${method} failed with HTTP ${response.status}`);
+        }
+
+        const body = (await response.json()) as {
+          result?: T;
+          error?: { code: number; message: string };
+        };
+        if (body.error) {
+          throw new Error(
+            `${method} failed: ${body.error.message} (code ${body.error.code})`,
+          );
+        }
+        return body.result as T;
+      }
+
+      throw new Error(
+        `${method} failed after ${retries + 1} attempts. Cause: ${
+          lastError instanceof Error ? lastError.message : String(lastError)
+        }`,
+        { cause: lastError },
+      );
+    },
+  };
+}
+
+export interface CreateStarknetEventStreamArgs {
+  rpc: StarknetRpc;
+  filters: StarknetStreamFilter[];
+  startingCursor: IndexerCursor;
+  options?: BlockStreamOptions & { chunkSize?: number; maxPages?: number };
+}
+
+/**
+ * Yields the same messages the DNA stream did, so the runtime, the DAO and
+ * every processor are untouched.
+ */
+export function createStarknetEventStream(
+  args: CreateStarknetEventStreamArgs,
+): AsyncGenerator<StarknetStreamMessage> {
+  const { chunkSize, maxPages, ...options } = args.options ?? {};
+
+  return createBlockStream<StarknetStreamEvent>({
+    adapter: createStarknetAdapter({
+      rpc: args.rpc,
+      filters: args.filters,
+      chunkSize,
+      maxPages,
+    }),
+    startingCursor: args.startingCursor,
+    options,
+  });
+}

--- a/src/starknet/eventStream.ts
+++ b/src/starknet/eventStream.ts
@@ -35,7 +35,7 @@
  *    filters are written unpadded, and the database stores them as numerics, so
  *    every comparison here is on the value and never on the string.
  */
-import type { Hex } from "viem";
+import { toHex, type Hex } from "viem";
 import type { IndexerCursor } from "../_shared/dao";
 import {
   createBlockStream,
@@ -85,6 +85,29 @@ export type StarknetStreamMessage = SharedStreamMessage<StarknetStreamEvent>;
 /** Felts compare by value: nodes pad them inconsistently and we do not. */
 function feltEquals(a: string, b: string): boolean {
   return BigInt(a) === BigInt(b);
+}
+
+/**
+ * A felt in one fixed spelling, applied to every block hash leaving this
+ * adapter.
+ *
+ * The adapter compares felts by value, but the shared core it feeds does not
+ * and cannot: `firstDivergentBlock` diffs `before.hash.toLowerCase() ===
+ * after.hash.toLowerCase()` and `headUnchanged` compares strings outright.
+ * Starknet nodes strip leading zeroes -- block 14555766 comes back as 62 hex
+ * characters, not 64 -- and two nodes behind one endpoint have historically
+ * disagreed about whether to. If the same block is ever spelled two ways, the
+ * digest diff reads it as a block that changed hash, `rollbackTo` invalidates
+ * and clears the window, and the next poll can do it again: rows deleted and
+ * re-indexed on a chain that never reorged, looking exactly like a real reorg
+ * in the logs.
+ *
+ * Canonicalising here rather than teaching the core about felts keeps the core
+ * chain-agnostic, and costs nothing downstream: the hash is stored in a numeric
+ * column, so padding never reaches the database either way.
+ */
+function canonicalFelt(felt: string): Hex {
+  return toHex(BigInt(felt), { size: 32 });
 }
 
 /**
@@ -184,7 +207,7 @@ export function groupEventsByBlock(
       block = {
         header: {
           blockNumber: BigInt(event.block_number),
-          blockHash: event.block_hash,
+          blockHash: canonicalFelt(event.block_hash),
           // Filled by `completeFresh`, which reads the block anyway.
           timestamp: new Date(0),
           baseFeePerGas: null,
@@ -244,7 +267,7 @@ function toChainHead(block: BlockHeaderResponse | null): ChainHead | null {
   const priceInFri = block.l2_gas_price?.price_in_fri;
   return {
     number: block.block_number,
-    hash: block.block_hash,
+    hash: canonicalFelt(block.block_hash),
     timestamp: new Date(block.timestamp * 1000),
     // What the DNA stream reported as the header's base fee, and what
     // `indexer_cursor.head_base_fee_per_gas` has held for Starknet all along.
@@ -374,11 +397,29 @@ export function createStarknetAdapter({
 }
 
 /**
+ * Retryable JSON-RPC error codes, matching the list viem applies to the EVM
+ * streams.
+ *
+ * A JSON-RPC error is usually an answer rather than a failure to answer, so
+ * most are not retried. These are the exceptions, and 429 is the one that
+ * matters here: Alchemy reports a compute-unit overage as an **HTTP 200
+ * carrying code 429**, so a client that only inspects the status code sees a
+ * successful response containing an error and gives up.
+ *
+ * Getting this wrong is not a dropped request. Throwing propagates out of
+ * `fetchHead`, exits the generator, and `restart.sh` restarts the worker a
+ * second later -- so the response to being throttled would be to poll the
+ * throttling endpoint harder, forever, while every EVM worker quietly backs
+ * off. Under the account's spend cap that is exactly when it would fire.
+ */
+const RETRYABLE_RPC_CODES = new Set([-1, -32005, -32603, 429]);
+
+/**
  * A JSON-RPC client with the retry behaviour viem gives the EVM streams.
  *
- * Retries only what is worth retrying -- a transport failure or a status the
- * server itself says is transient -- and never a JSON-RPC error, which is an
- * answer rather than a failure to answer.
+ * Retries a transport failure, a status the server says is transient, and the
+ * JSON-RPC codes above. Anything else is an answer, and is returned or thrown
+ * as one.
  */
 export function createStarknetRpc(
   url: string,
@@ -430,9 +471,14 @@ export function createStarknetRpc(
           error?: { code: number; message: string };
         };
         if (body.error) {
-          throw new Error(
+          const failure = new Error(
             `${method} failed: ${body.error.message} (code ${body.error.code})`,
           );
+          if (RETRYABLE_RPC_CODES.has(body.error.code)) {
+            lastError = failure;
+            continue;
+          }
+          throw failure;
         }
         return body.result as T;
       }

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -33,14 +33,17 @@ describe("network entrypoint guards", () => {
       },
     });
 
+    // Both networks now deliver the same shape, because both are read by the
+    // shared block stream: `logs`, and a base fee already resolved to a bigint
+    // rather than an apibara `l2GasPrice.priceInFri`.
     expect(
       parseStarknetBlockHeader({
-        events: [],
+        logs: [],
         header: {
           blockNumber: 789n,
           blockHash: "0xdef",
           timestamp,
-          l2GasPrice: { priceInFri: "0x123" },
+          baseFeePerGas: 0x123n,
         },
       }),
     ).toMatchObject({
@@ -52,7 +55,9 @@ describe("network entrypoint guards", () => {
       },
     });
 
+    // A block missing the events array, or the header, is not usable on either.
     expect(parseEvmBlockHeader({ events: [] })).toBeNull();
+    expect(parseStarknetBlockHeader({ events: [] })).toBeNull();
     expect(parseStarknetBlockHeader({ logs: [] })).toBeNull();
   });
 });


### PR DESCRIPTION
Starknet was the last network still read from the apibara DNA gRPC stream while every EVM chain moved to range-reading its own RPC. That meant two implementations of the same three problems — reorgs, poll backoff and the cursor — and only one of them had the bugs beaten out of it. A fix to the reorg window landed on twelve chains and skipped the thirteenth.

## The shape

The polling loop, the cursor-anchored reorg window, the digest diff, the retention floor, the measured block rate, the backoff and the finalized handling move to `src/_shared/blockStream.ts` **unchanged**, parameterised by a `ChainAdapter`. `src/evm/logStream.ts` keeps its whole public surface and is now the EVM adapter.

**The EVM regression proof is that its 88 tests pass with no edit to the test file.** If the shared core had changed semantics, a test body would have needed touching. None did.

The adapter boundary is drawn where cost is. `readRange` answers for a whole span in one request and runs every poll; `completeFresh` runs only for blocks *above the cursor*, so anything per-block belongs there. On Starknet that distinction is ~6k requests a day instead of ~390k — the reorg window is re-read every poll and would otherwise pay per-block costs for blocks already indexed.

## What Starknet actually does differently

- **`starknet_getEvents` takes one address, not a list.** Asking per contract would be twelve requests a poll where EVM makes one. The range read filters by event selector instead — an OR-list the RPC does accept — and narrows to our contracts locally. Measured on mainnet that takes a range read from 15.9 to 3.3 events per block. A processor filtering on address alone disables the prefilter rather than silently narrowing the read.
- **The URL pins JSON-RPC v0.10**, the first version where `EMITTED_EVENT` carries `transaction_index` and `event_index`. Those are packed into `event_id`, a primary key other tables order on, so an event arriving without them is **refused rather than defaulted to zero** — pointing this at v0.9 stops the worker instead of silently writing wrong keys.
- **`event_index` is per transaction** and counts every event the transaction emitted, not only ours. Block 14555766 holds 3 and 19 for one transaction, where numbering the matched events alone would give 0 and 1. That is what DNA wrote and what `compute_event_id` has packed into every Starknet `event_id` ever written, so it is not ours to renumber. (EVM uses the block-wide `logIndex`; both are inherited.)
- **Finality is `l1_accepted`.** `latest` is `ACCEPTED_ON_L2` and can still reorg; `pre_confirmed` has no hash at all, so nothing that cannot be rolled back to is indexed.
- **Felts compare by value everywhere.** Nodes return them unpadded, the processor filters are written unpadded, and the database stores them as numerics — a string compare would match nothing while looking perfectly healthy.

## Verification

Against production data, not against itself. Over **5,000 mainnet blocks**, every event the stream matches was checked against all **44 tables** holding `(block_number, transaction_index, event_index)`:

```
stream matched 1419 distinct positions
database holds 1400 distinct positions across 44 tables
IN DB BUT NOT PRODUCED: 0
produced but not in db: 19 (filterIds: 8)
```

Nothing in the database went unproduced. The 19 extras are all `SavedBalance`, which that processor deliberately drops unless it follows a `PositionFeesCollected`.

The positions themselves were agreed **three ways** — v0.10's values, a reconstruction from `starknet_getBlockWithReceipts`, and the rows DNA wrote years ago. `scripts/verifyStarknetStream.ts` is that check, kept so it can gate a deploy; it exits non-zero on any mismatch and was last run green against the production key:

```
verifying blocks 14553587..14556586 against the database
stream produced 572 Swapped events
database holds  572 Swapped events
OK: 572 events agree exactly on block:tx:event
```

The composed stream was then run live against the production endpoint from the real stored cursor, round-tripped out of its numeric column — the one path the DB comparison cannot reach, since it never constructs a cursor or runs a parser:

```
starting cursor: block 14554482
messages         40   (first: finalize)
invalidates      0
data blocks      39
events           88
parser calls     88  (0 threw)
OK: no rollback on boot, blocks flowing, every parser returned
```

**No invalidate on boot** is the deploy gate: a broken cursor comparison would rewind 71 blocks on every restart.

447 tests pass. Typecheck is clean apart from the pre-existing `dao.ts:528` error.

## Two fixes after review

Both live at the seam between the adapter and the shared core, which is why the adapter's own tests could not reach them:

- **Block hashes are canonicalised on the way out.** The adapter compares felts by value; the core cannot — `firstDivergentBlock` diffs hash *strings* and `headUnchanged` compares them outright. Starknet nodes strip leading zeroes (the fixture block is 62 hex characters, not 64), and two nodes behind one endpoint have historically disagreed about it. One block spelled two ways reads as a changed hash, so `rollbackTo` invalidates and clears the window — rows deleted and re-indexed on a chain that never reorged. The 5,000-block check could not have caught this: it reads each range once and never diffs.
- **A compute-unit overage is retried.** Alchemy reports one as an HTTP 200 carrying JSON-RPC code 429 — the case `fetchLogsChecked` already documents viem handling for EVM. This client inspected only the status code and threw, which exits the generator and lets `restart.sh` restart a second later: throttled, it would have polled the throttling endpoint *harder*, while every EVM worker backed off. Under the spend cap that is exactly when it fires.

## Cost

Roughly **1.9M Alchemy compute units a day, ~$26/month** at the 2 s poll floor, where DNA was billed separately. Starknet methods are cheap — `starknet_getEvents` is 20 CU against `eth_getLogs`'s 60. A poll is one head read plus one range read; blocks above the cursor add one read each, ~6.4k/day.

Starknet lands an event we index about every 13 seconds, so the shared backoff will rarely leave the floor. It is armed anyway because rarely is not never, and `NO_BLOCKS_TIMEOUT_MS` is five minutes, far above the 30 s ceiling. Note the runtime does **not** reset that watchdog on heartbeats, only on block messages — the tail message covers it while the head keeps moving.

## Downstream impact: none, checked rather than assumed

`api` and `quoter-service` are the only things that read this database directly — `mcp`, `interface` and `wallet` go through the api and open no connection of their own. Both depend on the same surface: five `indexer_cursor` columns, and `event_id`.

Against a **live cursor row written by the DNA stream that is still running**, the new adapter returns identical values:

```
indexer_cursor block 14558735 (written by the DNA stream) vs the new adapter:
  head_block_hash        MATCH  db=2822879207166127803137786522074090950588380023342421078929262990512106766091
  head_block_time        MATCH  db=1788875623
  head_base_fee_per_gas  MATCH  db=29564915314
```

- **`event_id` is unchanged** — that is what quoter-service's incremental sync keys on (`apsv.last_event_id > $3`), so monotonicity and identity both matter; verified over 5,000 blocks against 44 tables.
- **`fork_counter`**, which quoter-service compares to decide a full refetch, moves only on an invalidate — and a live boot from the real cursor produced none.
- **No schema change**, so nothing needs migrating.

The one behavioural difference is **latency**: DNA pushed a block as it was produced, this polls, so Starknet events land up to `POLL_INTERVAL_MS` (2 s) later than before.

## Deploying

- `STARKNET_RPC_URL` is a new secret in the app spec.
- **`starknet-mainnet` has already been enabled** on the Alchemy app the key belongs to (79 networks now, nothing dropped — the previous 78 were re-sent verbatim, since `app networks` replaces the list).
- **Apibara is gone entirely**: the four packages, `APIBARA_URL`, `DNA_TOKEN`, and the `APIBARA_DNA_TOKEN` / `STARKNET_MAINNET_APIBARA_URL` / `ETH_MAINNET_APIBARA_URL` secrets the deploy workflow passed to `envsubst`. The GitHub repository secrets can be deleted once this ships.
- Worth knowing about `envsubst`: it substitutes an **unset** variable with the empty string rather than failing, so a spec placeholder whose secret goes missing yields a worker configured with an empty value and a green deploy. Checked both directions after the removal — every `${...}` the spec still names is provided (`IMAGE_TAG` from the job env, the rest from the step), and no secret is passed that the spec no longer names.

https://claude.ai/code/session_018fCeEYi1BdAhcaKZmDwAKb
