### PR TITLE
Parse the Chainlink feed catalog with Effect Schema

### DIFF
--- a/src/price-sync/fetchers/chainlink.ts
+++ b/src/price-sync/fetchers/chainlink.ts
@@ -3,7 +3,7 @@ import type { Sql } from "postgres";
 import { PriceSyncError, tryPriceSync } from "../errors";
 import type { ChainlinkCatalogCache } from "./chainlinkCatalog";
 import {
-  discoverChainlinkFeeds,
+  discoverChainlinkFeedsDetailed,
   fetchChainlinkTokenPrices,
   type ChainlinkChainConfig,
   type ChainlinkFeedConfig,
@@ -61,6 +61,16 @@ export function makeChainlinkRoundTracker(): ChainlinkRoundTracker {
   };
 }
 
+// Most-rejected rule first. The tail is the long list of Chainlink products
+// this indexer was never going to price, so the head is the interesting part:
+// it is where a feed that should have appeared went.
+function formatSkippedFeeds(skipped: ReadonlyMap<string, number>): string {
+  return [...skipped]
+    .sort(([, a], [, b]) => b - a)
+    .map(([reason, count]) => `${count}x ${reason}`)
+    .join("; ");
+}
+
 // Feed discovery and the on-chain reads both need full-width EVM addresses,
 // unlike the numeric form the database stores prices under.
 function toEvmAddress(address: string): `0x${string}` {
@@ -99,6 +109,7 @@ export function chainlinkPriceFetcher({
   catalogCache,
 }: ChainlinkPriceFetcherOptions): PriceSyncJob {
   const shouldReportRound = makeChainlinkRoundTracker();
+  let lastFeedSummary: string | undefined;
 
   // Validity is anchored at the round's own updatedAt and extends through the
   // feed's staleness window -- mirroring the read-side contract -- floored at
@@ -141,7 +152,26 @@ export function chainlinkPriceFetcher({
 
       const tokens = yield* fetchChainlinkTokens(sql, chainId);
       const catalog = yield* catalogCache(catalogUrl, catalogRefreshIntervalMs);
-      return discoverChainlinkFeeds(catalog, tokens);
+      const { feeds, skipped } = discoverChainlinkFeedsDetailed(
+        catalog,
+        tokens,
+      );
+
+      // Reported at info, because a debug line would not be emitted: this
+      // worker installs no Logger and never lowers the minimum level, so
+      // `logDebug` is dropped and LOG_LEVEL only reaches the Winston logger
+      // that the Effect code does not use. Info is therefore the only level
+      // that makes this reachable -- and it only stays quiet because a
+      // summary is logged when it changes rather than on every plan, which
+      // runs once a job interval against a catalog cached for an hour.
+      const summary = `${feeds.length} feeds; skipped ${formatSkippedFeeds(skipped)}`;
+      if (summary !== lastFeedSummary) {
+        lastFeedSummary = summary;
+        yield* Effect.logInfo(
+          `Chainlink catalog for chain ${chainId} yielded ${summary}`,
+        );
+      }
+      return feeds;
     },
     Effect.catch((error) =>
       Effect.logWarning(

--- a/src/price-sync/fetchers/chainlinkFeeds.test.ts
+++ b/src/price-sync/fetchers/chainlinkFeeds.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   chainlinkFeedMaxAgeSeconds,
   discoverChainlinkFeeds,
+  discoverChainlinkFeedsDetailed,
   fetchChainlinkFeedCatalog,
   fetchChainlinkTokenPricesWithMulticall,
   parseChainlinkPriceConfig,
@@ -446,5 +447,111 @@ describe("verifiedClient", () => {
     const client = await verifiedClient("1", ["https://flaky"], create);
     expect(client).toBeDefined();
     expect(attempt).toBe(2);
+  });
+});
+
+describe("discoverChainlinkFeedsDetailed", () => {
+  const usable = {
+    proxyAddress: feedAddress,
+    heartbeat: 1200,
+    path: "eth-usd",
+    feedCategory: "low",
+    docs: {
+      baseAsset: "ETH",
+      quoteAsset: "USD",
+      deliveryChannelCode: "DF",
+      productType: "Price",
+      productTypeCode: "RefPrice",
+    },
+  };
+  const ethToken = { address: tokenAddress, symbol: "ETH" };
+
+  test("names the rule that rejected an entry", () => {
+    // The rule table used to pair each rule with a name and then discard the
+    // names, so a feed that failed to appear could not be traced to the rule
+    // that rejected it.
+    const { feeds, skipped } = discoverChainlinkFeedsDetailed(
+      [
+        { ...usable, feedCategory: "deprecating" },
+        { ...usable, heartbeat: 1e13 },
+        { ...usable, proxyAddress: "not-an-address" },
+      ],
+      [ethToken],
+    );
+
+    expect(feeds).toEqual([]);
+    const reasons = [...skipped.keys()].join(" | ");
+    expect(reasons).toContain("is not deprecating");
+    expect(reasons).toContain("has a usable heartbeat");
+    expect(reasons).toContain("has a proxy address");
+  });
+
+  test("reports the field a structural rule wanted", () => {
+    // Asserted on the parts this code chooses, not on Effect's exact wording:
+    // the schema formatter is free to reword between releases.
+    const { skipped } = discoverChainlinkFeedsDetailed(
+      [{ ...usable, docs: { ...usable.docs, quoteAsset: "EUR" } }],
+      [ethToken],
+    );
+    const reason = [...skipped.keys()][0];
+    expect(reason).toContain("quoteAsset");
+    expect(reason).toContain("USD");
+  });
+
+  test("counts entries that fail for the same reason", () => {
+    // A production catalog rejects most of what it carries, so the reasons are
+    // only readable as counts.
+    const { skipped } = discoverChainlinkFeedsDetailed(
+      [
+        { ...usable, docs: { ...usable.docs, quoteAsset: "EUR" } },
+        { ...usable, docs: { ...usable.docs, quoteAsset: "GBP" } },
+        { ...usable, feedCategory: "deprecating" },
+      ],
+      [ethToken],
+    );
+
+    const countOf = (needle: string) =>
+      [...skipped].find(([reason]) => reason.includes(needle))?.[1];
+    expect(countOf("quoteAsset")).toBe(2);
+    expect(countOf("is not deprecating")).toBe(1);
+  });
+
+  test("reports the two silent drops that are not rule failures", () => {
+    // A symbol the indexer does not carry uniquely, and two feeds of equal
+    // rank where picking either would be a guess. Both are ordinary outcomes,
+    // and both were previously invisible.
+    const ambiguousSymbol = discoverChainlinkFeedsDetailed(
+      [usable],
+      [
+        ethToken,
+        { address: "0x0000000000000000000000000000000000000003", symbol: "ETH" },
+      ],
+    );
+    expect(ambiguousSymbol.feeds).toEqual([]);
+    expect(
+      ambiguousSymbol.skipped.get("matches exactly one indexed token"),
+    ).toBe(1);
+
+    const tied = discoverChainlinkFeedsDetailed(
+      [
+        usable,
+        {
+          ...usable,
+          proxyAddress: "0x0000000000000000000000000000000000000009",
+        },
+      ],
+      [ethToken],
+    );
+    expect(tied.feeds).toEqual([]);
+    expect(tied.skipped.get("outranks the other feeds for its symbol")).toBe(1);
+  });
+
+  test("reports nothing when every entry becomes a feed", () => {
+    const { feeds, skipped } = discoverChainlinkFeedsDetailed(
+      [usable],
+      [ethToken],
+    );
+    expect(feeds).toEqual([{ tokenAddress, feedAddress, maxAgeSeconds: 2400 }]);
+    expect(skipped.size).toBe(0);
   });
 });

--- a/src/price-sync/fetchers/chainlinkFeeds.ts
+++ b/src/price-sync/fetchers/chainlinkFeeds.ts
@@ -1,3 +1,4 @@
+import { Result, Schema } from "effect";
 import {
   createPublicClient,
   fallback,
@@ -82,23 +83,6 @@ export interface ChainlinkToken {
   address: Address;
   symbol: string;
 }
-
-type ChainlinkCatalogEntry = {
-  proxyAddress?: unknown;
-  secondaryProxyAddress?: unknown;
-  heartbeat?: unknown;
-  path?: unknown;
-  feedCategory?: unknown;
-  docs?: {
-    baseAsset?: unknown;
-    quoteAsset?: unknown;
-    deliveryChannelCode?: unknown;
-    productType?: unknown;
-    productTypeCode?: unknown;
-    hidden?: unknown;
-    shutdownDate?: unknown;
-  };
-};
 
 interface ChainlinkReader {
   getChainId(): Promise<number>;
@@ -284,74 +268,125 @@ function groupTokensBySymbol(
   return bySymbol;
 }
 
-// The catalog carries every Chainlink data product, most of which are not USD
-// spot price feeds we can read. These are the admissibility rules, as a table
-// rather than one long conjunction: each rule is named, so a feed that fails to
-// appear can be traced to the exact rule that rejected it.
-const CATALOG_ENTRY_RULES: [string, (value: ChainlinkCatalogEntry) => boolean][] =
-  [
-    ["is a data feed", (v) => v.docs?.deliveryChannelCode === "DF"],
-    ["is a price product", (v) => v.docs?.productType === "Price"],
-    [
-      "is a reference or tokenized price",
-      (v) =>
-        ["RefPrice", "primaryTokenizedPrice"].includes(
-          String(v.docs?.productTypeCode),
-        ),
-    ],
-    ["is quoted in USD", (v) => v.docs?.quoteAsset === "USD"],
-    ["names a base asset", (v) => typeof v.docs?.baseAsset === "string"],
-    ["is not hidden", (v) => v.docs?.hidden !== true],
-    ["is not shut down", (v) => !v.docs?.shutdownDate],
-    ["is not deprecating", (v) => v.feedCategory !== "deprecating"],
-    ["has a path", (v) => typeof v.path === "string"],
-    [
-      "has a proxy address",
-      (v) => typeof v.proxyAddress === "string" && isAddress(v.proxyAddress),
-    ],
-    [
-      "has a usable heartbeat",
-      (v) =>
-        typeof v.heartbeat === "number" &&
-        Number.isSafeInteger(v.heartbeat) &&
-        v.heartbeat > 0 &&
-        v.heartbeat <= MAX_CHAINLINK_HEARTBEAT_SECONDS,
-    ],
-  ];
+/** An unconstrained field carrying only the named rule it must satisfy. */
+function rule(name: string, holds: (value: unknown) => boolean) {
+  return Schema.Unknown.pipe(
+    Schema.refine((value): value is unknown => holds(value), {
+      message: name,
+    }),
+  );
+}
 
-function isUsableCatalogEntry(value: ChainlinkCatalogEntry): boolean {
-  return CATALOG_ENTRY_RULES.every(([, holds]) => holds(value));
+// The catalog carries every Chainlink data product, most of which are not USD
+// spot price feeds we can read. This schema is the table of admissibility
+// rules, and decoding an entry against it is what applies them.
+//
+// It replaces a table that paired each rule with a name and then threw the
+// names away, so a feed that failed to appear could not be traced to the rule
+// that rejected it. Decoding reports one: a structural rule reports the field
+// and the value it wanted (`Expected "USD" at ["docs"]["quoteAsset"]`), which
+// is more specific than a name; the rules that are bare predicates carry the
+// name instead, since a path alone would say nothing.
+//
+// Decoding rather than validating is also what makes an accepted entry typed:
+// `proxyAddress` is an `Address` and `heartbeat` a bounded integer on the way
+// out, so building a feed from one needs no casts. The two `unknown`s that
+// forced those casts were the last type errors in this file.
+const UsableCatalogEntry = Schema.Struct({
+  proxyAddress: Schema.String.pipe(
+    Schema.refine((value): value is Address => isAddress(value), {
+      message: "has a proxy address",
+    }),
+  ),
+  heartbeat: Schema.Int.check(
+    Schema.isBetween(
+      { minimum: 1, maximum: MAX_CHAINLINK_HEARTBEAT_SECONDS },
+      { message: "has a usable heartbeat" },
+    ),
+  ),
+  path: Schema.String,
+  secondaryProxyAddress: Schema.optional(Schema.Unknown),
+  feedCategory: Schema.optional(
+    rule("is not deprecating", (v) => v !== "deprecating"),
+  ),
+  docs: Schema.Struct({
+    baseAsset: Schema.String,
+    quoteAsset: Schema.Literal("USD"),
+    deliveryChannelCode: Schema.Literal("DF"),
+    productType: Schema.Literal("Price"),
+    productTypeCode: Schema.Literals(["RefPrice", "primaryTokenizedPrice"]),
+    hidden: Schema.optional(rule("is not hidden", (v) => v !== true)),
+    shutdownDate: Schema.optional(rule("is not shut down", (v) => !v)),
+  }),
+});
+
+type UsableCatalogEntry = typeof UsableCatalogEntry.Type;
+
+const decodeCatalogEntry = Schema.decodeUnknownResult(UsableCatalogEntry);
+
+// Decode failures are multi-line, and these are counted as map keys and read
+// from a log line.
+function rejectionReason(error: { readonly message: string }): string {
+  return error.message.replace(/\s+/g, " ").trim();
 }
 
 // Lower is better. A feed with no secondary proxy is the plain one and wins
 // outright; among the rest, the shared SVR path is preferred.
-function feedRank(value: ChainlinkCatalogEntry): number {
+function feedRank(value: UsableCatalogEntry): number {
   if (!value.secondaryProxyAddress) return 0;
-  return String(value.path).includes("shared-svr") ? 1 : 2;
+  return value.path.includes("shared-svr") ? 1 : 2;
 }
 
-export function discoverChainlinkFeeds(
+// Reasons a decodable entry still does not become a feed. Both are ordinary,
+// and both are otherwise invisible: a symbol the indexer does not carry, or
+// carries twice, and two equally ranked feeds for one symbol where picking
+// either would be a guess.
+const NO_UNIQUE_TOKEN = "matches exactly one indexed token";
+const NO_RANK_WINNER = "outranks the other feeds for its symbol";
+
+export interface ChainlinkFeedDiscovery {
+  readonly feeds: ChainlinkFeedConfig[];
+  /**
+   * How many catalog entries each rule rejected.
+   *
+   * The catalog lists every Chainlink product, so rejecting most of it is the
+   * ordinary case and not a fault. This exists so that "why is this feed
+   * missing" is answerable from a log line rather than a debugger.
+   */
+  readonly skipped: ReadonlyMap<string, number>;
+}
+
+export function discoverChainlinkFeedsDetailed(
   catalog: unknown,
   tokens: ChainlinkToken[],
-): ChainlinkFeedConfig[] {
+): ChainlinkFeedDiscovery {
   if (!Array.isArray(catalog)) {
     throw new Error("Chainlink feed catalog must be an array");
   }
 
   const tokensBySymbol = groupTokensBySymbol(tokens);
+  const skipped = new Map<string, number>();
+  const skip = (reason: string) =>
+    skipped.set(reason, (skipped.get(reason) ?? 0) + 1);
 
   const catalogFeedsBySymbol = new Map<
     string,
     { feed: ChainlinkFeedConfig; rank: number }[]
   >();
   for (const rawValue of catalog) {
-    if (!rawValue || typeof rawValue !== "object") continue;
-    const value = rawValue as ChainlinkCatalogEntry;
-    if (!isUsableCatalogEntry(value)) continue;
+    const decoded = decodeCatalogEntry(rawValue);
+    if (Result.isFailure(decoded)) {
+      skip(rejectionReason(decoded.failure));
+      continue;
+    }
+    const value = decoded.success;
 
-    const symbol = normalizeSymbol(value.docs!.baseAsset as string);
+    const symbol = normalizeSymbol(value.docs.baseAsset);
     const matchingTokens = tokensBySymbol.get(symbol);
-    if (matchingTokens?.length !== 1) continue;
+    if (matchingTokens?.length !== 1) {
+      skip(NO_UNIQUE_TOKEN);
+      continue;
+    }
 
     const feed: ChainlinkFeedConfig = {
       tokenAddress: matchingTokens[0].address,
@@ -363,13 +398,25 @@ export function discoverChainlinkFeeds(
     catalogFeedsBySymbol.set(symbol, feeds);
   }
 
-  return [...catalogFeedsBySymbol.values()]
-    .map((feeds) => {
-      const bestRank = Math.min(...feeds.map(({ rank }) => rank));
-      const bestFeeds = feeds.filter(({ rank }) => rank === bestRank);
-      return bestFeeds.length === 1 ? bestFeeds[0].feed : null;
-    })
-    .filter((feed): feed is ChainlinkFeedConfig => feed !== null);
+  const feeds: ChainlinkFeedConfig[] = [];
+  for (const candidates of catalogFeedsBySymbol.values()) {
+    const bestRank = Math.min(...candidates.map(({ rank }) => rank));
+    const best = candidates.filter(({ rank }) => rank === bestRank);
+    if (best.length === 1) {
+      feeds.push(best[0].feed);
+    } else {
+      skip(NO_RANK_WINNER);
+    }
+  }
+
+  return { feeds, skipped };
+}
+
+export function discoverChainlinkFeeds(
+  catalog: unknown,
+  tokens: ChainlinkToken[],
+): ChainlinkFeedConfig[] {
+  return discoverChainlinkFeedsDetailed(catalog, tokens).feeds;
 }
 
 export async function fetchChainlinkFeedCatalog(


### PR DESCRIPTION
Continues the Effect adoption in `src/price-sync`. The rewrite itself landed in 79549e7; this takes the one remaining file where Effect earns its keep rather than adding ceremony — `chainlinkFeeds.ts`, which parses JSON nobody here controls.

## The problem

`discoverChainlinkFeeds` validated a catalog entry with a table of named predicates and then read fields off the result. TypeScript cannot see through a predicate, so every field stayed `unknown`, and the two reads that needed a real type were written over `unknown`:

```ts
feedAddress: getAddress(value.proxyAddress),               // TS2345
maxAgeSeconds: chainlinkFeedMaxAgeSeconds(value.heartbeat), // TS2345
```

Those were the only two type errors in the file, with a `!` and an `as string` on the line above them. Validating and then casting is the shape of the bug.

## What changed

Entries are decoded against a `Schema.Struct`. The schema **is** the old rule table — same rules, same order of strictness — so an accepted entry comes back typed and building a feed from it needs no casts.

The rule table also paired each rule with a name and then threw the names away, so a feed that failed to appear could not be traced to the rule that rejected it. Decoding produces a reason, and `discoverChainlinkFeedsDetailed` returns those reasons with a count each. Two drops that were never rule failures are counted the same way, because they were equally invisible:

- a base asset that matches no single indexed token
- two feeds of equal rank for one symbol, where picking either would be a guess

Real output, from the Arbitrum catalog:

```
986x Expected string at ["proxyAddress"]
 55x Expected "USD" at ["docs"]["quoteAsset"]
 17x Missing key at ["docs"]["baseAsset"]
  6x has a usable heartbeat at ["heartbeat"]
```

### On the log level

The summary is logged at **info**, and only when it changes. A debug line would not have been emitted at all: this worker installs no `Logger` and never lowers the minimum level, so `Effect.logDebug` is dropped, and `LOG_LEVEL` reaches only the Winston logger that the Effect code does not use. I checked this rather than assuming it — the first version of this PR used `logDebug` and would have shipped a diagnostic that never printed.

Logging on change is what keeps info quiet: discovery runs once a job interval against a catalog cached for an hour, so the same summary would otherwise repeat all day.

## Verification

**Differential check against production data.** The old rules and the new schema were run over the four catalogs production actually reads:

| catalog | entries | feeds (old) | feeds (new) | disagreements |
|---|---|---|---|---|
| mainnet | 290 | 92 | 92 | 0 |
| base | 186 | 86 | 86 | 0 |
| arbitrum | 1252 | 138 | 138 | 0 |
| robinhood | 57 | 50 | 50 | 0 |
| **total** | **1785** | **366** | **366** | **0** |

No entry is classified differently by either, so nothing gets priced that was not priced before, and nothing stops.

**Tests.** The 20 existing tests are unchanged — not one assertion was touched, which is what makes the differential result meaningful. Five new ones cover the reasons. Two of those five, and the existing heartbeat-bound test, were confirmed to fail against a deliberately broken build (rank-tie drop unrecorded, heartbeat bound removed), so they are not passing vacuously.

The new tests assert on substrings this code controls rather than on Effect's exact formatter output, so a cosmetic change in an RC bump does not turn a dependabot PR red.

**Typecheck.** `src` now typechecks with zero errors under the documented incantation. These two were the last; the `dao.ts` one recorded alongside them was fixed in #180.

`bun test` 458 pass / 0 fail, `bun run lint` clean.

## Scope

`jobs.ts`, `utils.ts` and `validatePriceSyncJobs.ts` are still plain, deliberately. `jobs.ts` is a declarative table of what is priced where — its own comment says so — and the other two are small pure helpers. Effect buys nothing in any of them.

https://claude.ai/code/session_018fCeEYi1BdAhcaKZmDwAKb
